### PR TITLE
Switch to explicit env vars and add Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,44 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,16 @@ services:
       - "8080:8000"
     volumes:
       - ./data:/data
-    env_file:
-      - .env
+    environment:
+      - GARMIN_EMAIL=${GARMIN_EMAIL}
+      - GARMIN_PASSWORD=${GARMIN_PASSWORD}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - TIMEZONE=${TIMEZONE:-UTC}
+      - DB_PATH=${DB_PATH:-/data/running_coach.db}
+      - GARMIN_TOKEN_DIR=${GARMIN_TOKEN_DIR:-/data/garmin_tokens}
+      - ACTIVITY_POLL_MINUTES=${ACTIVITY_POLL_MINUTES:-5}
+      - DAILY_SYNC_HOUR=${DAILY_SYNC_HOUR:-7}
+      - AI_MODEL=${AI_MODEL:-claude-sonnet-4-6}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/')"]


### PR DESCRIPTION
## Summary

- Replace `env_file: .env` with explicit `environment:` block in docker-compose.yml so TrueNAS SCALE UI can configure each env var individually
- Add GitHub Actions workflow (`.github/workflows/docker-publish.yml`) that builds and pushes a Docker image to GHCR on every push to main, tagged with `latest` and the commit SHA

## Test plan

- [ ] Verify docker-compose.yml uses `environment:` block with defaults
- [ ] After merge, verify GitHub Action runs and publishes image to `ghcr.io/stnkvcmls/running-coach`
- [ ] Pull image on TrueNAS: `docker pull ghcr.io/stnkvcmls/running-coach:latest`