### PR TITLE
Fix mobile layout for PWA and small screens

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -3,19 +3,23 @@
     "short_name": "RunCoach",
     "description": "AI-powered running coach with Garmin Connect integration",
     "start_url": "/",
+    "scope": "/",
     "display": "standalone",
+    "orientation": "portrait",
     "background_color": "#0f0f1a",
     "theme_color": "#1a1a2e",
     "icons": [
         {
             "src": "/static/icon-192.png",
             "sizes": "192x192",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "any maskable"
         },
         {
             "src": "/static/icon-512.png",
             "sizes": "512x512",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "any maskable"
         }
     ]
 }

--- a/static/style.css
+++ b/static/style.css
@@ -91,7 +91,11 @@ body {
 
 .stat-grid-2 { grid-template-columns: repeat(2, 1fr); }
 .stat-grid-3 { grid-template-columns: repeat(3, 1fr); }
-.stat-grid-4 { grid-template-columns: repeat(4, 1fr); }
+.stat-grid-4 { grid-template-columns: repeat(2, 1fr); }
+
+@media (min-width: 400px) {
+    .stat-grid-4 { grid-template-columns: repeat(4, 1fr); }
+}
 
 .stat {
     text-align: center;
@@ -125,11 +129,12 @@ body {
 .activity-item {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 10px;
     padding: 10px 0;
     text-decoration: none;
     color: inherit;
     border-bottom: 1px solid var(--border);
+    overflow: hidden;
 }
 
 .activity-item:last-child { border-bottom: none; }
@@ -168,6 +173,7 @@ body {
 .activity-stats {
     text-align: right;
     flex-shrink: 0;
+    white-space: nowrap;
 }
 
 .activity-stats .pace {
@@ -191,10 +197,11 @@ body {
 .daily-list-item {
     display: flex;
     align-items: center;
-    gap: 14px;
+    gap: 10px;
     text-decoration: none;
     color: inherit;
     cursor: pointer;
+    overflow: hidden;
 }
 
 .daily-list-item:active { opacity: 0.7; }
@@ -385,15 +392,24 @@ details summary {
 
 .cal-day {
     aspect-ratio: 1;
-    padding: 4px;
-    border-radius: 8px;
+    padding: 2px;
+    border-radius: 6px;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    font-size: 0.8rem;
+    font-size: 0.7rem;
     position: relative;
-    min-height: 44px;
+    min-height: 36px;
+}
+
+@media (min-width: 400px) {
+    .cal-day {
+        padding: 4px;
+        border-radius: 8px;
+        font-size: 0.8rem;
+        min-height: 44px;
+    }
 }
 
 .cal-day.empty { background: transparent; }
@@ -442,8 +458,10 @@ details summary {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     padding: 8px 0;
     border-bottom: 1px solid var(--border);
+    overflow: hidden;
 }
 
 .race-item:last-child { border-bottom: none; }
@@ -458,6 +476,7 @@ details summary {
     display: block;
     font-size: 0.8rem;
     color: var(--text-muted);
+    word-break: break-word;
 }
 
 .race-right {
@@ -503,9 +522,10 @@ details summary {
 .form-row {
     display: flex;
     gap: 12px;
+    flex-wrap: wrap;
 }
 
-.form-row > .form-group { flex: 1; }
+.form-row > .form-group { flex: 1; min-width: 0; }
 
 .time-inputs {
     align-items: center;
@@ -583,7 +603,14 @@ details summary {
 
 .button-group {
     display: flex;
+    flex-direction: column;
     gap: 8px;
+}
+
+@media (min-width: 400px) {
+    .button-group {
+        flex-direction: row;
+    }
 }
 
 .button-group .inline-form { flex: 1; }

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'running-coach-v1';
+const CACHE_NAME = 'running-coach-v2';
 const SHELL_URLS = [
     '/static/style.css',
     '/static/manifest.json',


### PR DESCRIPTION
## Summary
Fixes #7 — Mobile view displaying as desktop page

- `stat-grid-4` collapses to 2x2 grid on screens narrower than 400px
- Calendar cells use smaller padding/font on narrow screens, scale up at 400px
- Button groups (settings page) stack vertically on small screens
- Prevent horizontal overflow on activity list, daily list, and race items
- Form rows wrap on narrow screens instead of overflowing
- Bumped service worker cache to v2 so PWA users get the updated CSS
- Added `scope`, `orientation: portrait`, and `maskable` icon purpose to PWA manifest