### PR TITLE
Enhance activities with full Garmin data, area charts, and richer AI insights

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -17,6 +17,9 @@ SYSTEM_PROMPT = """You are an experienced, data-driven running coach. You analyz
 Your approach:
 - Focus on injury prevention and sustainable progressive overload
 - Analyze pacing strategy, HR drift, cadence, and training effect
+- Analyze running dynamics (ground contact time, vertical oscillation, vertical ratio) for form assessment when available
+- Use power metrics (NP, TSS, IF) for training load analysis when available
+- Consider respiration rate trends for effort assessment
 - Consider recovery indicators (sleep, stress, resting HR, body battery)
 - Tailor advice to upcoming races when applicable
 - Be concise: 3-5 key points per analysis
@@ -62,6 +65,40 @@ def _format_activity_context(activity: Activity) -> str:
         parts.append(f"VO2max: {activity.vo2max:.1f}")
     if activity.calories:
         parts.append(f"Calories: {activity.calories:.0f}")
+
+    # Running dynamics
+    if activity.avg_ground_contact_time:
+        parts.append(f"Ground Contact Time: {activity.avg_ground_contact_time:.0f} ms")
+    if activity.avg_vertical_oscillation:
+        parts.append(f"Vertical Oscillation: {activity.avg_vertical_oscillation:.1f} cm")
+    if activity.avg_vertical_ratio:
+        parts.append(f"Vertical Ratio: {activity.avg_vertical_ratio:.1f}%")
+
+    # Power metrics
+    if activity.normalized_power:
+        parts.append(f"Normalized Power: {activity.normalized_power:.0f} W")
+    if activity.training_stress_score:
+        parts.append(f"TSS: {activity.training_stress_score:.1f}")
+    if activity.intensity_factor:
+        parts.append(f"Intensity Factor: {activity.intensity_factor:.2f}")
+
+    # Respiration
+    if activity.avg_respiration_rate:
+        parts.append(f"Avg Respiration: {activity.avg_respiration_rate:.1f} br/min")
+    if activity.max_respiration_rate:
+        parts.append(f"Max Respiration: {activity.max_respiration_rate:.1f} br/min")
+
+    # Speed
+    if activity.avg_speed:
+        parts.append(f"Avg Speed: {activity.avg_speed * 3.6:.1f} km/h")
+    if activity.max_speed:
+        parts.append(f"Max Speed: {activity.max_speed * 3.6:.1f} km/h")
+
+    # Additional HR & elevation
+    if activity.min_hr:
+        parts.append(f"Min HR: {activity.min_hr} bpm")
+    if activity.max_elevation is not None and activity.min_elevation is not None:
+        parts.append(f"Elevation Range: {activity.min_elevation:.0f}m - {activity.max_elevation:.0f}m")
 
     # Add lap data if available
     if activity.laps_json:

--- a/app/database.py
+++ b/app/database.py
@@ -1,7 +1,8 @@
+import logging
 import os
 from contextlib import contextmanager
 
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 from app.config import settings
@@ -48,7 +49,42 @@ def db_session():
         db.close()
 
 
+def _migrate_db():
+    """Add new columns to existing tables if they don't exist."""
+    logger = logging.getLogger(__name__)
+    new_activity_columns = {
+        "avg_ground_contact_time": "FLOAT",
+        "avg_vertical_oscillation": "FLOAT",
+        "avg_vertical_ratio": "FLOAT",
+        "normalized_power": "FLOAT",
+        "training_stress_score": "FLOAT",
+        "intensity_factor": "FLOAT",
+        "avg_respiration_rate": "FLOAT",
+        "max_respiration_rate": "FLOAT",
+        "avg_speed": "FLOAT",
+        "max_speed": "FLOAT",
+        "min_hr": "INTEGER",
+        "max_elevation": "FLOAT",
+        "min_elevation": "FLOAT",
+    }
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(activities)")).fetchall()
+            existing = {row[1] for row in rows}
+            added = []
+            for col, dtype in new_activity_columns.items():
+                if col not in existing:
+                    conn.execute(text(f"ALTER TABLE activities ADD COLUMN {col} {dtype}"))
+                    added.append(col)
+            conn.commit()
+            if added:
+                logger.info("Migrated activities table: added %s", ", ".join(added))
+    except Exception:
+        logger.debug("Migration skipped (table may not exist yet)")
+
+
 def init_db():
     from app import models  # noqa: F401
 
     Base.metadata.create_all(bind=engine)
+    _migrate_db()

--- a/app/garmin_sync.py
+++ b/app/garmin_sync.py
@@ -67,7 +67,7 @@ def _extract_activity_fields(summary: dict, details: dict | None = None) -> dict
     if distance and duration and distance > 0:
         avg_pace = (duration / 60) / (distance / 1000)  # min/km
 
-    return {
+    fields = {
         "garmin_id": activity_id,
         "activity_type": summary.get("activityType", {}).get("typeKey", "unknown"),
         "name": summary.get("activityName", ""),
@@ -88,6 +88,28 @@ def _extract_activity_fields(summary: dict, details: dict | None = None) -> dict
         "avg_power": summary.get("avgPower"),
     }
 
+    # Extract additional fields from full activity summary (get_activity response)
+    act_summary = details.get("activity_summary") if details else None
+    # Merge: prefer detailed summary, fall back to list summary for some fields
+    src = act_summary or summary
+    fields.update({
+        "avg_ground_contact_time": src.get("avgGroundContactTime"),
+        "avg_vertical_oscillation": src.get("avgVerticalOscillation"),
+        "avg_vertical_ratio": src.get("avgVerticalRatio"),
+        "normalized_power": src.get("normPower"),
+        "training_stress_score": src.get("trainingStressScore"),
+        "intensity_factor": src.get("intensityFactor"),
+        "avg_respiration_rate": src.get("avgRespirationRate"),
+        "max_respiration_rate": src.get("maxRespirationRate"),
+        "avg_speed": src.get("averageSpeed"),
+        "max_speed": src.get("maxSpeed"),
+        "min_hr": src.get("minHR"),
+        "max_elevation": src.get("maxElevation"),
+        "min_elevation": src.get("minElevation"),
+    })
+
+    return fields
+
 
 def _parse_garmin_ts(ts_str: str | None) -> datetime | None:
     if not ts_str:
@@ -103,6 +125,11 @@ def _parse_garmin_ts(ts_str: str | None) -> datetime | None:
 def _fetch_activity_details(client: Garmin, activity_id) -> dict:
     """Fetch all detail endpoints for an activity."""
     details = {}
+    try:
+        details["activity_summary"] = client.get_activity(activity_id)
+    except Exception as e:
+        logger.debug("No activity summary for %s: %s", activity_id, e)
+
     try:
         details["splits"] = client.get_activity_splits(activity_id)
     except Exception as e:
@@ -136,7 +163,7 @@ def _store_activity(db: Session, summary: dict, details: dict, skip_ai: bool = F
     if existing:
         return None
 
-    fields = _extract_activity_fields(summary, details)
+    fields = _extract_activity_fields(summary, details or {})
 
     # Fetch laps from the summary's built-in laps if available
     laps = None

--- a/app/models.py
+++ b/app/models.py
@@ -50,6 +50,31 @@ class Activity(Base):
     synced_at = Column(DateTime, default=_utcnow)
     ai_analyzed = Column(Boolean, default=False)
 
+    # Running Dynamics
+    avg_ground_contact_time = Column(Float)
+    avg_vertical_oscillation = Column(Float)
+    avg_vertical_ratio = Column(Float)
+
+    # Power Metrics
+    normalized_power = Column(Float)
+    training_stress_score = Column(Float)
+    intensity_factor = Column(Float)
+
+    # Respiration
+    avg_respiration_rate = Column(Float)
+    max_respiration_rate = Column(Float)
+
+    # Speed
+    avg_speed = Column(Float)
+    max_speed = Column(Float)
+
+    # Heart Rate
+    min_hr = Column(Integer)
+
+    # Elevation
+    max_elevation = Column(Float)
+    min_elevation = Column(Float)
+
 
 class DailySummary(Base):
     __tablename__ = "daily_summaries"

--- a/app/routes.py
+++ b/app/routes.py
@@ -17,6 +17,68 @@ from app.utils import safe_json_loads
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _parse_activity_charts(laps_data) -> dict:
+    """Extract time-series chart data from activity details (laps_json)."""
+    if not laps_data or not isinstance(laps_data, dict):
+        return {}
+
+    descriptors = laps_data.get("metricDescriptors", [])
+    metrics = laps_data.get("activityDetailMetrics", [])
+    if not descriptors or not metrics:
+        return {}
+
+    # Build column index map
+    col_map = {}
+    for desc in descriptors:
+        key = desc.get("key", "")
+        idx = desc.get("metricsIndex")
+        if idx is not None:
+            col_map[key] = idx
+
+    charts = {}
+    # Sample ~200 points max for performance
+    step = max(1, len(metrics) // 200)
+    sampled = metrics[::step]
+
+    series_defs = [
+        ("heart_rate", "directHeartRate", "Heart Rate", "bpm"),
+        ("elevation", "directElevation", "Elevation", "m"),
+        ("pace", "directSpeed", "Pace", "min/km"),
+        ("cadence", "directRunCadence", "Cadence", "spm"),
+        ("power", "directPower", "Power", "W"),
+    ]
+
+    for chart_key, garmin_key, label, unit in series_defs:
+        if garmin_key not in col_map:
+            continue
+        idx = col_map[garmin_key]
+        values = []
+        for m in sampled:
+            metrics_arr = m.get("metrics", [])
+            if idx < len(metrics_arr) and metrics_arr[idx] is not None:
+                values.append(metrics_arr[idx])
+            else:
+                values.append(None)
+        if any(v is not None for v in values):
+            charts[chart_key] = {"label": label, "unit": unit, "data": values}
+
+    # Convert speed (m/s) to pace (min/km)
+    if "pace" in charts:
+        charts["pace"]["data"] = [
+            round(1000 / (60 * v), 2) if v and v > 0 else None
+            for v in charts["pace"]["data"]
+        ]
+
+    # Double cadence for running (Garmin reports half-cadence)
+    if "cadence" in charts:
+        charts["cadence"]["data"] = [
+            round(v * 2) if v is not None else None
+            for v in charts["cadence"]["data"]
+        ]
+
+    return charts
 templates = Jinja2Templates(directory="app/templates")
 
 
@@ -159,6 +221,9 @@ def activity_detail(request: Request, activity_id: int, db: Session = Depends(ge
     hr_zones = safe_json_loads(activity.hr_zones_json)
     weather = safe_json_loads(activity.weather_json)
 
+    # Parse time-series data for area charts
+    chart_data = _parse_activity_charts(laps)
+
     # Get AI insight for this activity
     insight = (
         db.query(Insight)
@@ -173,6 +238,7 @@ def activity_detail(request: Request, activity_id: int, db: Session = Depends(ge
         "splits": splits,
         "hr_zones": hr_zones,
         "weather": weather,
+        "chart_data": json.dumps(chart_data),
         "insight": insight,
         "page": "dashboard",
     })

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -61,8 +61,75 @@
         {% if activity.avg_power %}
         <div class="stat"><span class="stat-value">{{ activity.avg_power | round(0) | int }}W</span><span class="stat-label">Avg Power</span></div>
         {% endif %}
+        {% if activity.min_hr %}
+        <div class="stat"><span class="stat-value">{{ activity.min_hr }}</span><span class="stat-label">Min HR</span></div>
+        {% endif %}
+        {% if activity.avg_speed %}
+        <div class="stat"><span class="stat-value">{{ '%.1f' | format(activity.avg_speed * 3.6) }}</span><span class="stat-label">Avg km/h</span></div>
+        {% endif %}
+        {% if activity.max_speed %}
+        <div class="stat"><span class="stat-value">{{ '%.1f' | format(activity.max_speed * 3.6) }}</span><span class="stat-label">Max km/h</span></div>
+        {% endif %}
     </div>
 </section>
+
+{% if activity.avg_ground_contact_time or activity.avg_vertical_oscillation or activity.avg_vertical_ratio %}
+<section class="card">
+    <h2>Running Dynamics</h2>
+    <div class="stat-grid stat-grid-3">
+        {% if activity.avg_ground_contact_time %}
+        <div class="stat"><span class="stat-value">{{ activity.avg_ground_contact_time | round(0) | int }}ms</span><span class="stat-label">GCT</span></div>
+        {% endif %}
+        {% if activity.avg_vertical_oscillation %}
+        <div class="stat"><span class="stat-value">{{ '%.1f' | format(activity.avg_vertical_oscillation) }}cm</span><span class="stat-label">Vert. Osc.</span></div>
+        {% endif %}
+        {% if activity.avg_vertical_ratio %}
+        <div class="stat"><span class="stat-value">{{ '%.1f' | format(activity.avg_vertical_ratio) }}%</span><span class="stat-label">Vert. Ratio</span></div>
+        {% endif %}
+    </div>
+</section>
+{% endif %}
+
+{% if activity.normalized_power or activity.training_stress_score or activity.intensity_factor %}
+<section class="card">
+    <h2>Performance</h2>
+    <div class="stat-grid stat-grid-3">
+        {% if activity.normalized_power %}
+        <div class="stat"><span class="stat-value">{{ activity.normalized_power | round(0) | int }}W</span><span class="stat-label">NP</span></div>
+        {% endif %}
+        {% if activity.training_stress_score %}
+        <div class="stat"><span class="stat-value">{{ '%.1f' | format(activity.training_stress_score) }}</span><span class="stat-label">TSS</span></div>
+        {% endif %}
+        {% if activity.intensity_factor %}
+        <div class="stat"><span class="stat-value">{{ '%.2f' | format(activity.intensity_factor) }}</span><span class="stat-label">IF</span></div>
+        {% endif %}
+    </div>
+</section>
+{% endif %}
+
+{% if activity.avg_respiration_rate or activity.max_respiration_rate %}
+<section class="card">
+    <h2>Respiration</h2>
+    <div class="stat-grid stat-grid-2">
+        {% if activity.avg_respiration_rate %}
+        <div class="stat"><span class="stat-value">{{ '%.1f' | format(activity.avg_respiration_rate) }}</span><span class="stat-label">Avg br/min</span></div>
+        {% endif %}
+        {% if activity.max_respiration_rate %}
+        <div class="stat"><span class="stat-value">{{ '%.1f' | format(activity.max_respiration_rate) }}</span><span class="stat-label">Max br/min</span></div>
+        {% endif %}
+    </div>
+</section>
+{% endif %}
+
+{% if activity.max_elevation is not none and activity.min_elevation is not none %}
+<section class="card">
+    <h2>Elevation Range</h2>
+    <div class="stat-grid stat-grid-2">
+        <div class="stat"><span class="stat-value">{{ activity.min_elevation | round(0) | int }}m</span><span class="stat-label">Min</span></div>
+        <div class="stat"><span class="stat-value">{{ activity.max_elevation | round(0) | int }}m</span><span class="stat-label">Max</span></div>
+    </div>
+</section>
+{% endif %}
 
 {% if hr_zones and hr_zones is iterable and hr_zones is not string %}
 <section class="card">
@@ -125,6 +192,17 @@
         {% if weather.get('windSpeed') is not none %}
         <div class="stat"><span class="stat-value">{{ weather.windSpeed }} km/h</span><span class="stat-label">Wind</span></div>
         {% endif %}
+    </div>
+</section>
+{% endif %}
+
+{% set charts = chart_data | default('{}') %}
+{% if charts != '{}' %}
+<section class="card">
+    <h2>Activity Charts</h2>
+    <div class="chart-tabs" id="chartTabs"></div>
+    <div class="chart-container" style="height: 200px;">
+        <canvas id="activityChart"></canvas>
     </div>
 </section>
 {% endif %}
@@ -195,4 +273,97 @@ if (hrCtx && zoneData.length) {
 }
 </script>
 {% endif %}
+<script>
+const chartData = {{ chart_data | safe }};
+const chartKeys = Object.keys(chartData);
+const chartColors = {
+    heart_rate: { line: '#e74c3c', fill: 'rgba(231, 76, 60, 0.15)' },
+    elevation: { line: '#2ecc71', fill: 'rgba(46, 204, 113, 0.15)' },
+    pace:      { line: '#6c5ce7', fill: 'rgba(108, 92, 231, 0.15)' },
+    cadence:   { line: '#f39c12', fill: 'rgba(243, 156, 18, 0.15)' },
+    power:     { line: '#0984e3', fill: 'rgba(9, 132, 227, 0.15)' },
+};
+
+if (chartKeys.length > 0) {
+    const tabsEl = document.getElementById('chartTabs');
+    const canvas = document.getElementById('activityChart');
+    let activeChart = null;
+
+    function renderChart(key) {
+        if (activeChart) activeChart.destroy();
+        const series = chartData[key];
+        const colors = chartColors[key] || { line: '#6c5ce7', fill: 'rgba(108, 92, 231, 0.15)' };
+        const labels = series.data.map((_, i) => '');
+        // For pace chart, reverse Y axis (lower pace = faster)
+        const reverseY = key === 'pace';
+        activeChart = new Chart(canvas, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: series.label,
+                    data: series.data,
+                    borderColor: colors.line,
+                    backgroundColor: colors.fill,
+                    fill: true,
+                    borderWidth: 1.5,
+                    pointRadius: 0,
+                    pointHitRadius: 8,
+                    tension: 0.3,
+                    spanGaps: true,
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            title: () => '',
+                            label: (ctx) => {
+                                const v = ctx.parsed.y;
+                                if (v == null) return '';
+                                if (key === 'pace') {
+                                    const m = Math.floor(v);
+                                    const s = Math.round((v - m) * 60);
+                                    return `${m}:${s.toString().padStart(2, '0')} /km`;
+                                }
+                                return `${v.toFixed(key === 'elevation' ? 0 : 1)} ${series.unit}`;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: { display: false },
+                    y: {
+                        reverse: reverseY,
+                        grid: { color: 'rgba(255,255,255,0.06)' },
+                        ticks: { color: '#999', maxTicksLimit: 5 },
+                    }
+                },
+                interaction: { mode: 'index', intersect: false },
+            }
+        });
+
+        // Update active tab
+        tabsEl.querySelectorAll('.chart-tab').forEach(t => {
+            t.classList.toggle('active', t.dataset.key === key);
+        });
+    }
+
+    // Build tabs
+    chartKeys.forEach((key, i) => {
+        const btn = document.createElement('button');
+        btn.className = 'chart-tab' + (i === 0 ? ' active' : '');
+        btn.textContent = chartData[key].label;
+        btn.dataset.key = key;
+        btn.addEventListener('click', () => renderChart(key));
+        tabsEl.appendChild(btn);
+    });
+
+    // Render first chart
+    renderChart(chartKeys[0]);
+}
+</script>
 {% endblock %}

--- a/static/style.css
+++ b/static/style.css
@@ -685,6 +685,33 @@ details summary {
     color: var(--accent-light);
 }
 
+/* === Chart Tabs === */
+.chart-tabs {
+    display: flex;
+    gap: 4px;
+    overflow-x: auto;
+    margin-bottom: 12px;
+    -webkit-overflow-scrolling: touch;
+}
+
+.chart-tab {
+    padding: 6px 14px;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    background: var(--bg-input);
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s;
+}
+
+.chart-tab.active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+}
+
 /* === Markdown content === */
 .markdown strong { color: var(--text); }
 .markdown br { margin-bottom: 4px; }


### PR DESCRIPTION
## Summary
- Add 13 new Activity columns: running dynamics (GCT, vertical oscillation, vertical ratio), power metrics (NP, TSS, IF), respiration rates, speed, min HR, and elevation range
- Fetch full activity summary via `get_activity()` endpoint during Garmin sync
- Add SQLite migration to safely add new columns to existing databases
- Parse time-series data from activity details into area charts (HR, pace, elevation, cadence, power) with tabbed switching
- Display new stat sections: Running Dynamics, Performance, Respiration, Elevation Range
- Feed all new metrics into AI coaching context for richer analysis

## Test plan
- [ ] Verify `init_db()` runs migration without errors on existing DB
- [ ] Trigger a manual activity sync and confirm new fields are populated
- [ ] Load activity detail page — verify new stats show when data exists, hide when missing
- [ ] Verify area charts render with tabbed switching between metrics
- [ ] Trigger AI re-analysis and confirm new metrics appear in coaching output
- [ ] Test mobile responsiveness of charts and new stat sections

https://claude.ai/code/session_01G4K6butzZCpPSxQyTjbKsT