### PR TITLE
Add run/walk breakdown, power zones, max cadence, and 6 more chart series

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -99,6 +99,26 @@ def _format_activity_context(activity: Activity) -> str:
         parts.append(f"Min HR: {activity.min_hr} bpm")
     if activity.max_elevation is not None and activity.min_elevation is not None:
         parts.append(f"Elevation Range: {activity.min_elevation:.0f}m - {activity.max_elevation:.0f}m")
+    if activity.max_cadence:
+        parts.append(f"Max Cadence: {activity.max_cadence:.0f} spm")
+    if activity.run_time_sec and activity.walk_time_sec:
+        parts.append(
+            f"Run/Walk: {int(activity.run_time_sec // 60)}min run / {int(activity.walk_time_sec // 60)}min walk"
+        )
+    elif activity.run_time_sec:
+        parts.append(f"Run Time: {int(activity.run_time_sec // 60)}min")
+    if activity.power_zones_json:
+        try:
+            pz = json.loads(activity.power_zones_json)
+            if isinstance(pz, list):
+                zone_parts = [
+                    f"PZ{z.get('zoneNumber', '?')}: {int(z.get('secsInZone', 0) // 60)}m"
+                    for z in pz if z.get("secsInZone", 0) > 0
+                ]
+                if zone_parts:
+                    parts.append(f"Power Zones: {', '.join(zone_parts)}")
+        except (json.JSONDecodeError, TypeError):
+            pass
 
     # Add lap data if available
     if activity.laps_json:

--- a/app/database.py
+++ b/app/database.py
@@ -66,6 +66,11 @@ def _migrate_db():
         "min_hr": "INTEGER",
         "max_elevation": "FLOAT",
         "min_elevation": "FLOAT",
+        "max_cadence": "FLOAT",
+        "run_time_sec": "FLOAT",
+        "walk_time_sec": "FLOAT",
+        "typed_splits_json": "TEXT",
+        "power_zones_json": "TEXT",
     }
     try:
         with engine.connect() as conn:

--- a/app/garmin_sync.py
+++ b/app/garmin_sync.py
@@ -106,6 +106,7 @@ def _extract_activity_fields(summary: dict, details: dict | None = None) -> dict
         "min_hr": src.get("minHR"),
         "max_elevation": src.get("maxElevation"),
         "min_elevation": src.get("minElevation"),
+        "max_cadence": src.get("maxRunningCadenceInStepsPerMinute"),
     })
 
     return fields
@@ -150,6 +151,11 @@ def _fetch_activity_details(client: Garmin, activity_id) -> dict:
     except Exception as e:
         logger.debug("No split summaries for %s: %s", activity_id, e)
 
+    try:
+        details["typed_splits"] = client.get_activity_typed_splits(activity_id)
+    except Exception as e:
+        logger.debug("No typed splits for %s: %s", activity_id, e)
+
     return details
 
 
@@ -165,6 +171,29 @@ def _store_activity(db: Session, summary: dict, details: dict, skip_ai: bool = F
 
     fields = _extract_activity_fields(summary, details or {})
 
+    # Parse run/walk times from typed splits
+    run_time_sec = None
+    walk_time_sec = None
+    typed_splits = details.get("typed_splits")
+    if isinstance(typed_splits, list):
+        run_secs = 0.0
+        walk_secs = 0.0
+        for s in typed_splits:
+            split_type = (s.get("splitType") or "").upper()
+            dur = s.get("totalElapsedDuration") or 0
+            if "RUNNING" in split_type:
+                run_secs += dur
+            elif "WALKING" in split_type or "WALK" in split_type:
+                walk_secs += dur
+        if run_secs > 0:
+            run_time_sec = run_secs
+        if walk_secs > 0:
+            walk_time_sec = walk_secs
+
+    # Extract power zones from full activity summary
+    act_summary = (details or {}).get("activity_summary") or {}
+    power_zones = act_summary.get("powerZoneSummaries")
+
     # Fetch laps from the summary's built-in laps if available
     laps = None
     try:
@@ -176,10 +205,14 @@ def _store_activity(db: Session, summary: dict, details: dict, skip_ai: bool = F
 
     activity = Activity(
         **fields,
+        run_time_sec=run_time_sec,
+        walk_time_sec=walk_time_sec,
         laps_json=json.dumps(laps) if laps else None,
         splits_json=json.dumps(details.get("splits")) if details.get("splits") else None,
         hr_zones_json=json.dumps(details.get("hr_zones")) if details.get("hr_zones") else None,
         weather_json=json.dumps(details.get("weather")) if details.get("weather") else None,
+        typed_splits_json=json.dumps(typed_splits) if typed_splits else None,
+        power_zones_json=json.dumps(power_zones) if power_zones else None,
         raw_json=json.dumps(summary, default=str),
         synced_at=datetime.now(timezone.utc),
         ai_analyzed=skip_ai,

--- a/app/models.py
+++ b/app/models.py
@@ -75,6 +75,15 @@ class Activity(Base):
     max_elevation = Column(Float)
     min_elevation = Column(Float)
 
+    # Run/Walk
+    max_cadence = Column(Float)
+    run_time_sec = Column(Float)
+    walk_time_sec = Column(Float)
+
+    # Extended JSON data
+    typed_splits_json = Column(Text)
+    power_zones_json = Column(Text)
+
 
 class DailySummary(Base):
     __tablename__ = "daily_summaries"

--- a/app/routes.py
+++ b/app/routes.py
@@ -43,11 +43,17 @@ def _parse_activity_charts(laps_data) -> dict:
     sampled = metrics[::step]
 
     series_defs = [
-        ("heart_rate", "directHeartRate", "Heart Rate", "bpm"),
-        ("elevation", "directElevation", "Elevation", "m"),
-        ("pace", "directSpeed", "Pace", "min/km"),
-        ("cadence", "directRunCadence", "Cadence", "spm"),
-        ("power", "directPower", "Power", "W"),
+        ("heart_rate",  "directHeartRate",            "Heart Rate",  "bpm"),
+        ("elevation",   "directElevation",            "Elevation",   "m"),
+        ("pace",        "directSpeed",                "Pace",        "min/km"),
+        ("cadence",     "directRunCadence",           "Cadence",     "spm"),
+        ("power",       "directPower",                "Power",       "W"),
+        ("gct",         "directGroundContactTime",    "GCT",         "ms"),
+        ("vert_osc",    "directVerticalOscillation",  "Vert. Osc.",  "cm"),
+        ("vert_ratio",  "directVerticalRatio",        "Vert. Ratio", "%"),
+        ("stride",      "directStrideLength",         "Stride",      "m"),
+        ("perf_cond",   "directPerformanceCondition", "Perf. Cond.", ""),
+        ("stamina",     "directCurrentStamina",       "Stamina",     "%"),
     ]
 
     for chart_key, garmin_key, label, unit in series_defs:
@@ -220,6 +226,7 @@ def activity_detail(request: Request, activity_id: int, db: Session = Depends(ge
     splits = safe_json_loads(activity.splits_json)
     hr_zones = safe_json_loads(activity.hr_zones_json)
     weather = safe_json_loads(activity.weather_json)
+    power_zones = safe_json_loads(activity.power_zones_json)
 
     # Parse time-series data for area charts
     chart_data = _parse_activity_charts(laps)
@@ -238,6 +245,7 @@ def activity_detail(request: Request, activity_id: int, db: Session = Depends(ge
         "splits": splits,
         "hr_zones": hr_zones,
         "weather": weather,
+        "power_zones": power_zones,
         "chart_data": json.dumps(chart_data),
         "insight": insight,
         "page": "dashboard",

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -38,7 +38,10 @@
         <div class="stat"><span class="stat-value">{{ activity.max_hr }}</span><span class="stat-label">Max HR</span></div>
         {% endif %}
         {% if activity.avg_cadence %}
-        <div class="stat"><span class="stat-value">{{ activity.avg_cadence | round(0) | int }}</span><span class="stat-label">Cadence</span></div>
+        <div class="stat"><span class="stat-value">{{ activity.avg_cadence | round(0) | int }}</span><span class="stat-label">Avg Cadence</span></div>
+        {% endif %}
+        {% if activity.max_cadence %}
+        <div class="stat"><span class="stat-value">{{ activity.max_cadence | round(0) | int }}</span><span class="stat-label">Max Cadence</span></div>
         {% endif %}
         {% if activity.avg_stride %}
         <div class="stat"><span class="stat-value">{{ '%.2f' | format(activity.avg_stride) }}m</span><span class="stat-label">Stride</span></div>
@@ -90,6 +93,20 @@
 </section>
 {% endif %}
 
+{% if activity.run_time_sec or activity.walk_time_sec %}
+<section class="card">
+    <h2>Run / Walk</h2>
+    <div class="stat-grid stat-grid-2">
+        {% if activity.run_time_sec %}
+        <div class="stat"><span class="stat-value">{{ activity.run_time_sec | duration }}</span><span class="stat-label">Run Time</span></div>
+        {% endif %}
+        {% if activity.walk_time_sec %}
+        <div class="stat"><span class="stat-value">{{ activity.walk_time_sec | duration }}</span><span class="stat-label">Walk Time</span></div>
+        {% endif %}
+    </div>
+</section>
+{% endif %}
+
 {% if activity.normalized_power or activity.training_stress_score or activity.intensity_factor %}
 <section class="card">
     <h2>Performance</h2>
@@ -136,6 +153,15 @@
     <h2>HR Zones</h2>
     <div class="chart-container chart-sm">
         <canvas id="hrZoneChart"></canvas>
+    </div>
+</section>
+{% endif %}
+
+{% if power_zones and power_zones is iterable and power_zones is not string %}
+<section class="card">
+    <h2>Power Zones</h2>
+    <div class="chart-container chart-sm">
+        <canvas id="powerZoneChart"></canvas>
     </div>
 </section>
 {% endif %}
@@ -278,10 +304,16 @@ const chartData = {{ chart_data | safe }};
 const chartKeys = Object.keys(chartData);
 const chartColors = {
     heart_rate: { line: '#e74c3c', fill: 'rgba(231, 76, 60, 0.15)' },
-    elevation: { line: '#2ecc71', fill: 'rgba(46, 204, 113, 0.15)' },
-    pace:      { line: '#6c5ce7', fill: 'rgba(108, 92, 231, 0.15)' },
-    cadence:   { line: '#f39c12', fill: 'rgba(243, 156, 18, 0.15)' },
-    power:     { line: '#0984e3', fill: 'rgba(9, 132, 227, 0.15)' },
+    elevation:  { line: '#2ecc71', fill: 'rgba(46, 204, 113, 0.15)' },
+    pace:       { line: '#6c5ce7', fill: 'rgba(108, 92, 231, 0.15)' },
+    cadence:    { line: '#f39c12', fill: 'rgba(243, 156, 18, 0.15)' },
+    power:      { line: '#0984e3', fill: 'rgba(9, 132, 227, 0.15)' },
+    gct:        { line: '#fd79a8', fill: 'rgba(253, 121, 168, 0.15)' },
+    vert_osc:   { line: '#00cec9', fill: 'rgba(0, 206, 201, 0.15)' },
+    vert_ratio: { line: '#a29bfe', fill: 'rgba(162, 155, 254, 0.15)' },
+    stride:     { line: '#55efc4', fill: 'rgba(85, 239, 196, 0.15)' },
+    perf_cond:  { line: '#fdcb6e', fill: 'rgba(253, 203, 110, 0.15)' },
+    stamina:    { line: '#e17055', fill: 'rgba(225, 112, 85, 0.15)' },
 };
 
 if (chartKeys.length > 0) {
@@ -366,4 +398,43 @@ if (chartKeys.length > 0) {
     renderChart(chartKeys[0]);
 }
 </script>
+{% if power_zones and power_zones is iterable and power_zones is not string %}
+<script>
+const pzones = {{ power_zones | tojson }};
+const pzoneLabels = [];
+const pzoneData = [];
+const pzoneColors = ['#2ecc71', '#27ae60', '#f1c40f', '#e67e22', '#e74c3c'];
+if (Array.isArray(pzones)) {
+    pzones.forEach(z => {
+        pzoneLabels.push('PZ' + (z.zoneNumber || z.zoneLow || '?'));
+        pzoneData.push(Math.round((z.secsInZone || 0) / 60));
+    });
+}
+const pzCtx = document.getElementById('powerZoneChart');
+if (pzCtx && pzoneData.length) {
+    new Chart(pzCtx, {
+        type: 'bar',
+        data: {
+            labels: pzoneLabels,
+            datasets: [{
+                label: 'Minutes',
+                data: pzoneData,
+                backgroundColor: pzoneColors.slice(0, pzoneData.length),
+                borderRadius: 6,
+            }]
+        },
+        options: {
+            indexAxis: 'y',
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { display: false } },
+            scales: {
+                x: { beginAtZero: true, grid: { color: 'rgba(255,255,255,0.06)' }, ticks: { color: '#999' } },
+                y: { grid: { display: false }, ticks: { color: '#999' } }
+            }
+        }
+    });
+}
+</script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add 6 new time-series chart tabs from existing laps_json data: GCT, Vertical Oscillation, Vertical Ratio, Stride Length, Performance Condition, Stamina
- Add Power Zones horizontal bar chart (matches HR Zones UI pattern)
- Add Run/Walk stat card with run and walk durations from typed splits
- Add max cadence stat alongside avg cadence
- Feed max cadence, run/walk split, and power zones into AI coaching context

## Test plan
- [ ] Verify new chart tabs appear for activities with running dynamics data
- [ ] Verify Power Zones chart renders when power zone data is available
- [ ] Verify Run/Walk card shows when typed splits contain walking intervals
- [ ] Verify max cadence appears in Details section
- [ ] Trigger AI re-analysis and confirm new metrics in coaching output
- [ ] Test mobile responsiveness of new chart tabs scrolling

https://claude.ai/code/session_01G4K6butzZCpPSxQyTjbKsT