### PR TITLE
Fix: Upgrade Node.js actions to 24 in docker build workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Summary
- Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable to GitHub Actions workflow
- Opts into Node.js 24 support now instead of waiting for June 2nd, 2026 deadline
- Resolves issue #13: GitHub Actions Node.js 20 deprecation warning

## Changes
Updated `.github/workflows/docker-publish.yml` to add the Node.js 24 opt-in flag to prevent deprecated action warnings.