### PR TITLE
Fix: Upgrade Node.js actions to 24 in docker build workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   build-and-push:
@@ -21,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -29,7 +28,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -37,7 +36,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
- Upgrade Docker action versions to support Node.js 24 natively
- docker/login-action: v3 → v4
- docker/metadata-action: v5 → v6
- docker/build-push-action: v6 → v7
- Resolves issue #13: GitHub Actions Node.js 20 deprecation warning

## Changes
Updated `.github/workflows/docker-publish.yml` with newer action versions that natively support Node.js 24, rather than relying on forced opt-in.