### PR TITLE
Fix: Update actions/checkout to v6 for Node.js 24 support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Container Registry
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary
- Update actions/checkout from v4 to v6 (latest version with Node.js 24 support)
- Ensures all GitHub Actions in the workflow use versions compatible with Node.js 24

## Changes
Updated `.github/workflows/docker-publish.yml` to use actions/checkout@v6, which is the latest major version and supports Node.js 24.