### PR TITLE
Build Docker image on all branch pushes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary
- Expands the Docker build workflow trigger from `main`-only to all branches (`'**'`)
- Enables feature branch builds so images can be tested as containers before merging
- Tagging strategy (`latest` + SHA) remains unchanged

Closes #19

https://claude.ai/code/session_016ehvPoX7CdSPD8f1W6EC8s