### PR TITLE
Fix calendar workout dots not linking to activity detail

### DIFF
--- a/app/templates/calendar.html
+++ b/app/templates/calendar.html
@@ -57,7 +57,7 @@
             {% if d in activities_by_date %}
             <div class="day-dots">
                 {% for a in activities_by_date[d][:3] %}
-                <span class="dot {% if 'run' in (a.activity_type or '') %}run{% elif 'cycling' in (a.activity_type or '') or 'biking' in (a.activity_type or '') %}cycle{% else %}other{% endif %}" title="{{ a.name }}: {{ a.distance_m | distance_km }}km"></span>
+                <a href="/activity/{{ a.id }}" class="dot {% if 'run' in (a.activity_type or '') %}run{% elif 'cycling' in (a.activity_type or '') or 'biking' in (a.activity_type or '') %}cycle{% else %}other{% endif %}" title="{{ a.name }}: {{ a.distance_m | distance_km }}km"></a>
                 {% endfor %}
             </div>
             {% endif %}

--- a/static/style.css
+++ b/static/style.css
@@ -416,9 +416,12 @@ details summary {
 }
 
 .dot {
-    width: 6px;
-    height: 6px;
+    display: block;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
+    cursor: pointer;
+    text-decoration: none;
 }
 
 .dot.run { background: var(--success); }


### PR DESCRIPTION
## Summary

Fixes #17

- Calendar activity dots were plain `<span>` elements with no navigation — clicking them did nothing
- Changed dots to `<a href="/activity/{{ a.id }}">` links so each one navigates to the activity detail view
- Made dots slightly larger (6px → 8px) with `cursor: pointer` for better tap targets on mobile

## Test plan

- [ ] Open the calendar view
- [ ] Navigate to a month with logged activities (colored dots visible on days)
- [ ] Tap/click a dot — should navigate to the activity detail page with full workout info
- [ ] Verify multiple dots on the same day each link to their respective activity

https://claude.ai/code/session_019BNrfL9R5QWJ5QutDhC2Ec