### PR TITLE
Add workflow_dispatch trigger to docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,7 @@ name: Build and Push Docker Image
 on:
   push:
     branches: ['**']
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the Docker build and push workflow, enabling manual runs from the GitHub Actions UI for any branch.

## Test plan

- [ ] Navigate to Actions → "Build and Push Docker Image" and verify the "Run workflow" button appears
- [ ] Manually trigger the workflow and confirm it builds and pushes successfully