### PR TITLE
Add race priority and goal time display to Today view

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -130,6 +130,8 @@ def api_today(
             date=next_race_row.date,
             distance_label=next_race_row.distance_label,
             days_away=(next_race_row.date - date.today()).days,
+            goal_time_sec=next_race_row.goal_time_sec,
+            priority=next_race_row.priority,
         )
 
     # Scheduled workout events for the selected date

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -203,6 +203,8 @@ class RaceInfo(BaseModel):
     date: date
     distance_label: str | None = None
     days_away: int
+    goal_time_sec: int | None = None
+    priority: str | None = None
 
 
 class TodayResponse(BaseModel):

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -150,6 +150,8 @@ export interface RaceInfo {
   date: string
   distance_label: string | null
   days_away: number
+  goal_time_sec: number | null
+  priority: string | null
 }
 
 export interface TodayResponse {

--- a/frontend/src/components/today/TodayView.css
+++ b/frontend/src/components/today/TodayView.css
@@ -40,6 +40,26 @@
   margin-top: 2px;
 }
 
+.race-priority-badge {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 4px;
+  padding: 2px 7px;
+  margin-bottom: 8px;
+}
+
+.race-goal-time {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.65);
+  margin-top: 4px;
+}
+
 /* Daily snapshot */
 .daily-snapshot .snap-grid {
   display: grid;

--- a/frontend/src/components/today/TodayView.tsx
+++ b/frontend/src/components/today/TodayView.tsx
@@ -1,11 +1,19 @@
 import { useDateContext } from '../../App'
 import { useToday } from '../../api/hooks'
 import { formatDateKey, format, isToday as checkIsToday } from '../../utils/date'
+import { formatDuration } from '../../utils/formatting'
 import WorkoutCard from './WorkoutCard'
 import ScheduledWorkoutCard from './ScheduledWorkoutCard'
 import WeekOverview from './WeekOverview'
 import InsightsList from './InsightsList'
 import './TodayView.css'
+
+function formatPriority(priority: string | null): string | null {
+  if (priority === 'A') return 'Primary'
+  if (priority === 'B') return 'Secondary'
+  if (priority === 'C') return 'C Priority'
+  return null
+}
 
 export default function TodayView() {
   const { selectedDate } = useDateContext()
@@ -50,10 +58,20 @@ export default function TodayView() {
       {data?.next_race && (
         <section className="today-section">
           <div className="card race-card">
+            {formatPriority(data.next_race.priority) && (
+              <div className="race-priority-badge">
+                {formatPriority(data.next_race.priority)}
+              </div>
+            )}
             <div className="race-days">{data.next_race.days_away} days</div>
             <div className="race-name">{data.next_race.title}</div>
             {data.next_race.distance_label && (
               <div className="race-distance">{data.next_race.distance_label}</div>
+            )}
+            {data.next_race.goal_time_sec != null && (
+              <div className="race-goal-time">
+                Goal: {formatDuration(data.next_race.goal_time_sec)}
+              </div>
             )}
           </div>
         </section>


### PR DESCRIPTION
## Summary
Enhanced the race card in the Today view to display additional race details: priority level and goal time. This provides users with more context about their upcoming races at a glance.

## Key Changes
- **Backend (API & Schema)**
  - Added `goal_time_sec` and `priority` fields to the `RaceInfo` schema
  - Updated the API endpoint to include these fields when returning race information

- **Frontend (Components & Styling)**
  - Added `formatPriority()` utility function to convert priority codes (A/B/C) to human-readable labels (Primary/Secondary/C Priority)
  - Created new CSS classes for styling:
    - `.race-priority-badge`: Displays priority as a subtle badge with uppercase text
    - `.race-goal-time`: Displays the goal time in a smaller, muted font
  - Updated the race card to conditionally render priority badge and goal time using the `formatDuration()` utility
  - Updated TypeScript types to include the new fields

## Implementation Details
- Priority badges only render when a priority value exists
- Goal time only displays when `goal_time_sec` is not null
- Styling uses semi-transparent white colors to maintain visual consistency with existing race card design
- Priority formatting maps single-letter codes to user-friendly labels (A→Primary, B→Secondary, C→C Priority)

https://claude.ai/code/session_012iwx4zSdWmRrP3U3ZZUudL