### PR TITLE
Add AI backend selection: support Claude and Gemini with UI model picker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 GARMIN_EMAIL=your@email.com
 GARMIN_PASSWORD=your_password
 ANTHROPIC_API_KEY=sk-ant-...
+GEMINI_API_KEY=AIza...
 TIMEZONE=America/New_York
 DB_PATH=/data/running_coach.db
 GARMIN_TOKEN_DIR=/data/garmin_tokens

--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -3,12 +3,13 @@ import logging
 from datetime import datetime, date, timedelta, timezone
 
 import anthropic
+import google.generativeai as genai
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
 from app.config import settings
 from app.database import db_session
-from app.models import Activity, DailySummary, GarminCalendarEvent, Insight, MetricZone
+from app.models import Activity, DailySummary, GarminCalendarEvent, Insight, MetricZone, SyncStatus
 
 logger = logging.getLogger(__name__)
 
@@ -380,22 +381,8 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
     return "\n\n".join(sections)
 
 
-def _call_claude(context: str, trigger_type: str) -> tuple[str, str, str]:
-    """Call Claude API and return (content, summary, category)."""
-    client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
-
-    user_prompt = f"Analyze this {trigger_type} data and provide coaching insights:\n\n{context}"
-
-    response = client.messages.create(
-        model=settings.ai_model,
-        max_tokens=1024,
-        system=SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": user_prompt}],
-    )
-
-    content = response.content[0].text
-
-    # Extract summary (first line starting with **Summary:**)
+def _extract_summary_and_category(content: str, trigger_type: str) -> tuple[str, str]:
+    """Extract summary line and category from AI response text."""
     summary = ""
     for line in content.split("\n"):
         if line.strip().startswith("**Summary:**"):
@@ -403,16 +390,55 @@ def _call_claude(context: str, trigger_type: str) -> tuple[str, str, str]:
             break
     if not summary:
         summary = content.split("\n")[0][:200]
-
-    # Determine category
     category_map = {
         "activity": "workout_analysis",
         "daily_summary": "recovery",
         "weekly_review": "training_plan",
     }
-    category = category_map.get(trigger_type, "recommendation")
+    return summary, category_map.get(trigger_type, "recommendation")
 
+
+def _call_claude(context: str, trigger_type: str, model: str) -> tuple[str, str, str]:
+    """Call Claude API and return (content, summary, category)."""
+    client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+    user_prompt = f"Analyze this {trigger_type} data and provide coaching insights:\n\n{context}"
+    response = client.messages.create(
+        model=model,
+        max_tokens=1024,
+        system=SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": user_prompt}],
+    )
+    content = response.content[0].text
+    summary, category = _extract_summary_and_category(content, trigger_type)
     return content, summary, category
+
+
+def _call_gemini(context: str, trigger_type: str, model: str) -> tuple[str, str, str]:
+    """Call Gemini API and return (content, summary, category)."""
+    genai.configure(api_key=settings.gemini_api_key)
+    gemini_model = genai.GenerativeModel(model_name=model, system_instruction=SYSTEM_PROMPT)
+    user_prompt = f"Analyze this {trigger_type} data and provide coaching insights:\n\n{context}"
+    response = gemini_model.generate_content(user_prompt)
+    content = response.text
+    summary, category = _extract_summary_and_category(content, trigger_type)
+    return content, summary, category
+
+
+def _get_ai_config(db: Session) -> tuple[str, str]:
+    """Return (provider, model) from DB, falling back to env defaults."""
+    provider_row = db.query(SyncStatus).filter(SyncStatus.key == "ai_provider").first()
+    model_row = db.query(SyncStatus).filter(SyncStatus.key == "ai_model").first()
+    provider = provider_row.value if provider_row else "claude"
+    model = model_row.value if model_row else settings.ai_model
+    return provider, model
+
+
+def _call_ai(db: Session, context: str, trigger_type: str) -> tuple[str, str, str]:
+    """Dispatch to the configured AI provider and return (content, summary, category)."""
+    provider, model = _get_ai_config(db)
+    if provider == "gemini":
+        return _call_gemini(context, trigger_type, model)
+    return _call_claude(context, trigger_type, model)
 
 
 def _load_zones(db: Session) -> dict[str, list[MetricZone]]:
@@ -431,7 +457,7 @@ def analyze_activity(activity: Activity):
             zones_by_metric = _load_zones(db)
             activity_context = _format_activity_context(activity, zones_by_metric)
             full_context = _build_context(db, "activity", activity_context, reference_date=activity_date)
-            content, summary, category = _call_claude(full_context, "activity")
+            content, summary, category = _call_ai(db, full_context, "activity")
 
             insight = Insight(
                 created_at=datetime.now(timezone.utc),
@@ -459,7 +485,7 @@ def analyze_daily_summary(daily: DailySummary):
         try:
             daily_context = _format_daily_context(daily)
             full_context = _build_context(db, "daily_summary", daily_context, reference_date=daily.date)
-            content, summary, category = _call_claude(full_context, "daily_summary")
+            content, summary, category = _call_ai(db, full_context, "daily_summary")
 
             insight = Insight(
                 created_at=datetime.now(timezone.utc),
@@ -500,7 +526,7 @@ def analyze_activity_force(activity_id: int):
             zones_by_metric = _load_zones(db)
             activity_context = _format_activity_context(activity, zones_by_metric)
             full_context = _build_context(db, "activity", activity_context, reference_date=activity_date)
-            content, summary, category = _call_claude(full_context, "activity")
+            content, summary, category = _call_ai(db, full_context, "activity")
 
             insight = Insight(
                 created_at=datetime.now(timezone.utc),
@@ -557,7 +583,7 @@ def analyze_activity_with_feedback(activity_id: int):
 
             activity_date = activity.started_at.date() if isinstance(activity.started_at, datetime) else activity.started_at
             full_context = _build_context(db, "activity", activity_context, reference_date=activity_date)
-            content, summary, category = _call_claude(full_context, "activity")
+            content, summary, category = _call_ai(db, full_context, "activity")
 
             insight = Insight(
                 created_at=datetime.now(timezone.utc),
@@ -638,7 +664,7 @@ def weekly_review():
             activity_summaries = "\n\n".join(_format_activity_context(a, zones_by_metric) for a in week_activities)
             trigger_data = f"## Weekly Review ({week_start} to {date.today()})\n\n{activity_summaries}"
             full_context = _build_context(db, "weekly_review", trigger_data)
-            content, summary, category = _call_claude(full_context, "weekly_review")
+            content, summary, category = _call_ai(db, full_context, "weekly_review")
 
             insight = Insight(
                 created_at=datetime.now(timezone.utc),

--- a/app/api.py
+++ b/app/api.py
@@ -13,6 +13,8 @@ from app.models import Activity, DailySummary, GarminCalendarEvent, Insight, Met
 from app.schemas import (
     ActivityDetail,
     ActivitySummary,
+    AiConfigRequest,
+    AiConfigResponse,
     CalendarDay,
     CalendarEventResponse,
     DailySummaryDetail,
@@ -31,6 +33,11 @@ from app.utils import safe_json_loads, parse_activity_charts
 logger = logging.getLogger(__name__)
 
 api_router = APIRouter(prefix="/api/v1", tags=["api"])
+
+AVAILABLE_MODELS: dict[str, list[str]] = {
+    "claude": ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
+    "gemini": ["gemini-2.0-flash", "gemini-1.5-pro", "gemini-1.5-flash"],
+}
 
 
 # --- Today ---
@@ -429,6 +436,44 @@ def api_settings(db: Session = Depends(get_db)):
         "calendar_events": db.query(func.count(GarminCalendarEvent.id)).scalar() or 0,
     }
     return SettingsResponse(sync_statuses=sync_statuses, counts=counts)
+
+
+@api_router.get("/ai-config", response_model=AiConfigResponse)
+def api_get_ai_config(db: Session = Depends(get_db)):
+    from app.config import settings as app_settings
+    provider_row = db.query(SyncStatus).filter(SyncStatus.key == "ai_provider").first()
+    model_row = db.query(SyncStatus).filter(SyncStatus.key == "ai_model").first()
+    provider = provider_row.value if provider_row else "claude"
+    model = model_row.value if model_row else app_settings.ai_model
+    return AiConfigResponse(
+        provider=provider,
+        model=model,
+        available_providers=list(AVAILABLE_MODELS.keys()),
+        available_models=AVAILABLE_MODELS,
+    )
+
+
+@api_router.post("/ai-config", response_model=AiConfigResponse)
+def api_set_ai_config(config: AiConfigRequest, db: Session = Depends(get_db)):
+    if config.provider not in AVAILABLE_MODELS:
+        raise HTTPException(status_code=400, detail=f"Unknown provider: {config.provider}")
+    if config.model not in AVAILABLE_MODELS[config.provider]:
+        raise HTTPException(status_code=400, detail=f"Model {config.model} not valid for {config.provider}")
+
+    for key, value in [("ai_provider", config.provider), ("ai_model", config.model)]:
+        row = db.query(SyncStatus).filter(SyncStatus.key == key).first()
+        if row:
+            row.value = value
+        else:
+            db.add(SyncStatus(key=key, value=value))
+    db.commit()
+
+    return AiConfigResponse(
+        provider=config.provider,
+        model=config.model,
+        available_providers=list(AVAILABLE_MODELS.keys()),
+        available_models=AVAILABLE_MODELS,
+    )
 
 
 # --- Actions ---

--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     garmin_email: str = ""
     garmin_password: str = ""
     anthropic_api_key: str = ""
+    gemini_api_key: str = ""
     timezone: str = "UTC"
     db_path: str = "/data/running_coach.db"
     garmin_token_dir: str = "/data/garmin_tokens"

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -220,3 +220,15 @@ class TodayResponse(BaseModel):
 class SettingsResponse(BaseModel):
     sync_statuses: dict[str, Any] = {}
     counts: dict[str, int] = {}
+
+
+class AiConfigResponse(BaseModel):
+    provider: str
+    model: str
+    available_providers: list[str]
+    available_models: dict[str, list[str]]
+
+
+class AiConfigRequest(BaseModel):
+    provider: str
+    model: str

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - GARMIN_EMAIL=${GARMIN_EMAIL}
       - GARMIN_PASSWORD=${GARMIN_PASSWORD}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - TIMEZONE=${TIMEZONE:-UTC}
       - DB_PATH=${DB_PATH:-/data/running_coach.db}
       - GARMIN_TOKEN_DIR=${GARMIN_TOKEN_DIR:-/data/garmin_tokens}

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -11,6 +11,8 @@ import type {
   FeedbackRequest,
   InsightResponse,
   SettingsResponse,
+  AiConfigResponse,
+  AiConfigRequest,
 } from './types'
 
 export function useToday(date: string) {
@@ -119,6 +121,24 @@ export function useSubmitFeedback() {
       qc.invalidateQueries({ queryKey: ['activity', id] })
       setTimeout(() => qc.invalidateQueries({ queryKey: ['activity', id] }), 5000)
       setTimeout(() => qc.invalidateQueries({ queryKey: ['activity', id] }), 12000)
+    },
+  })
+}
+
+export function useAiConfig() {
+  return useQuery({
+    queryKey: ['ai-config'],
+    queryFn: () => apiGet<AiConfigResponse>('/ai-config'),
+  })
+}
+
+export function useSetAiConfig() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (config: AiConfigRequest) =>
+      apiPost<AiConfigResponse>('/ai-config', config),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['ai-config'] })
     },
   })
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -168,3 +168,15 @@ export interface SettingsResponse {
   sync_statuses: Record<string, { value: string; updated_at: string | null }>
   counts: Record<string, number>
 }
+
+export interface AiConfigResponse {
+  provider: string
+  model: string
+  available_providers: string[]
+  available_models: Record<string, string[]>
+}
+
+export interface AiConfigRequest {
+  provider: string
+  model: string
+}

--- a/frontend/src/components/settings/SettingsView.css
+++ b/frontend/src/components/settings/SettingsView.css
@@ -96,3 +96,37 @@
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
+
+.ai-config {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+}
+
+.ai-config-label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.ai-config-label select {
+  padding: 8px 10px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: 0.88rem;
+}
+
+.ai-config-label select:disabled {
+  opacity: 0.6;
+}
+
+.ai-config-error {
+  font-size: 0.78rem;
+  color: #e74c3c;
+}

--- a/frontend/src/components/settings/SettingsView.tsx
+++ b/frontend/src/components/settings/SettingsView.tsx
@@ -1,7 +1,65 @@
 import { useState } from 'react'
-import { RefreshCw, Database, CloudDownload } from 'lucide-react'
-import { useSettings, useTriggerSync } from '../../api/hooks'
+import { RefreshCw } from 'lucide-react'
+import { useSettings, useTriggerSync, useAiConfig, useSetAiConfig } from '../../api/hooks'
 import './SettingsView.css'
+
+const PROVIDER_LABELS: Record<string, string> = {
+  claude: 'Claude (Anthropic)',
+  gemini: 'Gemini (Google)',
+}
+
+function AiBackendSection() {
+  const { data, isLoading } = useAiConfig()
+  const setConfig = useSetAiConfig()
+
+  if (isLoading || !data) return null
+
+  const handleProviderChange = (provider: string) => {
+    const firstModel = data.available_models[provider]?.[0] ?? ''
+    setConfig.mutate({ provider, model: firstModel })
+  }
+
+  const handleModelChange = (model: string) => {
+    setConfig.mutate({ provider: data.provider, model })
+  }
+
+  const isPending = setConfig.isPending
+
+  return (
+    <section className="settings-section">
+      <h2 className="section-title">AI Backend</h2>
+      <div className="card ai-config">
+        <label className="ai-config-label">
+          Provider
+          <select
+            value={data.provider}
+            disabled={isPending}
+            onChange={e => handleProviderChange(e.target.value)}
+          >
+            {data.available_providers.map(p => (
+              <option key={p} value={p}>{PROVIDER_LABELS[p] ?? p}</option>
+            ))}
+          </select>
+        </label>
+        <label className="ai-config-label">
+          Model
+          <select
+            value={data.model}
+            disabled={isPending}
+            onChange={e => handleModelChange(e.target.value)}
+          >
+            {(data.available_models[data.provider] ?? []).map(m => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+        </label>
+        {setConfig.isError && (
+          <span className="ai-config-error">Failed to save config</span>
+        )}
+      </div>
+    </section>
+  )
+}
 
 export default function SettingsView() {
   const { data, isLoading } = useSettings()
@@ -12,6 +70,9 @@ export default function SettingsView() {
 
   return (
     <div className="settings-view">
+      {/* AI backend selector */}
+      <AiBackendSection />
+
       {/* Database stats */}
       <section className="settings-section">
         <h2 className="section-title">Database</h2>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ sqlalchemy==2.0.36
 aiosqlite==0.20.0
 garminconnect==0.2.25
 anthropic==0.42.0
+google-generativeai==0.8.6
 apscheduler==3.10.4
 python-dotenv==1.0.1
 pydantic-settings==2.7.0


### PR DESCRIPTION
- Add google-generativeai SDK to requirements.txt
- Add GEMINI_API_KEY to config, docker-compose, and .env.example
- Refactor ai_coach.py: extract _call_ai dispatcher that reads provider/model
  from DB (SyncStatus table) and routes to _call_claude or _call_gemini
- Add GET/POST /api/v1/ai-config endpoints for reading and saving AI config
- Add AiConfigResponse/AiConfigRequest Pydantic schemas
- Add AiBackendSection component to SettingsView with provider + model selects;
  changes save immediately to the backend with no separate Save button
- Fallback: existing deployments without DB config continue using Claude
  with the AI_MODEL env var value

https://claude.ai/code/session_016hapDeG6sPTsuh9UrdLi4F