### PR TITLE
Add AI backend selection: Claude and Gemini with UI model picker

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -441,6 +441,27 @@ def _call_ai(db: Session, context: str, trigger_type: str) -> tuple[str, str, st
     return _call_claude(context, trigger_type, model)
 
 
+def _save_error_insight(activity_id: int, exc: Exception) -> None:
+    """Persist a failure insight so the UI can show an error and allow retry."""
+    try:
+        with db_session() as db:
+            db.query(Insight).filter(
+                Insight.trigger_type == "activity",
+                Insight.trigger_id == activity_id,
+            ).delete()
+            db.add(Insight(
+                created_at=datetime.now(timezone.utc),
+                trigger_type="activity",
+                trigger_id=activity_id,
+                content=f"Analysis failed: {exc}\n\nCheck your AI backend configuration and use **Re-analyze** to retry.",
+                summary="Analysis failed — use Re-analyze to retry",
+                category="recommendation",
+            ))
+            db.commit()
+    except Exception:
+        logger.exception("Failed to save error insight for activity %s", activity_id)
+
+
 def _load_zones(db: Session) -> dict[str, list[MetricZone]]:
     """Load metric zones from the database, grouped by metric_key."""
     zones_by_metric: dict[str, list[MetricZone]] = {}
@@ -540,8 +561,9 @@ def analyze_activity_force(activity_id: int):
             activity.ai_analyzed = True
             db.commit()
             logger.info("AI re-analysis complete for activity %s: %s", activity.id, summary[:80])
-        except Exception:
+        except Exception as exc:
             logger.exception("AI re-analysis failed for activity %s", activity_id)
+            _save_error_insight(activity_id, exc)
 
 
 def analyze_activity_with_feedback(activity_id: int):
@@ -597,8 +619,9 @@ def analyze_activity_with_feedback(activity_id: int):
             activity.ai_analyzed = True
             db.commit()
             logger.info("AI feedback analysis complete for activity %s: %s", activity.id, summary[:80])
-        except Exception:
+        except Exception as exc:
             logger.exception("AI feedback analysis failed for activity %s", activity_id)
+            _save_error_insight(activity_id, exc)
 
 
 def backfill_missing_insights():

--- a/app/api.py
+++ b/app/api.py
@@ -36,7 +36,15 @@ api_router = APIRouter(prefix="/api/v1", tags=["api"])
 
 AVAILABLE_MODELS: dict[str, list[str]] = {
     "claude": ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
-    "gemini": ["gemini-2.0-flash", "gemini-1.5-pro", "gemini-1.5-flash"],
+    "gemini": [
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "gemini-3-flash",
+        "gemini-3.1-flash-lite",
+        "gemma-2-2b-it",
+        "gemma-4-26b-it",
+        "gemma-4-31b-it",
+    ],
 }
 
 


### PR DESCRIPTION
## Summary

- Add Gemini (Google) as an alternative AI backend alongside Claude (Anthropic)
- API keys (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`) configured via Docker environment variables
- Provider and model selection exposed in the Settings UI — changes save immediately with no restart required
- Model list is provider-specific: Claude (opus-4-7, sonnet-4-6, haiku-4-5) and Gemini (2.5 Flash, 2.5 Flash Lite, 3 Flash, 3.1 Flash Lite, Gemma 2 2b, Gemma 4 26b, Gemma 4 31B)
- Selection persists in the database (`SyncStatus` table); existing deployments continue using Claude with their current `AI_MODEL` env var until changed in the UI
- Fix: analysis failures no longer leave activities stuck in "Generating insights…" — a failure insight is saved so the Re-analyze button remains accessible for retry

## Test plan

- [ ] `GET /api/v1/ai-config` returns `provider="claude"` and current `AI_MODEL` env value on a fresh DB
- [ ] Settings UI shows provider and model selects pre-populated from DB; switching provider resets model to first option for that provider
- [ ] Config persists after page reload
- [ ] `POST /api/v1/ai-config` with unknown provider/model returns 400
- [ ] Set a valid `GEMINI_API_KEY`, switch to Gemini in UI, trigger analysis — insight generated via Gemini
- [ ] Simulate AI failure (e.g. invalid API key): activity shows error insight with Re-analyze button instead of spinning forever

https://claude.ai/code/session_016hapDeG6sPTsuh9UrdLi4F

---
_Generated by [Claude Code](https://claude.ai/code/session_016hapDeG6sPTsuh9UrdLi4F)_