### PR TITLE
Add Athlete Profile (P0-1)

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -9,7 +9,16 @@ from sqlalchemy import func
 
 from app.config import settings
 from app.database import db_session
-from app.models import Activity, DailySummary, GarminCalendarEvent, Insight, MetricZone, SyncStatus
+from app.models import (
+    Activity,
+    AthleteProfile,
+    DailySummary,
+    GarminCalendarEvent,
+    Insight,
+    MetricZone,
+    SyncStatus,
+)
+from app.utils import calculate_age
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +243,47 @@ def _format_daily_context(summary: DailySummary) -> str:
     return "\n".join(parts)
 
 
+def _format_athlete_profile_context(profile: AthleteProfile, reference_date: date | None = None) -> str:
+    """Format the athlete profile as a markdown block, emitting only set fields."""
+    ref = reference_date or date.today()
+    lines = []
+    if profile.name:
+        lines.append(f"- Name: {profile.name}")
+    age = calculate_age(profile.date_of_birth, ref)
+    if age is not None:
+        lines.append(f"- Age: {age}")
+    if profile.weight_kg:
+        lines.append(f"- Weight: {profile.weight_kg:.1f} kg")
+    if profile.goal_race:
+        goal = f"- Goal Race: {profile.goal_race}"
+        if profile.goal_race_date:
+            days_until = (profile.goal_race_date - ref).days
+            goal += f" on {profile.goal_race_date} ({days_until} days away)"
+        lines.append(goal)
+    elif profile.goal_race_date:
+        days_until = (profile.goal_race_date - ref).days
+        lines.append(f"- Goal Race Date: {profile.goal_race_date} ({days_until} days away)")
+    if profile.threshold_pace_min_km:
+        p_min = int(profile.threshold_pace_min_km)
+        p_sec = int((profile.threshold_pace_min_km - p_min) * 60)
+        lines.append(f"- Threshold Pace: {p_min}:{p_sec:02d}/km")
+    if profile.threshold_hr:
+        lines.append(f"- Threshold HR: {profile.threshold_hr} bpm")
+    if profile.max_hr:
+        lines.append(f"- Max HR: {profile.max_hr} bpm")
+    if profile.resting_hr:
+        lines.append(f"- Resting HR: {profile.resting_hr} bpm")
+    if profile.weekly_availability:
+        lines.append(f"- Weekly Availability: {profile.weekly_availability}")
+    if profile.training_preferences:
+        lines.append(f"- Training Preferences: {profile.training_preferences}")
+    if profile.injury_history:
+        lines.append(f"- Injury History: {profile.injury_history}")
+    if not lines:
+        return ""
+    return "## Athlete Profile\n" + "\n".join(lines)
+
+
 def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_date: date | None = None) -> str:
     """Build full context for AI analysis.
 
@@ -246,6 +296,13 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
     ref_datetime = datetime.combine(reference_date, datetime.min.time(), tzinfo=timezone.utc)
 
     sections = [f"## Current Data\n{trigger_data}"]
+
+    # Athlete profile (baseline personalization — lands right after Current Data)
+    profile = db.query(AthleteProfile).first()
+    if profile:
+        profile_context = _format_athlete_profile_context(profile, reference_date)
+        if profile_context:
+            sections.insert(1, profile_context)
 
     # Recent activities (last 14 days)
     cutoff = ref_datetime - timedelta(days=14)

--- a/app/api.py
+++ b/app/api.py
@@ -9,12 +9,22 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import Activity, DailySummary, GarminCalendarEvent, Insight, MetricZone, SyncStatus
+from app.models import (
+    Activity,
+    AthleteProfile,
+    DailySummary,
+    GarminCalendarEvent,
+    Insight,
+    MetricZone,
+    SyncStatus,
+)
 from app.schemas import (
     ActivityDetail,
     ActivitySummary,
     AiConfigRequest,
     AiConfigResponse,
+    AthleteProfileRequest,
+    AthleteProfileResponse,
     CalendarDay,
     CalendarEventResponse,
     DailySummaryDetail,
@@ -28,7 +38,7 @@ from app.schemas import (
     WeeklyMileage,
     WorkoutStepResponse,
 )
-from app.utils import safe_json_loads, parse_activity_charts
+from app.utils import safe_json_loads, parse_activity_charts, calculate_age
 
 logger = logging.getLogger(__name__)
 
@@ -482,6 +492,36 @@ def api_set_ai_config(config: AiConfigRequest, db: Session = Depends(get_db)):
         available_providers=list(AVAILABLE_MODELS.keys()),
         available_models=AVAILABLE_MODELS,
     )
+
+
+# --- Athlete Profile ---
+
+
+def _profile_response(profile: AthleteProfile) -> AthleteProfileResponse:
+    """Build a response, deriving age from date_of_birth."""
+    result = AthleteProfileResponse.model_validate(profile)
+    result.age = calculate_age(profile.date_of_birth)
+    return result
+
+
+@api_router.get("/athlete-profile", response_model=AthleteProfileResponse | None)
+def api_get_athlete_profile(db: Session = Depends(get_db)):
+    profile = db.query(AthleteProfile).first()
+    return _profile_response(profile) if profile else None
+
+
+@api_router.post("/athlete-profile", response_model=AthleteProfileResponse)
+def api_set_athlete_profile(profile_data: AthleteProfileRequest, db: Session = Depends(get_db)):
+    profile = db.query(AthleteProfile).first()
+    if profile is None:
+        profile = AthleteProfile(**profile_data.model_dump(exclude_unset=True))
+        db.add(profile)
+    else:
+        for key, value in profile_data.model_dump(exclude_unset=True).items():
+            setattr(profile, key, value)
+    db.commit()
+    db.refresh(profile)
+    return _profile_response(profile)
 
 
 # --- Actions ---

--- a/app/models.py
+++ b/app/models.py
@@ -174,3 +174,29 @@ class SyncStatus(Base):
     key = Column(String(100), unique=True, nullable=False)
     value = Column(Text)
     updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
+
+
+class AthleteProfile(Base):
+    """Single-athlete profile feeding personalization and the AI context.
+
+    The app is single-user, so this table holds at most one row (accessed
+    via ``.first()``).
+    """
+
+    __tablename__ = "athlete_profiles"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(Text, nullable=True)
+    date_of_birth = Column(Date, nullable=True)
+    weight_kg = Column(Float, nullable=True)
+    goal_race = Column(Text, nullable=True)
+    goal_race_date = Column(Date, nullable=True)
+    threshold_pace_min_km = Column(Float, nullable=True)
+    threshold_hr = Column(Integer, nullable=True)
+    max_hr = Column(Integer, nullable=True)
+    resting_hr = Column(Integer, nullable=True)
+    injury_history = Column(Text, nullable=True)
+    weekly_availability = Column(Text, nullable=True)
+    training_preferences = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=_utcnow)
+    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -232,3 +232,40 @@ class AiConfigResponse(BaseModel):
 class AiConfigRequest(BaseModel):
     provider: str
     model: str
+
+
+class AthleteProfileRequest(BaseModel):
+    name: str | None = None
+    date_of_birth: date | None = None
+    weight_kg: float | None = None
+    goal_race: str | None = None
+    goal_race_date: date | None = None
+    threshold_pace_min_km: float | None = None
+    threshold_hr: int | None = None
+    max_hr: int | None = None
+    resting_hr: int | None = None
+    injury_history: str | None = None
+    weekly_availability: str | None = None
+    training_preferences: str | None = None
+
+
+class AthleteProfileResponse(BaseModel):
+    id: int
+    name: str | None = None
+    date_of_birth: date | None = None
+    age: int | None = None
+    weight_kg: float | None = None
+    goal_race: str | None = None
+    goal_race_date: date | None = None
+    threshold_pace_min_km: float | None = None
+    threshold_hr: int | None = None
+    max_hr: int | None = None
+    resting_hr: int | None = None
+    injury_history: str | None = None
+    weekly_availability: str | None = None
+    training_preferences: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    class Config:
+        from_attributes = True

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,14 @@
 import json
+from datetime import date
+
+
+def calculate_age(dob: date | None, reference: date | None = None) -> int | None:
+    """Return age in whole years from a date of birth, or None if unset."""
+    if dob is None:
+        return None
+    today = reference or date.today()
+    years = today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
+    return years if years >= 0 else None
 
 
 def safe_json_loads(raw: str | None):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import { useState, createContext, useContext } from 'react'
-import { Routes, Route, useLocation } from 'react-router-dom'
+import { useState, useEffect, createContext, useContext } from 'react'
+import { Routes, Route, useLocation, useNavigate } from 'react-router-dom'
 import TopBar from './components/layout/TopBar'
 import BottomNav from './components/layout/BottomNav'
 import CalendarContainer from './components/layout/CalendarContainer'
@@ -10,6 +10,8 @@ import DailySummariesView from './components/daily/DailySummariesView'
 import DailyDetailView from './components/daily/DailyDetailView'
 import SettingsView from './components/settings/SettingsView'
 import WorkoutDetailView from './components/workout-detail/WorkoutDetailView'
+import OnboardingView from './components/onboarding/OnboardingView'
+import { useAthleteProfile } from './api/hooks'
 
 interface DateContextType {
   selectedDate: Date
@@ -29,8 +31,18 @@ export default function App() {
   const [selectedDate, setSelectedDate] = useState(new Date())
   const [calendarExpanded, setCalendarExpanded] = useState(false)
   const location = useLocation()
+  const navigate = useNavigate()
 
-  const isDetailPage = location.pathname.startsWith('/activities/') || location.pathname.startsWith('/daily/') || location.pathname.startsWith('/workouts/')
+  // First-run: redirect to onboarding when no athlete profile exists yet.
+  const { data: profile, isLoading: profileLoading } = useAthleteProfile()
+  useEffect(() => {
+    if (!profileLoading && profile === null && location.pathname !== '/onboarding') {
+      navigate('/onboarding', { replace: true })
+    }
+  }, [profileLoading, profile, location.pathname, navigate])
+
+  const isOnboarding = location.pathname === '/onboarding'
+  const isDetailPage = isOnboarding || location.pathname.startsWith('/activities/') || location.pathname.startsWith('/daily/') || location.pathname.startsWith('/workouts/')
   const showCalendar = !isDetailPage
 
   return (
@@ -62,6 +74,7 @@ export default function App() {
             <Route path="/daily/:id" element={<DailyDetailView />} />
             <Route path="/workouts/:id" element={<WorkoutDetailView />} />
             <Route path="/settings" element={<SettingsView />} />
+            <Route path="/onboarding" element={<OnboardingView />} />
           </Routes>
         </main>
         {!isDetailPage && <BottomNav />}

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -13,6 +13,8 @@ import type {
   SettingsResponse,
   AiConfigResponse,
   AiConfigRequest,
+  AthleteProfile,
+  AthleteProfileRequest,
 } from './types'
 
 export function useToday(date: string) {
@@ -139,6 +141,24 @@ export function useSetAiConfig() {
       apiPost<AiConfigResponse>('/ai-config', config),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['ai-config'] })
+    },
+  })
+}
+
+export function useAthleteProfile() {
+  return useQuery({
+    queryKey: ['athlete-profile'],
+    queryFn: () => apiGet<AthleteProfile | null>('/athlete-profile'),
+  })
+}
+
+export function useUpdateAthleteProfile() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (profile: AthleteProfileRequest) =>
+      apiPost<AthleteProfile>('/athlete-profile', profile),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['athlete-profile'] })
     },
   })
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -180,3 +180,37 @@ export interface AiConfigRequest {
   provider: string
   model: string
 }
+
+export interface AthleteProfile {
+  id: number
+  name: string | null
+  date_of_birth: string | null
+  age: number | null
+  weight_kg: number | null
+  goal_race: string | null
+  goal_race_date: string | null
+  threshold_pace_min_km: number | null
+  threshold_hr: number | null
+  max_hr: number | null
+  resting_hr: number | null
+  injury_history: string | null
+  weekly_availability: string | null
+  training_preferences: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface AthleteProfileRequest {
+  name?: string | null
+  date_of_birth?: string | null
+  weight_kg?: number | null
+  goal_race?: string | null
+  goal_race_date?: string | null
+  threshold_pace_min_km?: number | null
+  threshold_hr?: number | null
+  max_hr?: number | null
+  resting_hr?: number | null
+  injury_history?: string | null
+  weekly_availability?: string | null
+  training_preferences?: string | null
+}

--- a/frontend/src/components/onboarding/OnboardingView.css
+++ b/frontend/src/components/onboarding/OnboardingView.css
@@ -1,0 +1,31 @@
+.onboarding-view {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 32px 16px calc(32px + env(safe-area-inset-bottom, 0px));
+  min-height: 100dvh;
+}
+
+.onboarding-view__header {
+  margin-bottom: 24px;
+}
+
+.onboarding-view__header h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.onboarding-view__header p {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.onboarding-view__skip {
+  display: block;
+  width: 100%;
+  margin-top: 16px;
+  padding: 10px;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}

--- a/frontend/src/components/onboarding/OnboardingView.tsx
+++ b/frontend/src/components/onboarding/OnboardingView.tsx
@@ -1,0 +1,39 @@
+import { useNavigate } from 'react-router-dom'
+import { useAthleteProfile, useUpdateAthleteProfile } from '../../api/hooks'
+import type { AthleteProfileRequest } from '../../api/types'
+import ProfileForm from '../profile/ProfileForm'
+import './OnboardingView.css'
+
+export default function OnboardingView() {
+  const navigate = useNavigate()
+  const { data: profile, isLoading } = useAthleteProfile()
+  const updateProfile = useUpdateAthleteProfile()
+
+  if (isLoading) return <div className="spinner" />
+
+  const handleSubmit = (data: AthleteProfileRequest) => {
+    updateProfile.mutate(data, { onSuccess: () => navigate('/') })
+  }
+
+  return (
+    <div className="onboarding-view">
+      <header className="onboarding-view__header">
+        <h1>Welcome to Running Coach</h1>
+        <p>
+          Tell us about yourself so your coach can personalize every insight. You can change
+          any of this later in Settings.
+        </p>
+      </header>
+      <ProfileForm
+        initial={profile}
+        onSubmit={handleSubmit}
+        isPending={updateProfile.isPending}
+        isError={updateProfile.isError}
+        submitLabel="Get started"
+      />
+      <button className="onboarding-view__skip" type="button" onClick={() => navigate('/')}>
+        Skip for now
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/profile/ProfileForm.css
+++ b/frontend/src/components/profile/ProfileForm.css
@@ -1,0 +1,68 @@
+.profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile-form__row {
+  display: flex;
+  gap: 12px;
+}
+
+.profile-form__row .profile-form__field {
+  flex: 1;
+}
+
+.profile-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-form__field label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.profile-form__field input,
+.profile-form__field textarea {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-input);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  width: 100%;
+}
+
+.profile-form__field textarea {
+  resize: vertical;
+}
+
+.profile-form__field input:focus,
+.profile-form__field textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.profile-form__error {
+  color: var(--danger);
+  font-size: 0.82rem;
+}
+
+.profile-form__submit {
+  margin-top: 4px;
+  padding: 12px 20px;
+  background: var(--accent);
+  color: #fff;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.profile-form__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/profile/ProfileForm.tsx
+++ b/frontend/src/components/profile/ProfileForm.tsx
@@ -1,0 +1,151 @@
+import { useState } from 'react'
+import type { AthleteProfile, AthleteProfileRequest } from '../../api/types'
+import './ProfileForm.css'
+
+interface ProfileFormProps {
+  initial?: AthleteProfile | null
+  onSubmit: (data: AthleteProfileRequest) => void
+  isPending?: boolean
+  isError?: boolean
+  submitLabel?: string
+}
+
+interface FormState {
+  name: string
+  date_of_birth: string
+  weight_kg: string
+  goal_race: string
+  goal_race_date: string
+  threshold_pace_min_km: string
+  threshold_hr: string
+  max_hr: string
+  resting_hr: string
+  injury_history: string
+  weekly_availability: string
+  training_preferences: string
+}
+
+function toFormState(p?: AthleteProfile | null): FormState {
+  const s = (v: string | number | null | undefined) => (v === null || v === undefined ? '' : String(v))
+  return {
+    name: s(p?.name),
+    date_of_birth: s(p?.date_of_birth),
+    weight_kg: s(p?.weight_kg),
+    goal_race: s(p?.goal_race),
+    goal_race_date: s(p?.goal_race_date),
+    threshold_pace_min_km: s(p?.threshold_pace_min_km),
+    threshold_hr: s(p?.threshold_hr),
+    max_hr: s(p?.max_hr),
+    resting_hr: s(p?.resting_hr),
+    injury_history: s(p?.injury_history),
+    weekly_availability: s(p?.weekly_availability),
+    training_preferences: s(p?.training_preferences),
+  }
+}
+
+const text = (v: string) => (v.trim() === '' ? null : v.trim())
+const num = (v: string) => (v.trim() === '' ? null : Number(v))
+
+function toRequest(f: FormState): AthleteProfileRequest {
+  return {
+    name: text(f.name),
+    date_of_birth: text(f.date_of_birth),
+    weight_kg: num(f.weight_kg),
+    goal_race: text(f.goal_race),
+    goal_race_date: text(f.goal_race_date),
+    threshold_pace_min_km: num(f.threshold_pace_min_km),
+    threshold_hr: num(f.threshold_hr),
+    max_hr: num(f.max_hr),
+    resting_hr: num(f.resting_hr),
+    injury_history: text(f.injury_history),
+    weekly_availability: text(f.weekly_availability),
+    training_preferences: text(f.training_preferences),
+  }
+}
+
+export default function ProfileForm({ initial, onSubmit, isPending, isError, submitLabel = 'Save' }: ProfileFormProps) {
+  const [form, setForm] = useState<FormState>(() => toFormState(initial))
+
+  const set = (key: keyof FormState) => (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => setForm(prev => ({ ...prev, [key]: e.target.value }))
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit(toRequest(form))
+  }
+
+  return (
+    <form className="profile-form" onSubmit={handleSubmit}>
+      <div className="profile-form__field">
+        <label htmlFor="pf-name">Name</label>
+        <input id="pf-name" type="text" value={form.name} onChange={set('name')} />
+      </div>
+
+      <div className="profile-form__row">
+        <div className="profile-form__field">
+          <label htmlFor="pf-dob">Date of birth</label>
+          <input id="pf-dob" type="date" value={form.date_of_birth} onChange={set('date_of_birth')} />
+        </div>
+        <div className="profile-form__field">
+          <label htmlFor="pf-weight">Weight (kg)</label>
+          <input id="pf-weight" type="number" step="0.1" min="0" value={form.weight_kg} onChange={set('weight_kg')} />
+        </div>
+      </div>
+
+      <div className="profile-form__row">
+        <div className="profile-form__field">
+          <label htmlFor="pf-goal">Goal race</label>
+          <input id="pf-goal" type="text" placeholder="e.g. Berlin Marathon" value={form.goal_race} onChange={set('goal_race')} />
+        </div>
+        <div className="profile-form__field">
+          <label htmlFor="pf-goal-date">Goal race date</label>
+          <input id="pf-goal-date" type="date" value={form.goal_race_date} onChange={set('goal_race_date')} />
+        </div>
+      </div>
+
+      <div className="profile-form__row">
+        <div className="profile-form__field">
+          <label htmlFor="pf-pace">Threshold pace (min/km)</label>
+          <input id="pf-pace" type="number" step="0.01" min="0" value={form.threshold_pace_min_km} onChange={set('threshold_pace_min_km')} />
+        </div>
+        <div className="profile-form__field">
+          <label htmlFor="pf-thr-hr">Threshold HR (bpm)</label>
+          <input id="pf-thr-hr" type="number" min="0" value={form.threshold_hr} onChange={set('threshold_hr')} />
+        </div>
+      </div>
+
+      <div className="profile-form__row">
+        <div className="profile-form__field">
+          <label htmlFor="pf-max-hr">Max HR (bpm)</label>
+          <input id="pf-max-hr" type="number" min="0" value={form.max_hr} onChange={set('max_hr')} />
+        </div>
+        <div className="profile-form__field">
+          <label htmlFor="pf-rest-hr">Resting HR (bpm)</label>
+          <input id="pf-rest-hr" type="number" min="0" value={form.resting_hr} onChange={set('resting_hr')} />
+        </div>
+      </div>
+
+      <div className="profile-form__field">
+        <label htmlFor="pf-avail">Weekly availability</label>
+        <textarea id="pf-avail" rows={2} placeholder="e.g. 5 days/week, long run Sunday" value={form.weekly_availability} onChange={set('weekly_availability')} />
+      </div>
+
+      <div className="profile-form__field">
+        <label htmlFor="pf-prefs">Training preferences</label>
+        <textarea id="pf-prefs" rows={2} placeholder="e.g. prefer trails, 2 hard sessions/week" value={form.training_preferences} onChange={set('training_preferences')} />
+      </div>
+
+      <div className="profile-form__field">
+        <label htmlFor="pf-injury">Injury history</label>
+        <textarea id="pf-injury" rows={2} placeholder="e.g. left Achilles tendinopathy (2024)" value={form.injury_history} onChange={set('injury_history')} />
+      </div>
+
+      {isError && <span className="profile-form__error">Failed to save profile</span>}
+
+      <button className="profile-form__submit" type="submit" disabled={isPending}>
+        {isPending ? 'Saving…' : submitLabel}
+      </button>
+    </form>
+  )
+}

--- a/frontend/src/components/settings/AthleteProfileSection.tsx
+++ b/frontend/src/components/settings/AthleteProfileSection.tsx
@@ -1,0 +1,34 @@
+import { useAthleteProfile, useUpdateAthleteProfile } from '../../api/hooks'
+import type { AthleteProfileRequest } from '../../api/types'
+import ProfileForm from '../profile/ProfileForm'
+
+export default function AthleteProfileSection() {
+  const { data: profile, isLoading } = useAthleteProfile()
+  const updateProfile = useUpdateAthleteProfile()
+
+  if (isLoading) return null
+
+  const handleSubmit = (data: AthleteProfileRequest) => {
+    updateProfile.mutate(data)
+  }
+
+  return (
+    <section className="settings-section">
+      <h2 className="section-title">Athlete Profile</h2>
+      <div className="card">
+        <ProfileForm
+          initial={profile}
+          onSubmit={handleSubmit}
+          isPending={updateProfile.isPending}
+          isError={updateProfile.isError}
+          submitLabel="Save profile"
+        />
+        {updateProfile.isSuccess && !updateProfile.isPending && (
+          <span className="profile-form__error" style={{ color: 'var(--success)' }}>
+            Profile saved
+          </span>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/settings/SettingsView.tsx
+++ b/frontend/src/components/settings/SettingsView.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { useSettings, useTriggerSync, useAiConfig, useSetAiConfig } from '../../api/hooks'
+import AthleteProfileSection from './AthleteProfileSection'
 import './SettingsView.css'
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -70,6 +71,9 @@ export default function SettingsView() {
 
   return (
     <div className="settings-view">
+      {/* Athlete profile */}
+      <AthleteProfileSection />
+
       {/* AI backend selector */}
       <AiBackendSection />
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Development/test-only dependencies (not required at runtime).
+-r requirements.txt
+pytest==8.3.4

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,52 @@
+# P0-1 · Athlete Profile
+
+## Backend
+- [x] `app/models.py` — add `AthleteProfile` model
+- [x] `app/utils.py` — add `calculate_age(dob)` helper
+- [x] `app/schemas.py` — `AthleteProfileRequest` / `AthleteProfileResponse`
+- [x] `app/api.py` — GET/POST `/athlete-profile` (upsert)
+- [x] `app/ai_coach.py` — `_format_athlete_profile_context` + inject into `_build_context`
+
+## Frontend
+- [x] `api/types.ts` — `AthleteProfile` + `AthleteProfileRequest`
+- [x] `api/hooks.ts` — `useAthleteProfile` + `useUpdateAthleteProfile`
+- [x] `components/profile/ProfileForm.tsx` (+ css) — shared form
+- [x] `components/onboarding/OnboardingView.tsx` (+ css)
+- [x] `components/settings/AthleteProfileSection.tsx` wired into SettingsView
+- [x] `App.tsx` — `/onboarding` route, chrome-less, first-run redirect
+
+## Tests (backend pytest only)
+- [x] `requirements-dev.txt`, `tests/conftest.py`
+- [x] `tests/test_athlete_profile.py` (4 tests)
+- [x] `tests/test_ai_context.py` (2 tests)
+
+## Verification
+- [x] `pytest -q` → 6 passed
+- [x] `tsc --noEmit` clean + `npm run build` succeeds
+
+## Review
+
+Implemented P0-1 (Athlete Profile) end-to-end and only within scope.
+
+**Backend:** New singleton `AthleteProfile` table (auto-created by
+`Base.metadata.create_all`; no migration helper needed). `age` is derived from
+`date_of_birth` via a shared `calculate_age()` in `app/utils.py`, reused by both
+the API response and the AI context builder. `GET /api/v1/athlete-profile`
+returns `null` (200) when no profile exists so the frontend can detect first-run;
+`POST` upserts via `model_dump(exclude_unset=True)` so partial updates preserve
+existing fields. `_build_context` now inserts an `## Athlete Profile` section
+right after `## Current Data`, emitting only populated fields.
+
+**Frontend:** Shared `ProfileForm` powers both the dedicated chrome-less
+`/onboarding` route (with a Skip option) and an editable section in Settings.
+`App.tsx` redirects to `/onboarding` on first run when the profile is `null`.
+
+**Tests:** 6 backend pytest tests cover the null/create/update/partial API paths,
+computed age, and the AI-context injection (present + absent). All green.
+
+**Notes / out of scope:** Frontend Vitest harness left for P3-2 (per decision).
+A broken system `cryptography` rust binding (pulled in via `google.generativeai`)
+panicked on import in this container; fixed by `pip install --upgrade cryptography`
+— an environment fix, not a code change. The pre-existing Pydantic class-based
+`Config` deprecation warnings were left untouched to stay in scope.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app import models  # noqa: F401 - ensure models register on Base.metadata
+from app.api import api_router
+from app.database import Base, get_db
+
+
+@pytest.fixture
+def session_factory():
+    """In-memory SQLite shared across sessions via a single connection."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    yield sessionmaker(bind=engine)
+    engine.dispose()
+
+
+@pytest.fixture
+def db(session_factory):
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def client(session_factory):
+    app = FastAPI()
+    app.include_router(api_router)
+
+    def override_get_db():
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)

--- a/tests/test_ai_context.py
+++ b/tests/test_ai_context.py
@@ -1,0 +1,31 @@
+from datetime import date
+
+from app import ai_coach
+from app.models import AthleteProfile
+
+
+def test_context_includes_profile_section(db):
+    db.add(
+        AthleteProfile(
+            name="Sam Runner",
+            date_of_birth=date(1990, 6, 15),
+            goal_race="Berlin Marathon",
+            goal_race_date=date(2026, 9, 27),
+            max_hr=190,
+        )
+    )
+    db.commit()
+
+    context = ai_coach._build_context(db, "activity", "Test trigger data")
+    assert "## Athlete Profile" in context
+    assert "Sam Runner" in context
+    assert "Berlin Marathon" in context
+    # Age is derived from date_of_birth, not stored literally.
+    assert "- Age:" in context
+
+
+def test_context_omits_section_when_no_profile(db):
+    context = ai_coach._build_context(db, "activity", "Test trigger data")
+    assert "## Athlete Profile" not in context
+    # Still produces the baseline trigger section without crashing.
+    assert "## Current Data" in context

--- a/tests/test_athlete_profile.py
+++ b/tests/test_athlete_profile.py
@@ -1,0 +1,57 @@
+from datetime import date
+
+from app.models import AthleteProfile
+from app.utils import calculate_age
+
+
+def test_get_returns_null_when_absent(client):
+    resp = client.get("/api/v1/athlete-profile")
+    assert resp.status_code == 200
+    assert resp.json() is None
+
+
+def test_post_creates_profile_and_computes_age(client):
+    dob = "1990-06-15"
+    payload = {
+        "name": "Sam Runner",
+        "date_of_birth": dob,
+        "weight_kg": 68.5,
+        "goal_race": "Berlin Marathon",
+        "goal_race_date": "2026-09-27",
+        "threshold_hr": 168,
+        "max_hr": 190,
+        "resting_hr": 48,
+    }
+    resp = client.post("/api/v1/athlete-profile", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] >= 1
+    assert body["name"] == "Sam Runner"
+    assert body["age"] == calculate_age(date.fromisoformat(dob))
+
+    # GET round-trips the same data
+    fetched = client.get("/api/v1/athlete-profile").json()
+    assert fetched["goal_race"] == "Berlin Marathon"
+    assert fetched["age"] == body["age"]
+
+
+def test_second_post_updates_in_place(client, db):
+    client.post("/api/v1/athlete-profile", json={"name": "First", "max_hr": 185})
+    resp = client.post("/api/v1/athlete-profile", json={"name": "Second", "max_hr": 188})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Second"
+    # Singleton: exactly one row, not a duplicate insert.
+    assert db.query(AthleteProfile).count() == 1
+
+
+def test_partial_post_preserves_unspecified_fields(client):
+    client.post(
+        "/api/v1/athlete-profile",
+        json={"name": "Keep Me", "resting_hr": 50, "goal_race": "10K PB"},
+    )
+    # Update only one field; the others must remain.
+    client.post("/api/v1/athlete-profile", json={"resting_hr": 46})
+    body = client.get("/api/v1/athlete-profile").json()
+    assert body["resting_hr"] == 46
+    assert body["name"] == "Keep Me"
+    assert body["goal_race"] == "10K PB"


### PR DESCRIPTION
Add a singleton AthleteProfile (age via date_of_birth, weight, goal race,
thresholds, HR limits, injury history, availability, preferences) with
GET/POST API, a dedicated onboarding screen plus an editable Settings
section, and injection into the AI context builder so insights are
personalized. Includes backend pytest coverage.

https://claude.ai/code/session_01Fd2nFrW3MREx17jrScea3D