### PR TITLE
Add project-wide unit tests with coverage and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,4 +48,4 @@ jobs:
           path: |
             coverage.xml
             junit.xml
-          if-no-files-exist: ignore
+          if-no-files-found: ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,51 @@
+name: Tests
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests with coverage
+        env:
+          DB_PATH: ${{ runner.temp }}/test.db
+          GARMIN_TOKEN_DIR: ${{ runner.temp }}/garmin_tokens
+        run: |
+          pytest \
+            --cov=app \
+            --cov-report=term-missing \
+            --cov-report=xml \
+            --cov-fail-under=80 \
+            --junitxml=junit.xml
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            junit.xml
+          if-no-files-exist: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ build/
 *.swp
 *.swo
 .DS_Store
+
+# Test / coverage artifacts
+.pytest_cache/
+.coverage
+coverage.xml
+junit.xml
+htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 addopts = "-q"
 filterwarnings = [
     # The app targets Pydantic v2 but still uses class-based Config; silence the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+filterwarnings = [
+    # The app targets Pydantic v2 but still uses class-based Config; silence the
+    # deprecation noise so test output stays readable.
+    "ignore::DeprecationWarning",
+    "ignore::FutureWarning",
+]
+
+[tool.coverage.run]
+source = ["app"]
+branch = false
+omit = [
+    "app/templates/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+fail_under = 80
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 # Development/test-only dependencies (not required at runtime).
 -r requirements.txt
 pytest==8.3.4
+pytest-cov==6.0.0

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,19 @@
+# Lessons
+
+## CI: `pytest` vs `python -m pytest` and the `app` import
+
+**Symptom:** Tests passed locally with `python3 -m pytest` but CI failed at
+collection with `ModuleNotFoundError: No module named 'app'`.
+
+**Cause:** `python -m pytest` prepends the current directory to `sys.path`, so a
+top-level `app` package is importable. The bare `pytest` console script (what CI
+ran) does **not** add cwd to `sys.path`, so `from app import ...` in conftest failed.
+
+**Fix:** Add `pythonpath = ["."]` under `[tool.pytest.ini_options]`. pytest inserts
+this (relative to rootdir = the config file's dir) into `sys.path` regardless of how
+it's launched. Don't rely on the `-m` invocation form to make first-party packages
+importable.
+
+**Verify-as-CI tip:** Reproduce the bare-`pytest` path condition by running from a
+different cwd (e.g. `cd /tmp && pytest <repo>/tests`) rather than only
+`python -m pytest` from the repo root, which masks sys.path issues.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,63 +1,67 @@
-# P0-2 · Training Load model (CTL/ATL/TSB)
+# Project-wide unit tests + coverage CI
 
-Compute Fitness (CTL), Fatigue (ATL), Form (TSB) from per-activity TSS, surface a
-PMC-style chart on Today, and feed the current snapshot into the AI context.
+Add comprehensive unit tests across the whole backend and a GitHub Actions
+workflow that runs them with code coverage on every push to any branch.
 
-## Backend
-- [x] `app/training_load.py` (new) — per-activity TSS with estimation fallback
-      (power → pace-rTSS → hr-TSS → duration), daily EWMA series (CTL 42d, ATL 7d,
-      TSB = CTL − ATL), `current_load()`, and AI-context formatter.
-- [x] `app/schemas.py` — `TrainingLoadPoint`, `TrainingLoadResponse`; add
-      `training_load` snapshot to `TodayResponse`.
-- [x] `app/api.py` — `GET /training-load` trends endpoint; include current snapshot in `/today`.
-- [x] `app/ai_coach.py` — inject `## Training Load` section into `_build_context`
-      (+ a system-prompt line on reading CTL/ATL/TSB together).
+## Test suite (pytest)
+- [x] `tests/test_utils.py` — `calculate_age`, `safe_json_loads`, `parse_activity_charts`
+- [x] `tests/test_training_load.py` (existing) + edge cases for IF cap / HR fallback / `_interpret_tsb`
+- [x] `tests/test_api_helpers.py` — workout step parsing, distance/duration/pace formatters, `_parse_date`
+- [x] `tests/test_api_endpoints.py` — activities, daily-summaries, calendar, insights, settings, ai-config, sync, feedback, analyze
+- [x] `tests/test_ai_coach.py` — context formatters, summary/category extraction, provider dispatch (mocked), analyze flows (mocked)
+- [x] `tests/test_garmin_sync.py` — field extraction, timestamp/date/priority parsing, calendar response parsing, sync-status, `_store_activity` (mocked client)
+- [x] `tests/test_routes.py` — Jinja template filters + HTML endpoints
+- [x] `tests/test_main.py` — scheduled job wrappers (mocked sync/AI)
+- [x] `tests/test_database.py` — `get_db`/`db_session` generators, `init_db`/seed idempotency
 
-## Frontend
-- [x] `frontend/src/api/types.ts` — TrainingLoad types + `training_load` on TodayResponse.
-- [x] `frontend/src/api/hooks.ts` — `useTrainingLoad`.
-- [x] `frontend/src/components/today/TrainingLoadChart.tsx` (+ css) — Recharts PMC chart.
-- [x] `frontend/src/components/today/TodayView.tsx` — render the chart section.
+## Config
+- [x] `pyproject.toml` — pytest + coverage config (`--cov=app`, fail-under threshold)
+- [x] `requirements-dev.txt` — add `pytest-cov`
 
-## Tests
-- [x] `tests/test_training_load.py` — TSS estimation, EWMA series, current snapshot,
-      AI-context injection, `/training-load` + `/today` endpoints (12 tests).
+## CI
+- [x] `.github/workflows/tests.yml` — run on push to any branch; install deps, run pytest with coverage, upload report
 
 ## Verification
-- [x] `pytest -q` → 20 passed (12 new + 8 pre-existing)
-- [x] `tsc --noEmit` clean + `npm run build` succeeds
+- [x] `pytest --cov=app` passes locally with high coverage
 
 ## Review
 
-Implemented P0-2 (Training Load model, CTL/ATL/TSB) end-to-end and within scope.
+Added a project-wide pytest suite and a CI workflow that runs it with code
+coverage on every push to any branch.
 
-**Backend:** New `app/training_load.py` derives per-activity TSS, preferring the
-stored power `training_stress_score` and falling back through pace-based rTSS →
-HR-based hrTSS → a duration-only floor so non-power runs still contribute. It
-builds a daily EWMA series (CTL = 42-day, ATL = 7-day, both via the
-`alpha = 1 − exp(−1/N)` impulse-response form TrainingPeaks uses) seeded from the
-first activity, with TSB = CTL − ATL. `current_load()` returns the latest snapshot;
-`compute_load_series()` returns the trailing window. The estimators use the
-`AthleteProfile` thresholds from P0-1 (with `max_hr × 0.9` as a threshold-HR
-fallback). `_build_context` inserts a `## Training Load` section (Fitness/Fatigue/
-Form + a plain-language form reading) right after the profile, and a system-prompt
-line teaches the coach to read the three series together.
+**Tests (237 total, up from 20).** New files cover the whole backend:
+- `test_utils.py` — age math, JSON guard, activity chart parsing (pace/cadence conversions).
+- `test_api_helpers.py` — workout-step parsing, distance/duration/pace formatters, date parsing.
+- `test_api_endpoints.py` — every API route (activities, daily summaries, calendar
+  month/week, insights, settings, ai-config, athlete-profile, analyze/feedback/sync),
+  including 404 and validation paths. Background-job targets are stubbed so action
+  handlers don't spawn real work.
+- `test_ai_coach.py` — context formatters, summary/category extraction, provider
+  dispatch (Claude/Gemini mocked), and the analyze/force/feedback/weekly flows with
+  the AI call and `db_session` redirected to the in-memory DB.
+- `test_garmin_sync.py` — field/timestamp/date/priority/calendar parsing, sync-status
+  helpers, `_store_activity`, and the `sync_*` / `backfill_*` orchestrators with a
+  mocked Garmin client.
+- `test_routes.py` — Jinja filters and every HTML page/redirect.
+- `test_main.py` — scheduled-job wrappers and the SPA catch-all guard.
+- `test_database.py` — session generator/context-manager lifecycle and seed idempotency.
+- `test_training_load_edge.py` — TSB interpretation bands, IF cap, HR-threshold fallback.
 
-**API:** `GET /training-load?days=&date=` returns points + current; `/today` now
-carries a `training_load` snapshot computed as of the selected date.
+**Coverage: 89%** overall (`app/` only; templates omitted). Per-module: utils/models/
+config 100%, schemas 99%, training_load 99%, api 95%, routes 93%, database 89%,
+ai_coach 87%, garmin_sync 78%, main 70% (the async lifespan/scheduler is integration-
+level and left uncovered).
 
-**Frontend:** `TrainingLoadChart` (Recharts `ComposedChart`) shows a 90-day PMC —
-CTL area, ATL line, TSB line on a secondary axis with a zero reference — plus three
-headline stat tiles and a colour-coded Form badge. Rendered on Today only when a
-snapshot exists; the headline uses the `/today` snapshot while the chart pulls the
-series from the dedicated endpoint.
+**Config.** `pyproject.toml` sets pytest `testpaths`, silences the pre-existing
+Pydantic/genai deprecation noise, and configures coverage (source=`app`, templates
+omitted, `fail_under=80`). `pytest-cov` added to `requirements-dev.txt`.
 
-**Tests:** 12 new pytest tests cover TSS estimation (all four sources + zero-
-duration), EWMA seeding, window capping, fatigue decay on rest, AI-context
-injection (present/absent), and both endpoints. Full suite: 20 passed.
+**CI.** `.github/workflows/tests.yml` runs on push to any branch (plus PRs and manual
+dispatch): sets up Python 3.11 with pip caching, installs `requirements-dev.txt`, runs
+`pytest` with coverage and `--cov-fail-under=80`, and uploads the coverage/junit XML as
+an artifact. `DB_PATH`/`GARMIN_TOKEN_DIR` are pointed at the runner temp dir so the
+real engine initialises without needing `/data`.
 
-**Notes / out of scope:** Chose a same-day `TSB = CTL − ATL` (matching the plan's
-stated definition) over TrainingPeaks' yesterday-based variant — simpler and within
-the doc. No `DailyLoad` cache table: the series recomputes cheaply for a single user.
-The pre-existing Pydantic `Config` deprecation warnings and the bundle-size warning
-(recharts) were left untouched to stay in scope.
+**Notes.** Tests mock all external I/O (Garmin, Anthropic, Gemini) — no network or
+credentials needed. The conftest gained a `routes_client` fixture and a
+`patch_db_session` helper that redirects background-job `db_session()` onto the test DB.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,3 +46,46 @@ def client(session_factory):
 
     app.dependency_overrides[get_db] = override_get_db
     return TestClient(app)
+
+
+@pytest.fixture
+def routes_client(session_factory):
+    """TestClient wired to the legacy Jinja HTML routes."""
+    from app.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    def override_get_db():
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+@pytest.fixture
+def patch_db_session(session_factory, monkeypatch):
+    """Return a helper that points a module's ``db_session`` at the test DB.
+
+    Background-job code uses the ``db_session()`` context manager (bound to the
+    real engine) rather than FastAPI's injected session. Tests call this to
+    redirect that context manager onto the in-memory test database.
+    """
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_db_session():
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def _apply(module):
+        monkeypatch.setattr(module, "db_session", _fake_db_session)
+
+    return _apply

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -1,0 +1,441 @@
+import json
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from app import ai_coach
+from app.models import (
+    Activity,
+    AthleteProfile,
+    DailySummary,
+    GarminCalendarEvent,
+    Insight,
+    MetricZone,
+    SyncStatus,
+)
+
+
+# --- _classify_metric ---
+
+def _cadence_zones():
+    return [
+        MetricZone(metric_key="cadence", zone_name="excellent", zone_color="#ff69b4",
+                   percentile_label=">95%", min_value=185, max_value=None),
+        MetricZone(metric_key="cadence", zone_name="average", zone_color="#2ecc71",
+                   percentile_label="30-69%", min_value=163, max_value=173),
+        MetricZone(metric_key="cadence", zone_name="poor", zone_color="#e74c3c",
+                   percentile_label="<5%", min_value=None, max_value=151),
+    ]
+
+
+def test_classify_metric_bounded_zone():
+    out = ai_coach._classify_metric(168, _cadence_zones())
+    assert "Average zone" in out
+    assert "30-69%" in out
+
+
+def test_classify_metric_unbounded_max():
+    out = ai_coach._classify_metric(200, _cadence_zones())
+    assert "Excellent zone" in out
+
+
+def test_classify_metric_no_match_returns_empty():
+    # 160 falls between the poor (<151) and average (163-173) bands defined here.
+    assert ai_coach._classify_metric(160, _cadence_zones()) == ""
+
+
+# --- _format_activity_context ---
+
+def test_format_activity_context_core_fields():
+    act = Activity(
+        name="Tempo Run",
+        activity_type="running",
+        started_at=datetime(2026, 6, 10, 7, 30),
+        distance_m=10000,
+        duration_sec=2700,
+        avg_pace_min_km=4.5,
+        avg_hr=155,
+        max_hr=172,
+    )
+    text = ai_coach._format_activity_context(act)
+    assert "**Tempo Run** (running)" in text
+    assert "Distance: 10.00 km" in text
+    assert "Duration: 45:00" in text
+    assert "Avg Pace: 4:30 /km" in text
+    assert "Avg HR: 155 bpm" in text
+
+
+def test_format_activity_context_with_zone_classification():
+    act = Activity(name="Run", activity_type="running", avg_cadence=200)
+    zones = {"cadence": _cadence_zones()}
+    text = ai_coach._format_activity_context(act, zones)
+    assert "Cadence: 200 spm" in text
+    assert "Excellent zone" in text
+
+
+def test_format_activity_context_power_zones_json():
+    act = Activity(
+        name="Run", activity_type="running",
+        power_zones_json=json.dumps([{"zoneNumber": 2, "secsInZone": 600}]),
+    )
+    text = ai_coach._format_activity_context(act)
+    assert "Power Zones: PZ2: 10m" in text
+
+
+def test_format_activity_context_handles_missing_start():
+    act = Activity(name="Run", activity_type="running", started_at=None)
+    text = ai_coach._format_activity_context(act)
+    assert "Date: unknown" in text
+
+
+def test_format_activity_context_rich_fields():
+    act = Activity(
+        name="Long Run", activity_type="running",
+        started_at=datetime(2026, 6, 10, 7, 0),
+        distance_m=21000, duration_sec=7200, avg_pace_min_km=5.0,
+        avg_hr=150, max_hr=175, min_hr=110,
+        avg_cadence=180, avg_stride=1.2,
+        elevation_gain=200, elevation_loss=180,
+        training_effect_aerobic=3.5, training_effect_anaerobic=1.2, vo2max=52,
+        calories=1400,
+        avg_ground_contact_time=240, avg_vertical_oscillation=8.0, avg_vertical_ratio=7.0,
+        normalized_power=280, training_stress_score=120, intensity_factor=0.85,
+        avg_respiration_rate=35, max_respiration_rate=48,
+        avg_speed=3.3, max_speed=4.5,
+        max_elevation=300, min_elevation=100, max_cadence=190,
+        run_time_sec=6000, walk_time_sec=600,
+        hr_zones_json=json.dumps([{"zoneNumber": 2, "secsInZone": 1200}]),
+        splits_json=json.dumps({"lapDTOs": [
+            {"distance": 1000, "duration": 300, "averageHR": 150},
+        ]}),
+        laps_json=json.dumps({"metricDescriptors": [{"key": "directHeartRate"}]}),
+    )
+    text = ai_coach._format_activity_context(act)
+    assert "VO2max: 52.0" in text
+    assert "Ground Contact Time: 240 ms" in text
+    assert "Normalized Power: 280 W" in text
+    assert "Avg Respiration: 35.0 br/min" in text
+    assert "Avg Speed:" in text
+    assert "Min HR: 110 bpm" in text
+    assert "Run/Walk:" in text
+    assert "HR Zones: Z2: 20m" in text
+    assert "Split details:" in text
+    assert "(Detailed lap/metric data available)" in text
+
+
+# --- _format_daily_context ---
+
+def test_format_daily_context():
+    summary = DailySummary(
+        date=date(2026, 6, 10), steps=12000, resting_hr=47,
+        sleep_seconds=27000, sleep_score=85, stress_avg=30,
+        body_battery_high=95, body_battery_low=20, total_calories=2500,
+        intensity_minutes=45,
+    )
+    text = ai_coach._format_daily_context(summary)
+    assert "Daily Summary for 2026-06-10" in text
+    assert "Steps: 12,000" in text
+    assert "Sleep: 7h 30m" in text
+    assert "Body Battery: 20-95" in text
+
+
+# --- _format_athlete_profile_context ---
+
+def test_format_profile_context_emits_set_fields():
+    profile = AthleteProfile(
+        name="Sam", date_of_birth=date(1990, 6, 15),
+        goal_race="Berlin", goal_race_date=date(2026, 9, 27),
+        threshold_pace_min_km=4.0, threshold_hr=168, max_hr=190,
+    )
+    text = ai_coach._format_athlete_profile_context(profile, reference_date=date(2026, 6, 17))
+    assert "## Athlete Profile" in text
+    assert "- Name: Sam" in text
+    assert "- Age: 36" in text
+    assert "Goal Race: Berlin on 2026-09-27 (102 days away)" in text
+    assert "- Threshold Pace: 4:00/km" in text
+
+
+def test_format_profile_context_empty_returns_blank():
+    assert ai_coach._format_athlete_profile_context(AthleteProfile()) == ""
+
+
+def test_format_profile_context_goal_date_only():
+    profile = AthleteProfile(goal_race_date=date(2026, 7, 1))
+    text = ai_coach._format_athlete_profile_context(profile, reference_date=date(2026, 6, 17))
+    assert "Goal Race Date: 2026-07-01 (14 days away)" in text
+
+
+# --- _extract_summary_and_category ---
+
+def test_extract_summary_from_marker():
+    content = "Intro line\n**Summary:** Strong tempo effort\nMore text"
+    summary, category = ai_coach._extract_summary_and_category(content, "activity")
+    assert summary == "Strong tempo effort"
+    assert category == "workout_analysis"
+
+
+def test_extract_summary_fallback_first_line():
+    content = "Just the first line here\nSecond line"
+    summary, category = ai_coach._extract_summary_and_category(content, "daily_summary")
+    assert summary == "Just the first line here"
+    assert category == "recovery"
+
+
+def test_extract_category_default_for_unknown_trigger():
+    _, category = ai_coach._extract_summary_and_category("x", "something_else")
+    assert category == "recommendation"
+
+
+# --- _get_ai_config / _call_ai dispatch ---
+
+def test_get_ai_config_defaults(db):
+    provider, model = ai_coach._get_ai_config(db)
+    assert provider == "claude"
+    assert model  # falls back to settings.ai_model
+
+
+def test_get_ai_config_from_db(db):
+    db.add(SyncStatus(key="ai_provider", value="gemini"))
+    db.add(SyncStatus(key="ai_model", value="gemini-2.5-flash"))
+    db.commit()
+    provider, model = ai_coach._get_ai_config(db)
+    assert provider == "gemini"
+    assert model == "gemini-2.5-flash"
+
+
+def test_call_ai_dispatches_to_claude(db, monkeypatch):
+    called = {}
+
+    def fake_claude(context, trigger_type, model):
+        called["claude"] = (context, trigger_type, model)
+        return ("content", "summary", "category")
+
+    monkeypatch.setattr(ai_coach, "_call_claude", fake_claude)
+    result = ai_coach._call_ai(db, "ctx", "activity")
+    assert result == ("content", "summary", "category")
+    assert "claude" in called
+
+
+def test_call_ai_dispatches_to_gemini(db, monkeypatch):
+    db.add(SyncStatus(key="ai_provider", value="gemini"))
+    db.add(SyncStatus(key="ai_model", value="gemini-2.5-flash"))
+    db.commit()
+    monkeypatch.setattr(ai_coach, "_call_gemini", lambda c, t, m: ("g", "gs", "gc"))
+    assert ai_coach._call_ai(db, "ctx", "activity") == ("g", "gs", "gc")
+
+
+def test_call_claude_uses_anthropic(monkeypatch):
+    fake_msg = MagicMock()
+    fake_msg.content = [MagicMock(text="**Summary:** ok\nbody")]
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = fake_msg
+    monkeypatch.setattr(ai_coach.anthropic, "Anthropic", lambda *a, **k: fake_client)
+
+    content, summary, category = ai_coach._call_claude("ctx", "activity", "claude-x")
+    assert summary == "ok"
+    assert category == "workout_analysis"
+    fake_client.messages.create.assert_called_once()
+
+
+def test_call_gemini_uses_genai(monkeypatch):
+    fake_model = MagicMock()
+    fake_model.generate_content.return_value = MagicMock(text="**Summary:** good\nrest")
+    monkeypatch.setattr(ai_coach.genai, "configure", lambda **k: None)
+    monkeypatch.setattr(ai_coach.genai, "GenerativeModel", lambda **k: fake_model)
+
+    content, summary, category = ai_coach._call_gemini("ctx", "daily_summary", "gemini-x")
+    assert summary == "good"
+    assert category == "recovery"
+
+
+# --- analyze flows (DB redirected, AI mocked) ---
+
+@pytest.fixture
+def stub_ai(monkeypatch):
+    monkeypatch.setattr(
+        ai_coach, "_call_ai",
+        lambda db, ctx, trigger: ("**Summary:** mocked\nDetailed analysis", "mocked", "workout_analysis"),
+    )
+
+
+def test_analyze_activity_creates_insight(db, patch_db_session, stub_ai):
+    patch_db_session(ai_coach)
+    act = Activity(garmin_id=1, name="Run", activity_type="running",
+                   started_at=datetime(2026, 6, 10, 7, 0), duration_sec=3600, distance_m=10000)
+    db.add(act)
+    db.commit()
+    db.refresh(act)
+
+    ai_coach.analyze_activity(act)
+
+    insight = db.query(Insight).filter(Insight.trigger_id == act.id).first()
+    assert insight is not None
+    assert insight.summary == "mocked"
+    db.expire_all()
+    assert db.get(Activity, act.id).ai_analyzed is True
+
+
+def test_analyze_activity_force_replaces_existing(db, patch_db_session, stub_ai):
+    patch_db_session(ai_coach)
+    act = Activity(garmin_id=2, name="Run", activity_type="running",
+                   started_at=datetime(2026, 6, 10, 7, 0), duration_sec=3600)
+    db.add(act)
+    db.commit()
+    db.refresh(act)
+    db.add(Insight(trigger_type="activity", trigger_id=act.id, content="stale", summary="stale"))
+    db.commit()
+
+    ai_coach.analyze_activity_force(act.id)
+
+    insights = db.query(Insight).filter(Insight.trigger_id == act.id).all()
+    assert len(insights) == 1
+    assert insights[0].summary == "mocked"
+
+
+def test_analyze_activity_force_missing_activity_noop(db, patch_db_session, stub_ai):
+    patch_db_session(ai_coach)
+    ai_coach.analyze_activity_force(999)
+    assert db.query(Insight).count() == 0
+
+
+def test_analyze_activity_with_feedback_appends_feedback(db, patch_db_session, monkeypatch):
+    captured = {}
+
+    def fake_call(db_, ctx, trigger):
+        captured["ctx"] = ctx
+        return ("**Summary:** fb\nbody", "fb", "workout_analysis")
+
+    monkeypatch.setattr(ai_coach, "_call_ai", fake_call)
+    patch_db_session(ai_coach)
+
+    act = Activity(garmin_id=3, name="Run", activity_type="running",
+                   started_at=datetime(2026, 6, 10, 7, 0), duration_sec=3600,
+                   feedback_rating="bad", feedback_tags=json.dumps(["tough_pace"]),
+                   feedback_text="legs heavy")
+    db.add(act)
+    db.commit()
+    db.refresh(act)
+
+    ai_coach.analyze_activity_with_feedback(act.id)
+
+    assert "## User Feedback" in captured["ctx"]
+    assert "tough_pace" in captured["ctx"]
+    assert "legs heavy" in captured["ctx"]
+    assert db.query(Insight).filter(Insight.trigger_id == act.id).count() == 1
+
+
+def test_analyze_daily_summary_creates_insight(db, patch_db_session, stub_ai):
+    patch_db_session(ai_coach)
+    summary = DailySummary(date=date(2026, 6, 10), steps=10000)
+    db.add(summary)
+    db.commit()
+    db.refresh(summary)
+
+    ai_coach.analyze_daily_summary(summary)
+
+    insight = db.query(Insight).filter(Insight.trigger_type == "daily_summary").first()
+    assert insight is not None
+    db.expire_all()
+    assert db.get(DailySummary, summary.id).ai_analyzed is True
+
+
+def test_save_error_insight(db, patch_db_session):
+    patch_db_session(ai_coach)
+    act = Activity(garmin_id=4, name="Run", activity_type="running",
+                   started_at=datetime(2026, 6, 10, 7, 0))
+    db.add(act)
+    db.commit()
+    db.refresh(act)
+
+    ai_coach._save_error_insight(act.id, RuntimeError("boom"))
+
+    insight = db.query(Insight).filter(Insight.trigger_id == act.id).first()
+    assert insight is not None
+    assert "Analysis failed" in insight.content
+
+
+def test_analyze_activity_force_saves_error_on_failure(db, patch_db_session, monkeypatch):
+    patch_db_session(ai_coach)
+
+    def boom(*a, **k):
+        raise RuntimeError("ai down")
+
+    monkeypatch.setattr(ai_coach, "_call_ai", boom)
+    act = Activity(garmin_id=5, name="Run", activity_type="running",
+                   started_at=datetime(2026, 6, 10, 7, 0), duration_sec=3600)
+    db.add(act)
+    db.commit()
+    db.refresh(act)
+
+    ai_coach.analyze_activity_force(act.id)
+
+    insight = db.query(Insight).filter(Insight.trigger_id == act.id).first()
+    assert insight is not None
+    assert "Analysis failed" in insight.content
+
+
+def test_build_context_full_sections(db):
+    ref = date(2026, 6, 17)
+    # Recent activity within 14 days of the reference date.
+    db.add(Activity(
+        garmin_id=1, name="Easy Run", activity_type="running",
+        started_at=datetime(2026, 6, 16, 7, 0), distance_m=8000,
+        duration_sec=2400, avg_hr=145, avg_pace_min_km=5.0,
+    ))
+    # Recovery day.
+    db.add(DailySummary(
+        date=date(2026, 6, 16), sleep_seconds=27000, resting_hr=48,
+        body_battery_high=95, body_battery_low=25, stress_avg=30,
+    ))
+    # Upcoming race.
+    db.add(GarminCalendarEvent(
+        garmin_id="r1", event_type="race", date=date(2026, 9, 27),
+        title="Marathon", distance_label="Marathon", goal_time_sec=12600, priority="A",
+    ))
+    # A prior insight to avoid repeating.
+    db.add(Insight(trigger_type="activity", trigger_id=1, content="x",
+                   summary="Solid aerobic base", category="workout_analysis"))
+    db.commit()
+
+    context = ai_coach._build_context(db, "activity", "Trigger data", reference_date=ref)
+    assert "## Current Data" in context
+    assert "## Recent Activities (14 days)" in context
+    assert "Easy Run" in context
+    assert "## Weekly Volume (last 8 weeks)" in context
+    assert "## Recent Recovery (7 days)" in context
+    assert "## Upcoming Races" in context
+    assert "Marathon" in context
+    assert "## Recent Insights (avoid repeating these)" in context
+    assert "Solid aerobic base" in context
+
+
+def test_weekly_review_generates_insight(db, patch_db_session, monkeypatch):
+    patch_db_session(ai_coach)
+    monkeypatch.setattr(
+        ai_coach, "_call_ai",
+        lambda d, c, t: ("**Summary:** week done\nbody", "week done", "training_plan"),
+    )
+    # An activity within the last 7 days of today() so weekly_review picks it up.
+    from datetime import timedelta
+    db.add(Activity(
+        garmin_id=1, name="Run", activity_type="running",
+        started_at=datetime.combine(date.today() - timedelta(days=2), datetime.min.time()),
+        duration_sec=3600, distance_m=10000,
+    ))
+    db.commit()
+
+    ai_coach.weekly_review()
+
+    insight = db.query(Insight).filter(Insight.trigger_type == "weekly_review").first()
+    assert insight is not None
+    assert insight.category == "training_plan"
+
+
+def test_weekly_review_no_activities_skips(db, patch_db_session, monkeypatch):
+    patch_db_session(ai_coach)
+    called = MagicMock()
+    monkeypatch.setattr(ai_coach, "_call_ai", called)
+    ai_coach.weekly_review()
+    called.assert_not_called()
+    assert db.query(Insight).count() == 0

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,296 @@
+import json
+from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models import (
+    Activity,
+    DailySummary,
+    GarminCalendarEvent,
+    Insight,
+    SyncStatus,
+)
+
+
+# --- Fixtures / helpers ---
+
+def _add_activity(db, started_at, **kw):
+    defaults = dict(
+        garmin_id=int(started_at.timestamp()),
+        activity_type="running",
+        name="Morning Run",
+        started_at=started_at,
+        duration_sec=3600,
+        distance_m=10000,
+    )
+    defaults.update(kw)
+    act = Activity(**defaults)
+    db.add(act)
+    db.commit()
+    db.refresh(act)
+    return act
+
+
+# --- /activities ---
+
+def test_list_activities_pagination_and_filter(client, db):
+    base = datetime(2026, 6, 1, 7, 0)
+    for i in range(3):
+        _add_activity(db, base + timedelta(days=i))
+    _add_activity(db, base + timedelta(days=4), activity_type="cycling", name="Ride")
+
+    all_resp = client.get("/api/v1/activities")
+    assert all_resp.status_code == 200
+    assert len(all_resp.json()) == 4
+
+    running = client.get("/api/v1/activities?type=running")
+    assert len(running.json()) == 3
+
+    page2 = client.get("/api/v1/activities?page=2&limit=2")
+    assert len(page2.json()) == 2
+
+
+def test_activity_detail_includes_parsed_json(client, db):
+    act = _add_activity(
+        db,
+        datetime(2026, 6, 1, 7, 0),
+        splits_json=json.dumps([{"distance": 1000}]),
+        hr_zones_json=json.dumps([{"zoneNumber": 1, "secsInZone": 60}]),
+        feedback_tags=json.dumps(["sore_legs"]),
+    )
+    resp = client.get(f"/api/v1/activities/{act.id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["splits"] == [{"distance": 1000}]
+    assert body["feedback_tags"] == ["sore_legs"]
+
+
+def test_activity_detail_404(client):
+    assert client.get("/api/v1/activities/999").status_code == 404
+
+
+def test_activity_detail_links_scheduled_workout(client, db):
+    act = _add_activity(db, datetime(2026, 6, 1, 7, 0))
+    db.add(GarminCalendarEvent(
+        garmin_id="w1",
+        event_type="workout",
+        date=date(2026, 6, 1),
+        title="Tempo",
+        raw_json=json.dumps({"workoutSteps": [{"stepType": "warmup", "endCondition": "lap.button"}]}),
+    ))
+    db.commit()
+    body = client.get(f"/api/v1/activities/{act.id}").json()
+    assert body["scheduled_workout"] is not None
+    assert body["scheduled_workout"]["title"] == "Tempo"
+
+
+# --- /daily-summaries ---
+
+def test_daily_summaries_list_and_detail(client, db):
+    s = DailySummary(date=date(2026, 6, 1), steps=10000, resting_hr=48)
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+
+    listed = client.get("/api/v1/daily-summaries")
+    assert listed.status_code == 200
+    assert listed.json()[0]["steps"] == 10000
+
+    detail = client.get(f"/api/v1/daily-summaries/{s.id}")
+    assert detail.status_code == 200
+    assert detail.json()["summary"]["resting_hr"] == 48
+
+
+def test_daily_summary_detail_404(client):
+    assert client.get("/api/v1/daily-summaries/123").status_code == 404
+
+
+def test_daily_detail_includes_day_activities(client, db):
+    s = DailySummary(date=date(2026, 6, 1))
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    _add_activity(db, datetime(2026, 6, 1, 8, 0))
+    body = client.get(f"/api/v1/daily-summaries/{s.id}").json()
+    assert len(body["activities"]) == 1
+
+
+# --- /calendar ---
+
+def test_calendar_month(client, db):
+    _add_activity(db, datetime(2026, 6, 10, 7, 0))
+    db.add(GarminCalendarEvent(
+        garmin_id="r1", event_type="race", date=date(2026, 6, 20), title="10K",
+    ))
+    db.commit()
+    resp = client.get("/api/v1/calendar?month=2026-06")
+    assert resp.status_code == 200
+    days = resp.json()
+    assert len(days) == 30  # June has 30 days
+    by_date = {d["date"]: d for d in days}
+    assert len(by_date["2026-06-10"]["activities"]) == 1
+    assert len(by_date["2026-06-20"]["events"]) == 1
+
+
+def test_calendar_month_invalid_falls_back(client):
+    # Bad month string -> current month, still 200.
+    assert client.get("/api/v1/calendar?month=garbage").status_code == 200
+
+
+def test_calendar_week(client, db):
+    # 2026-06-17 is a Wednesday; week starts Monday 2026-06-15.
+    _add_activity(db, datetime(2026, 6, 16, 7, 0))
+    resp = client.get("/api/v1/calendar/week?date=2026-06-17")
+    assert resp.status_code == 200
+    days = resp.json()
+    assert len(days) == 7
+    assert days[0]["date"] == "2026-06-15"
+    assert len(days[1]["activities"]) == 1
+
+
+# --- /calendar-events/{id} ---
+
+def test_calendar_event_detail(client, db):
+    e = GarminCalendarEvent(
+        garmin_id="w1", event_type="workout", date=date(2026, 6, 17), title="Easy",
+        raw_json=json.dumps({"workoutSteps": [{"stepType": "interval", "endCondition": "lap.button"}]}),
+    )
+    db.add(e)
+    db.commit()
+    db.refresh(e)
+    resp = client.get(f"/api/v1/calendar-events/{e.id}")
+    assert resp.status_code == 200
+    assert resp.json()["workout_steps"]
+
+
+def test_calendar_event_detail_404(client):
+    assert client.get("/api/v1/calendar-events/77").status_code == 404
+
+
+# --- /insights ---
+
+def test_insights_list_and_filter(client, db):
+    db.add(Insight(trigger_type="activity", content="a", summary="A", category="workout_analysis"))
+    db.add(Insight(trigger_type="daily_summary", content="b", summary="B", category="recovery"))
+    db.commit()
+    assert len(client.get("/api/v1/insights").json()) == 2
+    recovery = client.get("/api/v1/insights?category=recovery").json()
+    assert len(recovery) == 1
+    assert recovery[0]["category"] == "recovery"
+
+
+# --- /settings ---
+
+def test_settings_counts_and_statuses(client, db):
+    _add_activity(db, datetime(2026, 6, 1, 7, 0))
+    db.add(SyncStatus(key="last_activity_sync", value="2026-06-01T00:00:00"))
+    db.commit()
+    body = client.get("/api/v1/settings").json()
+    assert body["counts"]["activities"] == 1
+    assert "last_activity_sync" in body["sync_statuses"]
+
+
+# --- /ai-config ---
+
+def test_ai_config_defaults(client):
+    body = client.get("/api/v1/ai-config").json()
+    assert body["provider"] == "claude"
+    assert "claude" in body["available_providers"]
+    assert "gemini" in body["available_models"]
+
+
+def test_ai_config_set_valid(client, db):
+    resp = client.post("/api/v1/ai-config", json={"provider": "gemini", "model": "gemini-2.5-flash"})
+    assert resp.status_code == 200
+    assert resp.json()["provider"] == "gemini"
+    # Persisted: a subsequent GET reflects it.
+    assert client.get("/api/v1/ai-config").json()["model"] == "gemini-2.5-flash"
+
+
+def test_ai_config_set_updates_existing(client):
+    client.post("/api/v1/ai-config", json={"provider": "claude", "model": "claude-sonnet-4-6"})
+    client.post("/api/v1/ai-config", json={"provider": "claude", "model": "claude-opus-4-7"})
+    assert client.get("/api/v1/ai-config").json()["model"] == "claude-opus-4-7"
+
+
+def test_ai_config_unknown_provider(client):
+    resp = client.post("/api/v1/ai-config", json={"provider": "openai", "model": "gpt"})
+    assert resp.status_code == 400
+
+
+def test_ai_config_invalid_model(client):
+    resp = client.post("/api/v1/ai-config", json={"provider": "claude", "model": "not-a-model"})
+    assert resp.status_code == 400
+
+
+# --- Actions: analyze / feedback / sync (threads mocked) ---
+
+@pytest.fixture
+def no_threads(monkeypatch):
+    """Stub the background job targets the action handlers spawn.
+
+    Handlers import these lazily (``from app.x import y``) then run them in a
+    daemon thread, so replacing the module attribute makes the spawned thread a
+    harmless no-op without touching the real ``threading`` module.
+    """
+    import app.ai_coach as ai_coach
+    import app.main as main_module
+    import app.garmin_sync as garmin_sync
+
+    monkeypatch.setattr(ai_coach, "analyze_activity_force", MagicMock())
+    monkeypatch.setattr(ai_coach, "analyze_activity_with_feedback", MagicMock())
+    monkeypatch.setattr(main_module, "_scheduled_activity_sync", MagicMock())
+    monkeypatch.setattr(main_module, "_scheduled_daily_sync", MagicMock())
+    monkeypatch.setattr(garmin_sync, "sync_calendar", MagicMock())
+
+
+def test_trigger_analysis_accepted(client, db, no_threads):
+    act = _add_activity(db, datetime(2026, 6, 1, 7, 0))
+    resp = client.post(f"/api/v1/activities/{act.id}/analyze")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "accepted"
+
+
+def test_trigger_analysis_404(client, no_threads):
+    assert client.post("/api/v1/activities/999/analyze").status_code == 404
+
+
+def test_submit_feedback(client, db, no_threads):
+    act = _add_activity(db, datetime(2026, 6, 1, 7, 0))
+    db.add(Insight(trigger_type="activity", trigger_id=act.id, content="old", summary="old"))
+    db.commit()
+    resp = client.post(
+        f"/api/v1/activities/{act.id}/feedback",
+        json={"rating": "bad", "tags": ["tough_pace"], "text": "legs heavy"},
+    )
+    assert resp.status_code == 200
+    db.expire_all()
+    refreshed = db.get(Activity, act.id)
+    assert refreshed.feedback_rating == "bad"
+    assert json.loads(refreshed.feedback_tags) == ["tough_pace"]
+    assert refreshed.ai_analyzed is False
+    # Existing insight was cleared.
+    assert db.query(Insight).filter(Insight.trigger_id == act.id).count() == 0
+
+
+def test_submit_feedback_404(client, no_threads):
+    resp = client.post("/api/v1/activities/999/feedback", json={"rating": "good"})
+    assert resp.status_code == 404
+
+
+def test_feedback_rejects_invalid_rating(client, db, no_threads):
+    act = _add_activity(db, datetime(2026, 6, 1, 7, 0))
+    resp = client.post(f"/api/v1/activities/{act.id}/feedback", json={"rating": "meh"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize("sync_type", ["activities", "daily", "calendar"])
+def test_trigger_sync_accepted(client, no_threads, sync_type):
+    resp = client.post(f"/api/v1/sync/{sync_type}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "accepted"
+
+
+def test_trigger_sync_unknown(client, no_threads):
+    assert client.post("/api/v1/sync/bogus").status_code == 400

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -1,0 +1,237 @@
+import json
+from datetime import date
+
+import pytest
+
+from app import api
+from app.models import GarminCalendarEvent
+
+
+# --- Formatters ---
+
+@pytest.mark.parametrize("meters,expected", [
+    (500, "500m"),
+    (999, "999m"),
+    (1000, "1km"),
+    (2000, "2km"),
+    (2400, "2.4km"),
+    (1500, "1.5km"),
+])
+def test_format_step_distance(meters, expected):
+    assert api._format_step_distance(meters) == expected
+
+
+@pytest.mark.parametrize("seconds,expected", [
+    (45, "45s"),
+    (59, "59s"),
+    (60, "1 min"),
+    (90, "1:30"),
+    (125, "2:05"),
+    (600, "10 min"),
+])
+def test_format_step_duration(seconds, expected):
+    assert api._format_step_duration(seconds) == expected
+
+
+@pytest.mark.parametrize("mps,expected", [
+    (0, ""),
+    (-1, ""),
+    (1000 / 300, "5:00/km"),   # 300 s/km
+    (1000 / 265, "4:25/km"),   # 265 s/km
+])
+def test_format_pace(mps, expected):
+    assert api._format_pace(mps) == expected
+
+
+# --- _garmin_str ---
+
+def test_garmin_str_plain_string():
+    assert api._garmin_str("warmup") == "warmup"
+
+
+def test_garmin_str_key_dict():
+    assert api._garmin_str({"stepTypeKey": "warmup", "stepTypeId": 1}) == "warmup"
+
+
+def test_garmin_str_fallback_string_value():
+    assert api._garmin_str({"foo": 1, "bar": "value"}) == "value"
+
+
+def test_garmin_str_empty():
+    assert api._garmin_str(123) == ""
+    assert api._garmin_str({"id": 5}) == ""
+
+
+# --- _parse_step_target ---
+
+def test_parse_step_target_pace_range():
+    step = {"targetType": "pace.zone", "targetValueOne": 1000 / 300, "targetValueTwo": 1000 / 280}
+    target_type, display = api._parse_step_target(step)
+    assert target_type == "pace"
+    # Both bounds are rendered as a range.
+    assert display == "4:40/km - 5:00/km"
+
+
+def test_parse_step_target_single_pace():
+    step = {"targetType": "speed", "targetValueOne": 1000 / 300}
+    target_type, display = api._parse_step_target(step)
+    assert target_type == "pace"
+    assert display == "5:00/km"
+
+
+def test_parse_step_target_heart_rate_zone():
+    step = {"targetType": "heart.rate.zone", "zoneNumber": 3}
+    target_type, display = api._parse_step_target(step)
+    assert target_type == "heart_rate"
+    assert display == "HR Zone 3"
+
+
+def test_parse_step_target_open():
+    assert api._parse_step_target({"targetType": "open"}) == ("open", None)
+    assert api._parse_step_target({}) == ("open", None)
+
+
+# --- _classify_activity_type ---
+
+@pytest.mark.parametrize("step_type,expected", [
+    ("rest", "rest"),
+    ("recovery", "rest"),
+    ("recover", "rest"),
+    ("interval", "run"),
+    ("warmup", "run"),
+])
+def test_classify_activity_type(step_type, expected):
+    assert api._classify_activity_type(step_type) == expected
+
+
+# --- _parse_single_step ---
+
+def test_parse_single_step_interval_distance():
+    step = {
+        "stepType": "interval",
+        "endCondition": "distance",
+        "endConditionValue": 1000,
+        "targetType": "pace",
+        "targetValueOne": 1000 / 300,
+        "description": "Hard effort",
+    }
+    parsed = api._parse_single_step(step, order=2)
+    assert parsed.step_order == 2
+    assert parsed.step_type == "interval"
+    assert parsed.end_condition == "distance"
+    assert parsed.end_condition_display == "1km"
+    assert parsed.end_condition_value == 1000
+    assert parsed.target_type == "pace"
+    assert parsed.activity_type == "run"
+    assert parsed.description == "Hard effort"
+
+
+def test_parse_single_step_time_and_lap_button():
+    timed = api._parse_single_step(
+        {"stepType": "rest", "endCondition": "time", "endConditionValue": 90}, 1
+    )
+    assert timed.step_type == "rest"
+    assert timed.end_condition == "time"
+    assert timed.end_condition_display == "1:30"
+    assert timed.activity_type == "rest"
+
+    lap = api._parse_single_step({"stepType": "interval", "endCondition": "lap.button"}, 1)
+    assert lap.end_condition == "lap_button"
+    assert lap.end_condition_display == "Lap Button"
+
+
+def test_parse_single_step_type_normalization():
+    assert api._parse_single_step({"stepType": "warm_up"}, 1).step_type == "warmup"
+    assert api._parse_single_step({"stepType": "cool_down"}, 1).step_type == "cooldown"
+    assert api._parse_single_step({"stepType": "active"}, 1).step_type == "interval"
+
+
+def test_parse_single_step_repeat_with_nested():
+    step = {
+        "stepType": "repeat",
+        "repeatCount": 4,
+        "workoutSteps": [
+            {"stepType": "interval", "endCondition": "distance", "endConditionValue": 400},
+            {"stepType": "rest", "endCondition": "time", "endConditionValue": 60},
+        ],
+    }
+    parsed = api._parse_single_step(step, 1)
+    assert parsed.step_type == "repeat"
+    assert parsed.repeat_count == 4
+    assert parsed.steps is not None and len(parsed.steps) == 2
+    assert parsed.steps[0].step_type == "interval"
+    assert parsed.steps[1].step_type == "rest"
+
+
+# --- _parse_workout_steps ---
+
+def test_parse_workout_steps_top_level():
+    raw = json.dumps({"workoutSteps": [
+        {"stepType": "warmup", "endCondition": "time", "endConditionValue": 600},
+        {"stepType": "interval", "endCondition": "distance", "endConditionValue": 5000},
+    ]})
+    steps = api._parse_workout_steps(raw)
+    assert len(steps) == 2
+    assert [s.step_order for s in steps] == [1, 2]
+
+
+def test_parse_workout_steps_from_segments():
+    raw = json.dumps({"workoutSegments": [
+        {"workoutSteps": [{"stepType": "interval", "endCondition": "lap.button"}]},
+    ]})
+    steps = api._parse_workout_steps(raw)
+    assert len(steps) == 1
+    assert steps[0].step_type == "interval"
+
+
+def test_parse_workout_steps_invalid_json():
+    assert api._parse_workout_steps("{bad json") == []
+
+
+def test_parse_workout_steps_skips_non_dicts():
+    raw = json.dumps({"steps": ["not a dict", {"stepType": "interval"}]})
+    steps = api._parse_workout_steps(raw)
+    assert len(steps) == 1
+
+
+# --- _enrich_event_with_steps ---
+
+def test_enrich_event_workout_with_steps():
+    event = GarminCalendarEvent(
+        id=1,
+        garmin_id="w1",
+        event_type="workout",
+        date=date(2026, 6, 17),
+        title="Intervals",
+        raw_json=json.dumps({"workoutSteps": [{"stepType": "warmup", "endCondition": "lap.button"}]}),
+    )
+    resp = api._enrich_event_with_steps(event)
+    assert resp.workout_steps is not None
+    assert len(resp.workout_steps) == 1
+
+
+def test_enrich_event_race_has_no_steps():
+    event = GarminCalendarEvent(
+        id=2,
+        garmin_id="r1",
+        event_type="race",
+        date=date(2026, 6, 17),
+        title="10K",
+        raw_json=json.dumps({"workoutSteps": []}),
+    )
+    resp = api._enrich_event_with_steps(event)
+    assert resp.workout_steps is None
+
+
+# --- _parse_date ---
+
+def test_parse_date_valid():
+    assert api._parse_date("2026-06-17") == date(2026, 6, 17)
+
+
+def test_parse_date_invalid_falls_back_to_today():
+    assert api._parse_date("not-a-date") == date.today()
+
+
+def test_parse_date_none_falls_back_to_today():
+    assert api._parse_date(None) == date.today()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,64 @@
+from app import database
+from app.models import MetricZone
+
+
+def test_get_db_yields_and_closes(monkeypatch):
+    closed = {"v": False}
+
+    class FakeSession:
+        def close(self):
+            closed["v"] = True
+
+    monkeypatch.setattr(database, "SessionLocal", lambda: FakeSession())
+
+    gen = database.get_db()
+    session = next(gen)
+    assert isinstance(session, FakeSession)
+    # Exhausting the generator triggers the finally/close.
+    try:
+        next(gen)
+    except StopIteration:
+        pass
+    assert closed["v"] is True
+
+
+def test_db_session_context_manager_closes(monkeypatch):
+    closed = {"v": False}
+
+    class FakeSession:
+        def close(self):
+            closed["v"] = True
+
+    monkeypatch.setattr(database, "SessionLocal", lambda: FakeSession())
+
+    with database.db_session() as session:
+        assert isinstance(session, FakeSession)
+    assert closed["v"] is True
+
+
+def test_init_db_seeds_metric_zones():
+    # Operates on the real module engine (a local SQLite file in CI).
+    database.init_db()
+    with database.engine.connect() as conn:
+        from sqlalchemy import text
+        count = conn.execute(text("SELECT COUNT(*) FROM metric_zones")).scalar()
+    assert count and count > 0
+
+
+def test_seed_metric_zones_is_idempotent():
+    database.init_db()
+    with database.engine.connect() as conn:
+        from sqlalchemy import text
+        first = conn.execute(text("SELECT COUNT(*) FROM metric_zones")).scalar()
+    # Running again must not duplicate rows.
+    database._seed_metric_zones()
+    with database.engine.connect() as conn:
+        from sqlalchemy import text
+        second = conn.execute(text("SELECT COUNT(*) FROM metric_zones")).scalar()
+    assert first == second
+
+
+def test_migrate_db_is_safe_to_rerun():
+    # Adding already-present columns must not raise.
+    database.init_db()
+    database._migrate_db()

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -1,0 +1,459 @@
+import json
+from datetime import date, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from app import garmin_sync
+from app.models import Activity, DailySummary, GarminCalendarEvent, SyncStatus
+
+
+# --- _parse_garmin_ts ---
+
+def test_parse_garmin_ts_space_format():
+    assert garmin_sync._parse_garmin_ts("2026-06-10 07:30:00") == datetime(2026, 6, 10, 7, 30, 0)
+
+
+def test_parse_garmin_ts_iso_with_micros():
+    assert garmin_sync._parse_garmin_ts("2026-06-10T07:30:00.500") == datetime(2026, 6, 10, 7, 30, 0, 500000)
+
+
+def test_parse_garmin_ts_none_and_invalid():
+    assert garmin_sync._parse_garmin_ts(None) is None
+    assert garmin_sync._parse_garmin_ts("nonsense") is None
+
+
+# --- _extract_activity_fields ---
+
+def test_extract_activity_fields_basic_and_pace():
+    summary = {
+        "activityId": 12345,
+        "activityType": {"typeKey": "running"},
+        "activityName": "Morning Run",
+        "startTimeLocal": "2026-06-10 07:00:00",
+        "duration": 1800,       # 30 min
+        "distance": 5000,       # 5 km
+        "averageHR": 150,
+        "maxHR": 170,
+        "calories": 350,
+    }
+    fields = garmin_sync._extract_activity_fields(summary)
+    assert fields["garmin_id"] == 12345
+    assert fields["activity_type"] == "running"
+    assert fields["name"] == "Morning Run"
+    # 30 min over 5 km = 6 min/km
+    assert fields["avg_pace_min_km"] == pytest.approx(6.0)
+    assert fields["avg_hr"] == 150
+
+
+def test_extract_activity_fields_no_distance_no_pace():
+    fields = garmin_sync._extract_activity_fields({"activityId": 1, "duration": 600})
+    assert fields["avg_pace_min_km"] is None
+    assert fields["activity_type"] == "unknown"
+
+
+def test_extract_activity_fields_prefers_detail_summary():
+    summary = {"activityId": 1, "normPower": 100}
+    details = {"activity_summary": {"normPower": 250, "trainingStressScore": 88}}
+    fields = garmin_sync._extract_activity_fields(summary, details)
+    assert fields["normalized_power"] == 250
+    assert fields["training_stress_score"] == 88
+
+
+# --- _daily_summary_fields ---
+
+def test_daily_summary_fields_intensity_minutes_sum():
+    stats = {
+        "totalSteps": 8000,
+        "totalKilocalories": 2200,
+        "restingHeartRate": 50,
+        "moderateIntensityMinutes": 20,
+        "vigorousIntensityMinutes": 10,
+        "floorsAscended": 12,
+    }
+    fields = garmin_sync._daily_summary_fields(stats, 35, 27000, 80, {"x": 1})
+    assert fields["steps"] == 8000
+    assert fields["intensity_minutes"] == 30
+    assert fields["stress_avg"] == 35
+    assert fields["sleep_seconds"] == 27000
+    assert fields["ai_analyzed"] is False
+
+
+# --- _parse_calendar_date ---
+
+def test_parse_calendar_date_variants():
+    assert garmin_sync._parse_calendar_date(None) is None
+    assert garmin_sync._parse_calendar_date(date(2026, 6, 10)) == date(2026, 6, 10)
+    assert garmin_sync._parse_calendar_date("2026-06-10") == date(2026, 6, 10)
+    assert garmin_sync._parse_calendar_date("2026-06-10T07:00:00") == date(2026, 6, 10)
+
+
+def test_parse_calendar_date_epoch_millis():
+    # 2026-06-10 00:00 UTC in ms
+    ms = datetime(2026, 6, 10, tzinfo=garmin_sync.timezone.utc).timestamp() * 1000
+    assert garmin_sync._parse_calendar_date(ms) == date(2026, 6, 10)
+
+
+def test_parse_calendar_date_invalid_string():
+    assert garmin_sync._parse_calendar_date("garbage") is None
+
+
+# --- _parse_race_priority ---
+
+@pytest.mark.parametrize("raw,expected", [
+    (None, None),
+    (1, "A"),
+    (2, "B"),
+    (3, "C"),
+    ("A", "A"),
+    ("b", "B"),
+    ("PRIMARY", "A"),
+    ("SECONDARY", "B"),
+    ("FUN", "C"),
+])
+def test_parse_race_priority(raw, expected):
+    assert garmin_sync._parse_race_priority(raw) == expected
+
+
+# --- _race_distance_label ---
+
+@pytest.mark.parametrize("meters,label", [
+    (None, None),
+    (5000, "5K"),
+    (10000, "10K"),
+    (21097.5, "Half Marathon"),
+    (42195, "Marathon"),
+    (3000, "3.0km"),
+])
+def test_race_distance_label(meters, label):
+    assert garmin_sync._race_distance_label(meters) == label
+
+
+# --- _extract_goal_time_from_details ---
+
+def test_extract_goal_time_from_custom_goal():
+    detail = {"eventCustomization": {"customGoal": {"value": 5400, "unitType": "time"}}}
+    assert garmin_sync._extract_goal_time_from_details(detail) == 5400
+
+
+def test_extract_goal_time_from_top_level_field_ms():
+    # value > 86400 is treated as milliseconds.
+    detail = {"goalTimeInSeconds": 5400000}
+    assert garmin_sync._extract_goal_time_from_details(detail) == 5400
+
+
+def test_extract_goal_time_none():
+    assert garmin_sync._extract_goal_time_from_details({}) is None
+
+
+# --- _parse_calendar_response ---
+
+def test_parse_calendar_response_race():
+    data = {"calendarItems": [{
+        "itemType": "race",
+        "date": "2026-09-27",
+        "eventId": 99,
+        "title": "Berlin Marathon",
+        "distance": 42195,
+        "primaryEvent": True,
+    }]}
+    events = garmin_sync._parse_calendar_response(data)
+    assert len(events) == 1
+    evt = events[0]
+    assert evt["event_type"] == "race"
+    assert evt["distance_label"] == "Marathon"
+    assert evt["priority"] == "A"
+    assert evt["title"] == "Berlin Marathon"
+
+
+def test_parse_calendar_response_workout_builds_description():
+    data = {"calendarItems": [{
+        "itemType": "workout",
+        "date": "2026-06-17",
+        "workoutId": 5,
+        "title": "Intervals",
+        "workoutSteps": [
+            {"stepName": "Warmup", "endConditionValue": 600},
+            {"stepName": "Repeats"},
+        ],
+    }]}
+    events = garmin_sync._parse_calendar_response(data)
+    assert len(events) == 1
+    evt = events[0]
+    assert evt["event_type"] == "workout"
+    assert "Warmup: 600" in evt["workout_description"]
+
+
+def test_parse_calendar_response_skips_unknown_type_and_undated():
+    data = {"calendarItems": [
+        {"itemType": "sleep", "date": "2026-06-17"},
+        {"itemType": "race", "date": None},
+    ]}
+    assert garmin_sync._parse_calendar_response(data) == []
+
+
+def test_parse_calendar_response_empty():
+    assert garmin_sync._parse_calendar_response({}) == []
+
+
+# --- sync status helpers (DB) ---
+
+def test_get_set_sync_status_roundtrip(db):
+    assert garmin_sync._get_sync_status(db, "missing") is None
+    garmin_sync._set_sync_status(db, "k", "v1")
+    assert garmin_sync._get_sync_status(db, "k") == "v1"
+    # Update in place.
+    garmin_sync._set_sync_status(db, "k", "v2")
+    assert garmin_sync._get_sync_status(db, "k") == "v2"
+    assert db.query(SyncStatus).filter(SyncStatus.key == "k").count() == 1
+
+
+# --- _store_activity (Garmin client mocked) ---
+
+def test_store_activity_creates_row(db, monkeypatch):
+    fake_client = MagicMock()
+    fake_client.get_activity_details.return_value = {"metricDescriptors": []}
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+
+    summary = {
+        "activityId": 555,
+        "activityType": {"typeKey": "running"},
+        "activityName": "Run",
+        "startTimeLocal": "2026-06-10 07:00:00",
+        "duration": 1800,
+        "distance": 5000,
+    }
+    details = {
+        "splits": [{"distance": 1000}],
+        "typed_splits": [
+            {"splitType": "RUNNING", "totalElapsedDuration": 1500},
+            {"splitType": "WALKING", "totalElapsedDuration": 300},
+        ],
+    }
+    activity = garmin_sync._store_activity(db, summary, details, skip_ai=True)
+    assert activity is not None
+    assert activity.garmin_id == 555
+    assert activity.run_time_sec == 1500
+    assert activity.walk_time_sec == 300
+    assert activity.ai_analyzed is True
+    assert json.loads(activity.splits_json) == [{"distance": 1000}]
+
+
+def test_store_activity_skips_duplicate(db, monkeypatch):
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: MagicMock())
+    db.add(Activity(garmin_id=777, name="Existing", activity_type="running"))
+    db.commit()
+    result = garmin_sync._store_activity(db, {"activityId": 777}, {}, skip_ai=True)
+    assert result is None
+
+
+def test_store_activity_no_id_returns_none(db):
+    assert garmin_sync._store_activity(db, {}, {}) is None
+
+
+# --- sync_calendar orchestration (client + db mocked) ---
+
+def test_get_garmin_client_fresh_login(monkeypatch):
+    # Reset the cached client so a fresh login path runs.
+    monkeypatch.setattr(garmin_sync, "_garmin_client", None)
+
+    fake_client = MagicMock()
+    fake_client.get_full_name.return_value = "Sam Runner"
+    monkeypatch.setattr(garmin_sync, "Garmin", lambda *a, **k: fake_client)
+
+    client = garmin_sync.get_garmin_client()
+    assert client is fake_client
+    fake_client.login.assert_called()
+
+
+def test_get_garmin_client_reuses_live_session(monkeypatch):
+    live = MagicMock()
+    live.get_full_name.return_value = "Sam"
+    monkeypatch.setattr(garmin_sync, "_garmin_client", live)
+    # Should return the cached client without constructing a new one.
+    monkeypatch.setattr(garmin_sync, "Garmin", lambda *a, **k: pytest.fail("should not re-create"))
+    assert garmin_sync.get_garmin_client() is live
+
+
+def test_fetch_activity_details_tolerates_failures():
+    client = MagicMock()
+    client.get_activity.return_value = {"summary": 1}
+    client.get_activity_splits.side_effect = RuntimeError("no splits")
+    client.get_activity_hr_in_timezones.return_value = [{"zone": 1}]
+    client.get_activity_weather.return_value = {"temp": 20}
+    client.get_activity_split_summaries.return_value = []
+    client.get_activity_typed_splits.return_value = []
+
+    details = garmin_sync._fetch_activity_details(client, 123)
+    assert details["activity_summary"] == {"summary": 1}
+    # Endpoint that raised is simply absent.
+    assert "splits" not in details
+    assert details["weather"] == {"temp": 20}
+
+
+def test_fetch_workout_details_returns_dict():
+    client = MagicMock()
+    client.connectapi.return_value = {"workoutSteps": []}
+    assert garmin_sync._fetch_workout_details(client, 5) == {"workoutSteps": []}
+
+
+def test_fetch_workout_details_handles_error():
+    client = MagicMock()
+    client.connectapi.side_effect = RuntimeError("boom")
+    assert garmin_sync._fetch_workout_details(client, 5) is None
+
+
+def test_fetch_race_event_details_no_uuid():
+    assert garmin_sync._fetch_race_event_details(MagicMock(), {}) is None
+
+
+def test_sync_activities_stores_new(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    monkeypatch.setattr(garmin_sync.time, "sleep", lambda *a, **k: None)
+
+    fake_client = MagicMock()
+    fake_client.get_activities.return_value = [
+        {"activityId": 1001, "activityType": {"typeKey": "running"},
+         "activityName": "Run", "startTimeLocal": "2026-06-10 07:00:00",
+         "duration": 1800, "distance": 5000},
+    ]
+    fake_client.get_activity_details.return_value = {"metricDescriptors": []}
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+    monkeypatch.setattr(garmin_sync, "_fetch_activity_details", lambda c, gid: {})
+
+    new = garmin_sync.sync_activities()
+    assert len(new) == 1
+    assert db.query(Activity).filter(Activity.garmin_id == 1001).count() == 1
+    # Sync status was recorded.
+    assert garmin_sync._get_sync_status(db, "last_activity_sync") is not None
+
+
+def test_sync_activities_skips_existing(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    monkeypatch.setattr(garmin_sync.time, "sleep", lambda *a, **k: None)
+    db.add(Activity(garmin_id=2002, name="Old", activity_type="running"))
+    db.commit()
+
+    fake_client = MagicMock()
+    fake_client.get_activities.return_value = [{"activityId": 2002}]
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+
+    new = garmin_sync.sync_activities()
+    assert new == []
+
+
+def test_sync_daily_summary_creates_row(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+
+    fake_client = MagicMock()
+    fake_client.get_stats.return_value = {
+        "totalSteps": 9000, "restingHeartRate": 49, "averageStressLevel": 28,
+    }
+    fake_client.get_user_summary.return_value = {}
+    fake_client.get_sleep_data.return_value = {
+        "dailySleepDTO": {"sleepTimeSeconds": 27000,
+                          "sleepScores": {"overall": {"value": 82}}}
+    }
+    fake_client.get_heart_rates.return_value = {}
+    fake_client.get_all_day_stress.return_value = {}
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+
+    summary = garmin_sync.sync_daily_summary(date(2026, 6, 10))
+    assert summary is not None
+    stored = db.query(DailySummary).filter(DailySummary.date == date(2026, 6, 10)).first()
+    assert stored.steps == 9000
+    assert stored.sleep_seconds == 27000
+    assert stored.sleep_score == 82
+    assert stored.stress_avg == 28
+
+
+def test_sync_daily_summary_updates_existing(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    db.add(DailySummary(date=date(2026, 6, 10), steps=1))
+    db.commit()
+
+    fake_client = MagicMock()
+    fake_client.get_stats.return_value = {"totalSteps": 9999}
+    fake_client.get_user_summary.return_value = {}
+    fake_client.get_sleep_data.return_value = {}
+    fake_client.get_heart_rates.return_value = {}
+    fake_client.get_all_day_stress.return_value = {}
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+
+    garmin_sync.sync_daily_summary(date(2026, 6, 10))
+    db.expire_all()
+    assert db.query(DailySummary).filter(DailySummary.date == date(2026, 6, 10)).count() == 1
+    assert db.query(DailySummary).filter(DailySummary.date == date(2026, 6, 10)).first().steps == 9999
+
+
+def test_backfill_activities_walks_pages(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    monkeypatch.setattr(garmin_sync.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(garmin_sync, "_fetch_activity_details", lambda c, gid: {})
+
+    fake_client = MagicMock()
+    # First page returns one activity (< page_size) so the loop stops after it.
+    fake_client.get_activities.side_effect = [
+        [{"activityId": 3001, "activityType": {"typeKey": "running"},
+          "activityName": "Run", "startTimeLocal": "2026-06-10 07:00:00",
+          "duration": 1800, "distance": 5000}],
+    ]
+    fake_client.get_activity_details.return_value = {"metricDescriptors": []}
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+
+    garmin_sync.backfill_activities()
+    assert db.query(Activity).filter(Activity.garmin_id == 3001).count() == 1
+    assert garmin_sync._get_sync_status(db, "backfill_activities") == "complete"
+
+
+def test_backfill_activities_skips_when_complete(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    garmin_sync._set_sync_status(db, "backfill_activities", "complete")
+    monkeypatch.setattr(garmin_sync, "get_garmin_client",
+                        lambda: pytest.fail("client should not be created"))
+    garmin_sync.backfill_activities()  # returns immediately
+
+
+def test_backfill_daily_summaries_completes(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    monkeypatch.setattr(garmin_sync.time, "sleep", lambda *a, **k: None)
+    # Stub the per-day sync so we don't hit Garmin; return None to skip storage.
+    monkeypatch.setattr(garmin_sync, "sync_daily_summary", lambda target: None)
+
+    garmin_sync.backfill_daily_summaries()
+    assert garmin_sync._get_sync_status(db, "backfill_daily") == "complete"
+
+
+def test_backfill_daily_summaries_skips_when_complete(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    garmin_sync._set_sync_status(db, "backfill_daily", "complete")
+    called = MagicMock()
+    monkeypatch.setattr(garmin_sync, "sync_daily_summary", called)
+    garmin_sync.backfill_daily_summaries()
+    called.assert_not_called()
+
+
+def test_sync_calendar_upserts_events(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+
+    fake_client = MagicMock()
+
+    def fake_connectapi(endpoint):
+        if "calendar-service/year" in endpoint:
+            return {"calendarItems": [{
+                "itemType": "race",
+                "date": "2099-09-27",
+                "eventId": 1,
+                "title": "Future Race",
+                "distance": 10000,
+            }]}
+        return {}
+
+    fake_client.connectapi.side_effect = fake_connectapi
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+    monkeypatch.setattr(garmin_sync.time, "sleep", lambda *a, **k: None)
+
+    count = garmin_sync.sync_calendar()
+    assert count >= 1
+    races = db.query(GarminCalendarEvent).filter(GarminCalendarEvent.event_type == "race").all()
+    assert any(r.title == "Future Race" for r in races)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock
+
+import app.main as main
+
+
+def test_scheduled_activity_sync_runs_both(monkeypatch):
+    sync_activities = MagicMock()
+    sync_calendar = MagicMock()
+    import app.garmin_sync as garmin_sync
+    monkeypatch.setattr(garmin_sync, "sync_activities", sync_activities)
+    monkeypatch.setattr(garmin_sync, "sync_calendar", sync_calendar)
+
+    main._scheduled_activity_sync()
+
+    sync_activities.assert_called_once()
+    sync_calendar.assert_called_once()
+
+
+def test_scheduled_activity_sync_survives_calendar_error(monkeypatch):
+    import app.garmin_sync as garmin_sync
+    monkeypatch.setattr(garmin_sync, "sync_activities", MagicMock())
+    monkeypatch.setattr(garmin_sync, "sync_calendar", MagicMock(side_effect=RuntimeError("boom")))
+    # Should swallow the calendar failure, not raise.
+    main._scheduled_activity_sync()
+
+
+def test_scheduled_daily_sync_triggers_ai(monkeypatch):
+    summary = MagicMock(id=1)
+    import app.garmin_sync as garmin_sync
+    import app.ai_coach as ai_coach
+    monkeypatch.setattr(garmin_sync, "sync_daily_summary", MagicMock(return_value=summary))
+    analyze = MagicMock()
+    monkeypatch.setattr(ai_coach, "analyze_daily_summary", analyze)
+
+    main._scheduled_daily_sync()
+
+    analyze.assert_called_once_with(summary)
+
+
+def test_scheduled_daily_sync_no_summary_skips_ai(monkeypatch):
+    import app.garmin_sync as garmin_sync
+    import app.ai_coach as ai_coach
+    monkeypatch.setattr(garmin_sync, "sync_daily_summary", MagicMock(return_value=None))
+    analyze = MagicMock()
+    monkeypatch.setattr(ai_coach, "analyze_daily_summary", analyze)
+
+    main._scheduled_daily_sync()
+
+    analyze.assert_not_called()
+
+
+def test_scheduled_weekly_review_delegates(monkeypatch):
+    import app.ai_coach as ai_coach
+    review = MagicMock()
+    monkeypatch.setattr(ai_coach, "weekly_review", review)
+    main._scheduled_weekly_review()
+    review.assert_called_once()
+
+
+def test_run_backfill_runs_all_steps(monkeypatch):
+    import app.garmin_sync as garmin_sync
+    import app.ai_coach as ai_coach
+    backfill_activities = MagicMock()
+    backfill_daily = MagicMock()
+    weekly = MagicMock()
+    monkeypatch.setattr(garmin_sync, "backfill_activities", backfill_activities)
+    monkeypatch.setattr(garmin_sync, "backfill_daily_summaries", backfill_daily)
+    monkeypatch.setattr(ai_coach, "weekly_review", weekly)
+
+    main._run_backfill()
+
+    backfill_activities.assert_called_once()
+    backfill_daily.assert_called_once()
+    weekly.assert_called_once()
+
+
+def test_spa_catch_all_rejects_api_paths():
+    import asyncio
+    from fastapi import HTTPException
+
+    with __import__("pytest").raises(HTTPException) as exc:
+        asyncio.run(main.spa_catch_all("api/v1/today"))
+    assert exc.value.status_code == 404

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,159 @@
+import json
+from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from app import routes
+from app.models import Activity, DailySummary, GarminCalendarEvent, Insight
+
+
+# --- Template filters (pure) ---
+
+@pytest.mark.parametrize("pace,expected", [
+    (None, "-"),
+    (0, "-"),
+    (-1, "-"),
+    (4.5, "4:30"),
+    (5.0, "5:00"),
+    (4.0833, "4:04"),
+])
+def test_pace_str(pace, expected):
+    assert routes._pace_str(pace) == expected
+
+
+@pytest.mark.parametrize("seconds,expected", [
+    (None, "-"),
+    (0, "-"),
+    (90, "1:30"),
+    (3661, "1:01:01"),
+    (600, "10:00"),
+])
+def test_duration_str(seconds, expected):
+    assert routes._duration_str(seconds) == expected
+
+
+@pytest.mark.parametrize("meters,expected", [
+    (None, "-"),
+    (0, "-"),
+    (5000, "5.00"),
+    (12000, "12.0"),
+    (10000, "10.0"),
+])
+def test_distance_str(meters, expected):
+    assert routes._distance_str(meters) == expected
+
+
+# --- HTML endpoints ---
+
+def _add_activity(db, started_at, **kw):
+    defaults = dict(
+        garmin_id=int(started_at.timestamp()),
+        activity_type="running",
+        name="Run",
+        started_at=started_at,
+        duration_sec=3600,
+        distance_m=10000,
+    )
+    defaults.update(kw)
+    a = Activity(**defaults)
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def test_dashboard_renders(routes_client, db):
+    _add_activity(db, datetime(2026, 6, 10, 7, 0))
+    db.add(Insight(trigger_type="activity", content="x", summary="Nice run", category="workout_analysis"))
+    db.commit()
+    resp = routes_client.get("/")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_dashboard_with_next_race(routes_client, db):
+    db.add(GarminCalendarEvent(
+        garmin_id="r1", event_type="race",
+        date=date.today() + timedelta(days=30), title="Marathon",
+    ))
+    db.commit()
+    assert routes_client.get("/").status_code == 200
+
+
+def test_activity_detail_page(routes_client, db):
+    a = _add_activity(
+        db, datetime(2026, 6, 10, 7, 0),
+        splits_json=json.dumps([{"distance": 1000}]),
+    )
+    resp = routes_client.get(f"/activity/{a.id}")
+    assert resp.status_code == 200
+
+
+def test_activity_detail_page_404(routes_client):
+    assert routes_client.get("/activity/999").status_code == 404
+
+
+def test_daily_list_and_detail_pages(routes_client, db):
+    s = DailySummary(date=date(2026, 6, 10), steps=10000)
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    assert routes_client.get("/daily").status_code == 200
+    assert routes_client.get(f"/daily/{s.id}").status_code == 200
+
+
+def test_daily_detail_404(routes_client):
+    assert routes_client.get("/daily/999").status_code == 404
+
+
+def test_insights_page_and_filter(routes_client, db):
+    db.add(Insight(trigger_type="activity", content="x", summary="A", category="workout_analysis"))
+    db.commit()
+    assert routes_client.get("/insights").status_code == 200
+    assert routes_client.get("/insights?category=workout_analysis").status_code == 200
+
+
+def test_calendar_page(routes_client, db):
+    _add_activity(db, datetime(2026, 6, 10, 7, 0))
+    resp = routes_client.get("/calendar?month=2026-06")
+    assert resp.status_code == 200
+
+
+def test_calendar_page_invalid_month(routes_client):
+    assert routes_client.get("/calendar?month=bad").status_code == 200
+
+
+def test_settings_page(routes_client, db):
+    _add_activity(db, datetime(2026, 6, 10, 7, 0))
+    assert routes_client.get("/settings").status_code == 200
+
+
+# --- POST actions (threads' targets stubbed) ---
+
+@pytest.fixture
+def stub_jobs(monkeypatch):
+    import app.ai_coach as ai_coach
+    import app.main as main_module
+    import app.garmin_sync as garmin_sync
+
+    monkeypatch.setattr(ai_coach, "analyze_activity_force", MagicMock())
+    monkeypatch.setattr(main_module, "_scheduled_activity_sync", MagicMock())
+    monkeypatch.setattr(main_module, "_scheduled_daily_sync", MagicMock())
+    monkeypatch.setattr(garmin_sync, "sync_calendar", MagicMock())
+
+
+def test_trigger_activity_analysis_redirects(routes_client, db, stub_jobs):
+    a = _add_activity(db, datetime(2026, 6, 10, 7, 0))
+    resp = routes_client.post(f"/activity/{a.id}/analyze", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+def test_trigger_activity_analysis_404(routes_client, stub_jobs):
+    assert routes_client.post("/activity/999/analyze", follow_redirects=False).status_code == 404
+
+
+@pytest.mark.parametrize("path", ["/sync/activities", "/sync/daily", "/sync/calendar"])
+def test_sync_post_redirects(routes_client, stub_jobs, path):
+    resp = routes_client.post(path, follow_redirects=False)
+    assert resp.status_code == 303

--- a/tests/test_training_load_edge.py
+++ b/tests/test_training_load_edge.py
@@ -1,0 +1,67 @@
+from app import training_load
+from app.models import Activity, AthleteProfile
+
+
+# --- _interpret_tsb thresholds ---
+
+def test_interpret_tsb_bands():
+    assert training_load._interpret_tsb(20) == "very fresh / detraining risk"
+    assert training_load._interpret_tsb(10) == "fresh, tapered"
+    assert training_load._interpret_tsb(0) == "neutral / race-ready range"
+    assert training_load._interpret_tsb(-20) == "productive training fatigue"
+    assert training_load._interpret_tsb(-40) == "high fatigue — overreaching risk"
+
+
+# --- intensity factor cap ---
+
+def test_estimate_tss_intensity_capped():
+    # An absurdly fast pace would blow up the IF; it is capped at _MAX_IF (1.5).
+    profile = AthleteProfile(threshold_pace_min_km=5.0)
+    fast = Activity(duration_sec=3600, avg_pace_min_km=0.5)  # IF would be 10
+    capped = Activity(duration_sec=3600, avg_pace_min_km=5.0 / 1.5)  # IF == 1.5
+    tss_fast, _ = training_load.estimate_tss(fast, profile)
+    tss_capped, _ = training_load.estimate_tss(capped, profile)
+    assert tss_fast == tss_capped
+
+
+# --- HR threshold falls back to max_hr * 0.9 ---
+
+def test_estimate_tss_hr_threshold_from_max_hr():
+    profile = AthleteProfile(max_hr=200)  # threshold ~ 180
+    act = Activity(duration_sec=3600, avg_hr=180)
+    tss, source = training_load.estimate_tss(act, profile)
+    assert source == "hr"
+    assert round(tss) == 100
+
+
+# --- format context renders snapshot ---
+
+def test_format_training_load_context_renders_values():
+    from app.schemas import TrainingLoadPoint
+    from datetime import date
+
+    point = TrainingLoadPoint(date=date(2026, 6, 17), tss=80, ctl=55, atl=70, tsb=-15)
+    text = training_load.format_training_load_context(point)
+    assert "## Training Load" in text
+    assert "Fitness (CTL, 42d): 55" in text
+    assert "Fatigue (ATL, 7d): 70" in text
+    assert "Form (TSB" in text
+    assert "productive training fatigue" in text
+
+
+# --- compute_load_series with days<=0 returns full series ---
+
+def test_compute_load_series_no_window_returns_full(db):
+    from datetime import datetime as dt, date, timedelta
+    base = dt(2026, 5, 1, 7, 0)
+    for i in range(5):
+        db.add(Activity(
+            garmin_id=int((base + timedelta(days=i)).timestamp()),
+            activity_type="running", name="Run",
+            started_at=base + timedelta(days=i),
+            duration_sec=3600, distance_m=10000, training_stress_score=50,
+        ))
+    db.commit()
+    full = training_load.compute_load_series(db, end_date=date(2026, 5, 5), days=0)
+    # From first activity (May 1) through May 5 == 5 days.
+    assert len(full) == 5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,122 @@
+from datetime import date
+
+from app.utils import calculate_age, safe_json_loads, parse_activity_charts
+
+
+# --- calculate_age ---
+
+def test_calculate_age_none_dob():
+    assert calculate_age(None) is None
+
+
+def test_calculate_age_before_birthday():
+    # Reference is the day before the 30th birthday.
+    assert calculate_age(date(1990, 6, 15), date(2020, 6, 14)) == 29
+
+
+def test_calculate_age_on_birthday():
+    assert calculate_age(date(1990, 6, 15), date(2020, 6, 15)) == 30
+
+
+def test_calculate_age_after_birthday():
+    assert calculate_age(date(1990, 6, 15), date(2020, 12, 1)) == 30
+
+
+def test_calculate_age_negative_returns_none():
+    # Date of birth in the future yields a negative age -> None.
+    assert calculate_age(date(2030, 1, 1), date(2020, 1, 1)) is None
+
+
+def test_calculate_age_defaults_to_today():
+    # Just confirm it runs without an explicit reference and is plausible.
+    age = calculate_age(date(2000, 1, 1))
+    assert age is not None and age >= 20
+
+
+# --- safe_json_loads ---
+
+def test_safe_json_loads_valid():
+    assert safe_json_loads('{"a": 1}') == {"a": 1}
+
+
+def test_safe_json_loads_list():
+    assert safe_json_loads("[1, 2, 3]") == [1, 2, 3]
+
+
+def test_safe_json_loads_none():
+    assert safe_json_loads(None) is None
+
+
+def test_safe_json_loads_empty_string():
+    assert safe_json_loads("") is None
+
+
+def test_safe_json_loads_invalid():
+    assert safe_json_loads("{not json}") is None
+
+
+# --- parse_activity_charts ---
+
+def test_parse_charts_empty_or_invalid():
+    assert parse_activity_charts(None) == {}
+    assert parse_activity_charts("string") == {}
+    assert parse_activity_charts({}) == {}
+    assert parse_activity_charts({"metricDescriptors": []}) == {}
+
+
+def _laps(metric_rows, descriptors):
+    return {
+        "metricDescriptors": descriptors,
+        "activityDetailMetrics": [{"metrics": row} for row in metric_rows],
+    }
+
+
+def test_parse_charts_heart_rate_series():
+    data = _laps(
+        metric_rows=[[120], [130], [140]],
+        descriptors=[{"key": "directHeartRate", "metricsIndex": 0}],
+    )
+    charts = parse_activity_charts(data)
+    assert "heart_rate" in charts
+    assert charts["heart_rate"]["label"] == "Heart Rate"
+    assert charts["heart_rate"]["unit"] == "bpm"
+    assert charts["heart_rate"]["data"] == [120, 130, 140]
+
+
+def test_parse_charts_pace_converted_from_speed():
+    # speed 2.5 m/s -> pace 1000/(60*2.5) = 6.67 min/km
+    data = _laps(
+        metric_rows=[[2.5], [0]],
+        descriptors=[{"key": "directSpeed", "metricsIndex": 0}],
+    )
+    charts = parse_activity_charts(data)
+    assert charts["pace"]["data"][0] == round(1000 / (60 * 2.5), 2)
+    # Zero speed yields None (avoids divide-by-zero).
+    assert charts["pace"]["data"][1] is None
+
+
+def test_parse_charts_cadence_doubled():
+    data = _laps(
+        metric_rows=[[85], [90]],
+        descriptors=[{"key": "directRunCadence", "metricsIndex": 0}],
+    )
+    charts = parse_activity_charts(data)
+    # Garmin reports half-cadence; values are doubled.
+    assert charts["cadence"]["data"] == [170, 180]
+
+
+def test_parse_charts_all_none_series_dropped():
+    data = _laps(
+        metric_rows=[[None], [None]],
+        descriptors=[{"key": "directHeartRate", "metricsIndex": 0}],
+    )
+    # A series with no usable values is not emitted.
+    assert "heart_rate" not in parse_activity_charts(data)
+
+
+def test_parse_charts_unknown_metric_ignored():
+    data = _laps(
+        metric_rows=[[5]],
+        descriptors=[{"key": "directSomethingElse", "metricsIndex": 0}],
+    )
+    assert parse_activity_charts(data) == {}


### PR DESCRIPTION
Expand the test suite from 20 to 237 tests covering the whole backend
(utils, schemas, models, database, training_load, ai_coach, garmin_sync,
api, routes, main) with external I/O (Garmin, Anthropic, Gemini) mocked.
Overall coverage is 89%.

Add pyproject.toml (pytest + coverage config, fail_under=80), pytest-cov
to requirements-dev.txt, and a Tests workflow that runs pytest with
coverage on every push to any branch (plus PRs and manual dispatch).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fx9sjWnNPHoToYo23RTtVC