### PR TITLE
Source name, DOB, and weight from Garmin (read-only profile fields)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -573,14 +573,24 @@ def api_get_athlete_profile(db: Session = Depends(get_db)):
     return _profile_response(profile) if profile else None
 
 
+# Name, date of birth, and weight are always sourced from Garmin and are not
+# user-editable, so ignore any client-supplied values for these fields.
+GARMIN_MANAGED_PROFILE_FIELDS = {"name", "date_of_birth", "weight_kg"}
+
+
 @api_router.post("/athlete-profile", response_model=AthleteProfileResponse)
 def api_set_athlete_profile(profile_data: AthleteProfileRequest, db: Session = Depends(get_db)):
+    updates = {
+        key: value
+        for key, value in profile_data.model_dump(exclude_unset=True).items()
+        if key not in GARMIN_MANAGED_PROFILE_FIELDS
+    }
     profile = db.query(AthleteProfile).first()
     if profile is None:
-        profile = AthleteProfile(**profile_data.model_dump(exclude_unset=True))
+        profile = AthleteProfile(**updates)
         db.add(profile)
     else:
-        for key, value in profile_data.model_dump(exclude_unset=True).items():
+        for key, value in updates.items():
             setattr(profile, key, value)
     db.commit()
     db.refresh(profile)

--- a/app/garmin_sync.py
+++ b/app/garmin_sync.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.database import db_session
-from app.models import Activity, DailySummary, GarminCalendarEvent, SyncStatus
+from app.models import Activity, AthleteProfile, DailySummary, GarminCalendarEvent, SyncStatus
 
 logger = logging.getLogger(__name__)
 
@@ -342,6 +342,90 @@ def sync_daily_summary(target_date: date | None = None) -> DailySummary | None:
 
         except Exception:
             logger.exception("Daily summary sync failed for %s", date_str)
+            return None
+
+
+# Athlete profile fields that are always sourced from Garmin (read-only in the UI).
+GARMIN_PROFILE_FIELDS = ("name", "date_of_birth", "weight_kg")
+
+
+def _fetch_latest_garmin_weight(client: Garmin) -> float | None:
+    """Return the most recent weight (in grams) from Garmin body composition."""
+    try:
+        today = date.today()
+        start = today - timedelta(days=30)
+        data = client.get_body_composition(start.isoformat(), today.isoformat()) or {}
+        latest = None
+        for measurement in data.get("dateWeightList") or []:
+            weight = measurement.get("weight")
+            if weight:
+                latest = weight  # list is chronological; keep the last non-null
+        return latest
+    except Exception:
+        logger.debug("Could not fetch Garmin body composition weight", exc_info=True)
+        return None
+
+
+def _fetch_garmin_profile_fields(client: Garmin) -> dict:
+    """Pull name, date of birth, and weight (kg) from Garmin user settings."""
+    fields: dict = {}
+
+    try:
+        name = client.get_full_name()
+        if name:
+            fields["name"] = name
+    except Exception:
+        logger.debug("Could not fetch Garmin full name", exc_info=True)
+
+    user_data: dict = {}
+    try:
+        settings_data = client.get_user_profile() or {}
+        user_data = settings_data.get("userData") or {}
+    except Exception:
+        logger.debug("Could not fetch Garmin user settings", exc_info=True)
+
+    dob = _parse_calendar_date(user_data.get("birthDate"))
+    if dob:
+        fields["date_of_birth"] = dob
+
+    weight_g = user_data.get("weight") or _fetch_latest_garmin_weight(client)
+    if weight_g:
+        fields["weight_kg"] = round(weight_g / 1000, 1)
+
+    return fields
+
+
+def sync_athlete_profile() -> AthleteProfile | None:
+    """Sync name, date of birth, and weight from Garmin into the athlete profile.
+
+    These three fields are Garmin-managed (read-only in the UI), so the local
+    values are always overwritten to stay in sync with Garmin.
+    """
+    logger.info("Syncing athlete profile from Garmin...")
+    client = get_garmin_client()
+
+    with db_session() as db:
+        try:
+            fields = _fetch_garmin_profile_fields(client)
+            if not fields:
+                logger.info("No Garmin profile fields available to sync")
+                return None
+
+            profile = db.query(AthleteProfile).first()
+            if profile is None:
+                profile = AthleteProfile(**fields)
+                db.add(profile)
+            else:
+                for key, value in fields.items():
+                    setattr(profile, key, value)
+
+            db.commit()
+            db.refresh(profile)
+            _set_sync_status(db, "last_profile_sync", datetime.now(timezone.utc).isoformat())
+            logger.info("Athlete profile synced from Garmin: %s", ", ".join(fields))
+            return profile
+        except Exception:
+            logger.exception("Athlete profile sync failed")
             return None
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -37,8 +37,13 @@ def _scheduled_activity_sync():
 
 def _scheduled_daily_sync():
     """Scheduled job: sync daily summary and trigger AI."""
-    from app.garmin_sync import sync_daily_summary
+    from app.garmin_sync import sync_athlete_profile, sync_daily_summary
     from app.ai_coach import analyze_daily_summary
+
+    try:
+        sync_athlete_profile()
+    except Exception:
+        logger.exception("Athlete profile sync failed")
 
     summary = sync_daily_summary()
     if summary:
@@ -57,10 +62,14 @@ def _scheduled_weekly_review():
 
 def _run_backfill():
     """Run historical backfill in a background thread."""
-    from app.garmin_sync import backfill_activities, backfill_daily_summaries
+    from app.garmin_sync import backfill_activities, backfill_daily_summaries, sync_athlete_profile
     from app.ai_coach import weekly_review
 
     logger.info("Starting historical backfill...")
+    try:
+        sync_athlete_profile()
+    except Exception:
+        logger.exception("Athlete profile sync failed")
     backfill_activities()
     backfill_daily_summaries()
     logger.info("Backfill complete. Generating initial training summary...")

--- a/frontend/src/components/profile/ProfileForm.css
+++ b/frontend/src/components/profile/ProfileForm.css
@@ -47,6 +47,16 @@
   border-color: var(--accent);
 }
 
+.profile-form__field input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.profile-form__hint {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
 .profile-form__error {
   color: var(--danger);
   font-size: 0.82rem;

--- a/frontend/src/components/profile/ProfileForm.tsx
+++ b/frontend/src/components/profile/ProfileForm.tsx
@@ -82,17 +82,20 @@ export default function ProfileForm({ initial, onSubmit, isPending, isError, sub
     <form className="profile-form" onSubmit={handleSubmit}>
       <div className="profile-form__field">
         <label htmlFor="pf-name">Name</label>
-        <input id="pf-name" type="text" value={form.name} onChange={set('name')} />
+        <input id="pf-name" type="text" value={form.name} disabled readOnly />
+        <span className="profile-form__hint">Synced from Garmin</span>
       </div>
 
       <div className="profile-form__row">
         <div className="profile-form__field">
           <label htmlFor="pf-dob">Date of birth</label>
-          <input id="pf-dob" type="date" value={form.date_of_birth} onChange={set('date_of_birth')} />
+          <input id="pf-dob" type="date" value={form.date_of_birth} disabled readOnly />
+          <span className="profile-form__hint">Synced from Garmin</span>
         </div>
         <div className="profile-form__field">
           <label htmlFor="pf-weight">Weight (kg)</label>
-          <input id="pf-weight" type="number" step="0.1" min="0" value={form.weight_kg} onChange={set('weight_kg')} />
+          <input id="pf-weight" type="number" step="0.1" min="0" value={form.weight_kg} disabled readOnly />
+          <span className="profile-form__hint">Synced from Garmin</span>
         </div>
       </div>
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,89 +1,55 @@
-# P1-3 Custom, Threshold-Anchored Zones — Implementation Plan
+# Pull Name, DOB, Weight from Garmin — Implementation Plan
 
 ## Goal
-Let the athlete configure HR/pace/power zones anchored to threshold values (from AthleteProfile),
-replacing the hardcoded percentile-only bands for those metrics. Use them in the Settings UI, the
-AI context, and a new pace zone chart in Activity Detail.
+Always source the athlete's Name, Date of birth, and Weight from Garmin (read-only),
+and disable those three fields in the Athlete Profile form.
 
 ## Checklist
 
 ### Backend
-
-- [x] `app/models.py`
-  - Add `threshold_power` column to `AthleteProfile`
-  - Add new `ZoneConfig` model (zone_type, zone_number, zone_name, zone_color, min_pct, max_pct)
-
-- [x] `app/database.py`
-  - Extend `_migrate_db()` to add `threshold_power` to `athlete_profiles`
-  - Add `_seed_zone_configs()` with Coggan-style defaults for HR, pace, power
-  - Call `_seed_zone_configs()` from `init_db()`
-
-- [x] `app/schemas.py`
-  - Add `ZoneConfigResponse`, `ZoneConfigUpdate`, `ZoneConfigBulkUpdate`, `ZoneConfigsResponse`
-  - Add `threshold_power` to `AthleteProfileRequest` and `AthleteProfileResponse`
-
-- [x] `app/api.py`
-  - Import `ZoneConfig` model, import new zone schemas
-  - Add `_compute_zone_bounds()` helper (applies threshold to get absolute values)
-  - Add `GET /api/v1/zones` endpoint
-  - Add `PUT /api/v1/zones` endpoint
-
-- [x] `app/ai_coach.py`
-  - Import `ZoneConfig` model
-  - Add `_classify_by_zones(value, configs, threshold)` helper
-  - Update `_format_activity_context()` to annotate avg_hr and avg_pace with custom zone labels
-  - Update `_format_athlete_profile_context()` to include threshold_power when set
-  - Update `_build_context()` (load zone configs via `_load_zone_configs()` helper)
+- [ ] `app/garmin_sync.py`: import `AthleteProfile`
+- [ ] `app/garmin_sync.py`: add `_fetch_garmin_profile_fields()` (name via get_full_name,
+      DOB + weight via get_user_profile().userData, weight fallback via body composition)
+- [ ] `app/garmin_sync.py`: add `sync_athlete_profile()` upsert + sync status
+- [ ] `app/main.py`: call `sync_athlete_profile()` on backfill startup and in daily sync
+- [ ] `app/api.py`: strip Garmin-managed fields (name/dob/weight) from the POST so the
+      user can never override them
 
 ### Frontend
+- [ ] `frontend/src/components/profile/ProfileForm.tsx`: disable Name, DOB, Weight inputs,
+      add "Synced from Garmin" hint
 
-- [x] `frontend/src/api/client.ts` — Add `apiPut<T>` function
-
-- [x] `frontend/src/api/types.ts`
-  - Add `ZoneConfig`, `ZoneConfigUpdate`, `ZoneConfigBulkUpdate`, `ZoneConfigsResponse`
-  - Add `threshold_power` to `AthleteProfile` and `AthleteProfileRequest`
-
-- [x] `frontend/src/api/hooks.ts`
-  - Add `useZoneConfigs()` and `useUpdateZoneConfigs()` hooks
-
-- [x] `frontend/src/components/profile/ProfileForm.tsx`
-  - Add `threshold_power` field (FTP in watts)
-
-- [x] `frontend/src/components/settings/ZoneConfigSection.tsx` (new)
-  - Zone editor for HR, Pace, Power zones
-  - Editable zone names and % boundaries; shows computed absolute values from profile thresholds
-
-- [x] `frontend/src/components/settings/ZoneConfigSection.css` (new)
-
-- [x] `frontend/src/components/settings/SettingsView.tsx`
-  - Import and render `<ZoneConfigSection />`
-
-- [x] `frontend/src/components/activity-detail/PaceZonesChart.tsx` (new)
-  - Compute time-in-zone from chart_data pace series using custom zone configs
-  - Bar chart (matches HrZonesChart style)
-
-- [x] `frontend/src/components/activity-detail/PaceZonesChart.css` (new)
-
-- [x] `frontend/src/components/activity-detail/ActivityDetailView.tsx`
-  - Import and render `<PaceZonesChart />` for running activities with pace data
+### Verify
+- [ ] Backend unit tests for the new extraction + sync
+- [ ] Run pytest, run frontend build/typecheck
 
 ## Review
 
-All 15 checklist items complete. Build passes with no TypeScript errors.
+All checklist items complete.
 
 ### What was implemented
+**Backend**
+- `app/garmin_sync.py`: `sync_athlete_profile()` pulls name (`get_full_name`), date of
+  birth and weight from Garmin user settings (`get_user_profile().userData`), with a
+  body-composition fallback for weight. Upserts the singleton `AthleteProfile`,
+  always overwriting the three Garmin-managed fields; records `last_profile_sync`.
+- `app/main.py`: profile sync runs on startup backfill and in the daily scheduled sync.
+- `app/api.py`: `POST /athlete-profile` strips `name`/`date_of_birth`/`weight_kg` so the
+  client can never override Garmin-sourced values (authoritative server-side).
 
-**Backend:**
-- New `ZoneConfig` SQLAlchemy model with 15 seeded default zones (5 each for HR, pace, power)
-  using Coggan-style percentages of threshold values
-- `threshold_power` (FTP in watts) added to `AthleteProfile` model and migrated into the DB
-- New API endpoints `GET /api/v1/zones` and `PUT /api/v1/zones` for reading and editing zones
-- `_classify_by_zones()` function in `ai_coach.py` classifies HR and pace values using custom zones
-- AI context now annotates `Avg HR` and `Avg Pace` with the zone label when profile thresholds are set
+**Frontend**
+- `ProfileForm.tsx`: Name, Date of birth and Weight inputs are `disabled`/`readOnly`
+  with a "Synced from Garmin" hint; remaining fields stay editable.
 
-**Frontend:**
-- Settings page shows a "Training Zones" section with three zone editors (HR, Pace, Power)
-- Each zone shows editable name and % boundaries; computed absolute values appear once profile
-  thresholds are set
-- `FTP / Threshold power` field added to Athlete Profile form
-- New `PaceZonesChart` in Activity Detail computes time in each custom pace zone from chart data
+### Verification
+- Backend: full suite passes (301 tests), coverage 88% (CI gate 80%). New tests cover
+  field extraction, weight fallback, missing-data tolerance, profile upsert/overwrite,
+  and the API ignoring Garmin-managed fields. Updated existing athlete-profile API tests
+  to reflect the new read-only behavior.
+- Frontend: `tsc --noEmit` clean; vitest 50 tests pass.
+
+### Local env note
+`garminconnect==0.2.25` pulls `withings_sync`, whose wheel won't build on this box's
+setuptools (CI on py3.11 is fine). Installed garminconnect with `--no-deps` and added a
+tiny local `withings_sync.fit` stub purely to run tests; `fit` is only used by
+`add_body_composition`, which this change never calls.

--- a/tests/test_athlete_profile.py
+++ b/tests/test_athlete_profile.py
@@ -10,12 +10,8 @@ def test_get_returns_null_when_absent(client):
     assert resp.json() is None
 
 
-def test_post_creates_profile_and_computes_age(client):
-    dob = "1990-06-15"
+def test_post_creates_profile_with_editable_fields(client):
     payload = {
-        "name": "Sam Runner",
-        "date_of_birth": dob,
-        "weight_kg": 68.5,
         "goal_race": "Berlin Marathon",
         "goal_race_date": "2026-09-27",
         "threshold_hr": 168,
@@ -26,20 +22,57 @@ def test_post_creates_profile_and_computes_age(client):
     assert resp.status_code == 200
     body = resp.json()
     assert body["id"] >= 1
-    assert body["name"] == "Sam Runner"
-    assert body["age"] == calculate_age(date.fromisoformat(dob))
+    assert body["goal_race"] == "Berlin Marathon"
+    assert body["max_hr"] == 190
 
     # GET round-trips the same data
     fetched = client.get("/api/v1/athlete-profile").json()
     assert fetched["goal_race"] == "Berlin Marathon"
-    assert fetched["age"] == body["age"]
+    assert fetched["resting_hr"] == 48
+
+
+def test_post_ignores_garmin_managed_fields(client, db):
+    """Name, DOB, and weight are sourced from Garmin and must not be set via POST."""
+    # Seed Garmin-managed values as the sync would.
+    db.add(AthleteProfile(name="Garmin Name", date_of_birth=date(1990, 6, 15), weight_kg=68.5))
+    db.commit()
+
+    resp = client.post(
+        "/api/v1/athlete-profile",
+        json={
+            "name": "Hacker",
+            "date_of_birth": "2000-01-01",
+            "weight_kg": 99.9,
+            "max_hr": 190,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # Garmin-managed fields untouched; editable field applied.
+    assert body["name"] == "Garmin Name"
+    assert body["date_of_birth"] == "1990-06-15"
+    assert body["weight_kg"] == 68.5
+    assert body["max_hr"] == 190
+    assert body["age"] == calculate_age(date(1990, 6, 15))
+
+
+def test_post_does_not_create_garmin_fields(client):
+    """Posting only Garmin-managed fields creates a row without those values."""
+    resp = client.post(
+        "/api/v1/athlete-profile",
+        json={"name": "Ignore", "weight_kg": 80.0},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] is None
+    assert body["weight_kg"] is None
 
 
 def test_second_post_updates_in_place(client, db):
-    client.post("/api/v1/athlete-profile", json={"name": "First", "max_hr": 185})
-    resp = client.post("/api/v1/athlete-profile", json={"name": "Second", "max_hr": 188})
+    client.post("/api/v1/athlete-profile", json={"goal_race": "First", "max_hr": 185})
+    resp = client.post("/api/v1/athlete-profile", json={"goal_race": "Second", "max_hr": 188})
     assert resp.status_code == 200
-    assert resp.json()["name"] == "Second"
+    assert resp.json()["goal_race"] == "Second"
     # Singleton: exactly one row, not a duplicate insert.
     assert db.query(AthleteProfile).count() == 1
 
@@ -47,11 +80,10 @@ def test_second_post_updates_in_place(client, db):
 def test_partial_post_preserves_unspecified_fields(client):
     client.post(
         "/api/v1/athlete-profile",
-        json={"name": "Keep Me", "resting_hr": 50, "goal_race": "10K PB"},
+        json={"resting_hr": 50, "goal_race": "10K PB"},
     )
     # Update only one field; the others must remain.
     client.post("/api/v1/athlete-profile", json={"resting_hr": 46})
     body = client.get("/api/v1/athlete-profile").json()
     assert body["resting_hr"] == 46
-    assert body["name"] == "Keep Me"
     assert body["goal_race"] == "10K PB"

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from app import garmin_sync
-from app.models import Activity, DailySummary, GarminCalendarEvent, SyncStatus
+from app.models import Activity, AthleteProfile, DailySummary, GarminCalendarEvent, SyncStatus
 
 
 # --- _parse_garmin_ts ---
@@ -384,6 +384,72 @@ def test_sync_daily_summary_updates_existing(db, patch_db_session, monkeypatch):
     db.expire_all()
     assert db.query(DailySummary).filter(DailySummary.date == date(2026, 6, 10)).count() == 1
     assert db.query(DailySummary).filter(DailySummary.date == date(2026, 6, 10)).first().steps == 9999
+
+
+# --- athlete profile sync (Garmin client mocked) ---
+
+def _profile_client(weight_grams=70500, birth="1990-04-15"):
+    fake_client = MagicMock()
+    fake_client.get_full_name.return_value = "Jane Runner"
+    fake_client.get_user_profile.return_value = {
+        "userData": {"birthDate": birth, "weight": weight_grams}
+    }
+    return fake_client
+
+
+def test_fetch_garmin_profile_fields_from_user_data():
+    fields = garmin_sync._fetch_garmin_profile_fields(_profile_client())
+    assert fields["name"] == "Jane Runner"
+    assert fields["date_of_birth"] == date(1990, 4, 15)
+    assert fields["weight_kg"] == 70.5
+
+
+def test_fetch_garmin_profile_fields_weight_fallback():
+    fake_client = _profile_client(weight_grams=None)
+    fake_client.get_body_composition.return_value = {
+        "dateWeightList": [
+            {"date": "2026-06-01", "weight": 71000},
+            {"date": "2026-06-10", "weight": 70200},
+        ]
+    }
+    fields = garmin_sync._fetch_garmin_profile_fields(fake_client)
+    assert fields["weight_kg"] == 70.2  # latest non-null entry
+
+
+def test_fetch_garmin_profile_fields_tolerates_missing_data():
+    fake_client = MagicMock()
+    fake_client.get_full_name.return_value = None
+    fake_client.get_user_profile.return_value = {}
+    fake_client.get_body_composition.return_value = {}
+    assert garmin_sync._fetch_garmin_profile_fields(fake_client) == {}
+
+
+def test_sync_athlete_profile_creates_row(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", _profile_client)
+
+    profile = garmin_sync.sync_athlete_profile()
+    assert profile is not None
+    stored = db.query(AthleteProfile).first()
+    assert stored.name == "Jane Runner"
+    assert stored.date_of_birth == date(1990, 4, 15)
+    assert stored.weight_kg == 70.5
+
+
+def test_sync_athlete_profile_overwrites_garmin_fields_but_keeps_others(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    db.add(AthleteProfile(name="Old Name", weight_kg=80.0, goal_race="Berlin Marathon"))
+    db.commit()
+
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", _profile_client)
+    garmin_sync.sync_athlete_profile()
+    db.expire_all()
+
+    stored = db.query(AthleteProfile).first()
+    assert db.query(AthleteProfile).count() == 1
+    assert stored.name == "Jane Runner"
+    assert stored.weight_kg == 70.5
+    assert stored.goal_race == "Berlin Marathon"  # non-Garmin field untouched
 
 
 def test_backfill_activities_walks_pages(db, patch_db_session, monkeypatch):


### PR DESCRIPTION
Always pull the athlete's name, date of birth, and weight from Garmin and
make those fields read-only in the profile UI.

Backend:
- garmin_sync.sync_athlete_profile() fetches name (get_full_name), DOB and
  weight from Garmin user settings, with a body-composition fallback for
  weight, and upserts the singleton AthleteProfile, always overwriting the
  three Garmin-managed fields.
- Run the profile sync on startup backfill and in the daily scheduled sync.
- POST /athlete-profile ignores name/date_of_birth/weight_kg so the client
  can never override Garmin-sourced values.

Frontend:
- Disable the Name, Date of birth, and Weight inputs with a "Synced from
  Garmin" hint; other fields remain editable.

Tests:
- Cover field extraction, weight fallback, missing-data tolerance, and
  profile upsert/overwrite; update athlete-profile API tests for the new
  read-only behavior.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HQnRF18rj9F2e6nUNPMJvF