### PR TITLE
Add pace format conversion and sync resting HR from Garmin

### DIFF
--- a/app/garmin_sync.py
+++ b/app/garmin_sync.py
@@ -381,7 +381,7 @@ def _fetch_latest_garmin_weight(client: Garmin) -> float | None:
 
 
 def _fetch_garmin_profile_fields(client: Garmin) -> dict:
-    """Pull name, date of birth, and weight (kg) from Garmin user settings."""
+    """Pull name, date of birth, weight (kg), and resting HR from Garmin."""
     fields: dict = {}
 
     try:
@@ -406,13 +406,25 @@ def _fetch_garmin_profile_fields(client: Garmin) -> dict:
     if weight_g:
         fields["weight_kg"] = round(weight_g / 1000, 1)
 
+    # Resting HR: try today then yesterday (today's value may not be available yet)
+    try:
+        for delta in (0, 1):
+            day_str = (date.today() - timedelta(days=delta)).isoformat()
+            stats = client.get_stats(day_str) or {}
+            rhr = stats.get("restingHeartRate")
+            if rhr:
+                fields["resting_hr"] = rhr
+                break
+    except Exception:
+        logger.debug("Could not fetch Garmin resting HR", exc_info=True)
+
     return fields
 
 
 def sync_athlete_profile() -> AthleteProfile | None:
-    """Sync name, date of birth, and weight from Garmin into the athlete profile.
+    """Sync name, date of birth, weight, and resting HR from Garmin into the athlete profile.
 
-    These three fields are Garmin-managed (read-only in the UI), so the local
+    These fields are Garmin-managed (read-only in the UI), so the local
     values are always overwritten to stay in sync with Garmin.
     """
     logger.info("Syncing athlete profile from Garmin...")

--- a/frontend/src/components/profile/ProfileForm.tsx
+++ b/frontend/src/components/profile/ProfileForm.tsx
@@ -26,6 +26,25 @@ interface FormState {
   training_preferences: string
 }
 
+function paceToMmSs(val: number | null | undefined): string {
+  if (val === null || val === undefined) return ''
+  const mins = Math.floor(val)
+  const secs = Math.round((val - mins) * 60)
+  return `${mins}:${String(secs).padStart(2, '0')}`
+}
+
+function mmSsToFloat(val: string): number | null {
+  if (val.trim() === '') return null
+  const parts = val.split(':')
+  if (parts.length === 2) {
+    const mins = parseInt(parts[0], 10)
+    const secs = parseInt(parts[1], 10)
+    if (!isNaN(mins) && !isNaN(secs)) return mins + secs / 60
+  }
+  const n = parseFloat(val)
+  return isNaN(n) ? null : n
+}
+
 function toFormState(p?: AthleteProfile | null): FormState {
   const s = (v: string | number | null | undefined) => (v === null || v === undefined ? '' : String(v))
   return {
@@ -34,7 +53,7 @@ function toFormState(p?: AthleteProfile | null): FormState {
     weight_kg: s(p?.weight_kg),
     goal_race: s(p?.goal_race),
     goal_race_date: s(p?.goal_race_date),
-    threshold_pace_min_km: s(p?.threshold_pace_min_km),
+    threshold_pace_min_km: paceToMmSs(p?.threshold_pace_min_km),
     threshold_hr: s(p?.threshold_hr),
     threshold_power: s(p?.threshold_power),
     max_hr: s(p?.max_hr),
@@ -55,7 +74,7 @@ function toRequest(f: FormState): AthleteProfileRequest {
     weight_kg: num(f.weight_kg),
     goal_race: text(f.goal_race),
     goal_race_date: text(f.goal_race_date),
-    threshold_pace_min_km: num(f.threshold_pace_min_km),
+    threshold_pace_min_km: mmSsToFloat(f.threshold_pace_min_km),
     threshold_hr: num(f.threshold_hr),
     threshold_power: num(f.threshold_power),
     max_hr: num(f.max_hr),
@@ -112,8 +131,8 @@ export default function ProfileForm({ initial, onSubmit, isPending, isError, sub
 
       <div className="profile-form__row">
         <div className="profile-form__field">
-          <label htmlFor="pf-pace">Threshold pace (min/km)</label>
-          <input id="pf-pace" type="number" step="0.01" min="0" value={form.threshold_pace_min_km} onChange={set('threshold_pace_min_km')} />
+          <label htmlFor="pf-pace">Threshold pace (mm:ss/km)</label>
+          <input id="pf-pace" type="text" placeholder="mm:ss" value={form.threshold_pace_min_km} onChange={set('threshold_pace_min_km')} />
         </div>
         <div className="profile-form__field">
           <label htmlFor="pf-thr-hr">Threshold HR (bpm)</label>
@@ -135,7 +154,8 @@ export default function ProfileForm({ initial, onSubmit, isPending, isError, sub
         </div>
         <div className="profile-form__field">
           <label htmlFor="pf-rest-hr">Resting HR (bpm)</label>
-          <input id="pf-rest-hr" type="number" min="0" value={form.resting_hr} onChange={set('resting_hr')} />
+          <input id="pf-rest-hr" type="number" min="0" value={form.resting_hr} disabled readOnly />
+          <span className="profile-form__hint">Synced from Garmin</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Improves the athlete profile form by converting the threshold pace input to a user-friendly mm:ss format and adds automatic syncing of resting heart rate from Garmin.

## Key Changes

**Frontend (ProfileForm.tsx)**
- Added `paceToMmSs()` helper to convert decimal pace values to mm:ss format for display
- Added `mmSsToFloat()` helper to parse mm:ss input back to decimal for API submission
- Changed threshold pace input from `type="number"` to `type="text"` with mm:ss placeholder
- Updated label from "min/km" to "mm:ss/km" to clarify expected format
- Made resting HR field read-only and disabled, with hint text "Synced from Garmin"

**Backend (garmin_sync.py)**
- Extended `_fetch_garmin_profile_fields()` to fetch resting heart rate from Garmin stats
- Implements fallback logic: tries today's stats first, then yesterday (since today's value may not be available yet)
- Updated docstrings to reflect that resting HR is now synced alongside name, DOB, and weight
- Added error handling with debug logging for resting HR fetch failures

## Implementation Details

The pace conversion functions handle edge cases:
- `paceToMmSs()` returns empty string for null/undefined values
- `mmSsToFloat()` accepts both mm:ss format and raw decimal input for backward compatibility
- Resting HR fetch includes a 1-day lookback window to handle Garmin's delayed stat availability

https://claude.ai/code/session_01BRbSd4JEwsAbxcYcdGyohb