### PR TITLE
fix(tests): mock get_stats in Garmin profile test helpers

### DIFF
--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -394,6 +394,7 @@ def _profile_client(weight_grams=70500, birth="1990-04-15"):
     fake_client.get_user_profile.return_value = {
         "userData": {"birthDate": birth, "weight": weight_grams}
     }
+    fake_client.get_stats.return_value = {}
     return fake_client
 
 
@@ -421,6 +422,7 @@ def test_fetch_garmin_profile_fields_tolerates_missing_data():
     fake_client.get_full_name.return_value = None
     fake_client.get_user_profile.return_value = {}
     fake_client.get_body_composition.return_value = {}
+    fake_client.get_stats.return_value = {}
     assert garmin_sync._fetch_garmin_profile_fields(fake_client) == {}
 
 


### PR DESCRIPTION
The resting HR sync logic calls get_stats(), but the test mocks for
_profile_client and the tolerates-missing-data test didn't stub this
method. MagicMock auto-creates a truthy return value, causing resting_hr
to be set to a MagicMock object which SQLite can't bind.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UD5PuZMaz9m8xDBkMWZo1e