### PR TITLE
P3-5: bump anthropic SDK to 0.111.0 and refresh Claude model IDs

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 api_router = APIRouter(prefix="/api/v1", tags=["api"])
 
 AVAILABLE_MODELS: dict[str, list[str]] = {
-    "claude": ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
+    "claude": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
     "gemini": [
         "gemini-2.5-flash",
         "gemini-2.5-flash-lite",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ jinja2==3.1.4
 sqlalchemy==2.0.36
 aiosqlite==0.20.0
 garminconnect==0.2.25
-anthropic==0.42.0
+anthropic==0.111.0
 google-generativeai==0.8.6
 apscheduler==3.10.4
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary

- **`requirements.txt`**: bump `anthropic==0.42.0` → `0.111.0` (latest release)
- **`app/api.py`**: add `claude-opus-4-8` (current latest Opus) to `AVAILABLE_MODELS`; retain `claude-opus-4-7` for backward compatibility
- **`app/config.py`** / **`app/ai_coach.py`**: verified — `claude-sonnet-4-6` default is current, no hardcoded model IDs in ai_coach.py

## Test plan

- [ ] `pip install -r requirements.txt` installs without conflict
- [ ] `GET /api/v1/ai-config/models` returns `claude-opus-4-8` as a valid Claude option
- [ ] Existing tests pass (`tests/test_api_endpoints.py` — `claude-opus-4-7` still in list)
- [ ] AI chat still works end-to-end with the default `claude-sonnet-4-6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FFNTrxzqrJz4VwScjMkmm

---
_Generated by [Claude Code](https://claude.ai/code/session_016FFNTrxzqrJz4VwScjMkmm)_