### PR TITLE
feat(p3-1): data export — CSV/JSON endpoints + Settings UI

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,10 +1,13 @@
 import calendar as cal_mod
+import csv
+import io
 import json
 import logging
 import threading
 from datetime import date, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response, StreamingResponse
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -842,6 +845,72 @@ def api_trigger_sync(sync_type: str):
     else:
         raise HTTPException(status_code=400, detail=f"Unknown sync type: {sync_type}")
     return {"status": "accepted"}
+
+
+# --- Data Export ---
+
+@api_router.get("/export/activities")
+def api_export_activities(
+    format: str = Query("csv", pattern="^(csv|json)$"),
+    db: Session = Depends(get_db),
+):
+    activities = db.query(Activity).order_by(Activity.started_at.desc()).all()
+
+    if format == "json":
+        data = [ActivitySummary.model_validate(a).model_dump() for a in activities]
+        content = json.dumps(data, default=str, indent=2)
+        return Response(
+            content=content,
+            media_type="application/json",
+            headers={"Content-Disposition": "attachment; filename=activities.json"},
+        )
+
+    fields = [
+        "id", "garmin_id", "activity_type", "name", "started_at",
+        "duration_sec", "distance_m", "avg_hr", "max_hr",
+        "avg_pace_min_km", "calories", "elevation_gain",
+    ]
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=fields, extrasaction="ignore")
+    writer.writeheader()
+    for a in activities:
+        row = ActivitySummary.model_validate(a).model_dump()
+        writer.writerow({k: ("" if row[k] is None else str(row[k])) for k in fields})
+    return StreamingResponse(
+        io.BytesIO(output.getvalue().encode()),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=activities.csv"},
+    )
+
+
+@api_router.get("/export/insights")
+def api_export_insights(
+    format: str = Query("csv", pattern="^(csv|json)$"),
+    db: Session = Depends(get_db),
+):
+    insights = db.query(Insight).order_by(Insight.created_at.desc()).all()
+
+    if format == "json":
+        data = [InsightResponse.model_validate(i).model_dump() for i in insights]
+        content = json.dumps(data, default=str, indent=2)
+        return Response(
+            content=content,
+            media_type="application/json",
+            headers={"Content-Disposition": "attachment; filename=insights.json"},
+        )
+
+    fields = ["id", "created_at", "trigger_type", "trigger_id", "category", "summary", "content"]
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=fields, extrasaction="ignore")
+    writer.writeheader()
+    for i in insights:
+        row = InsightResponse.model_validate(i).model_dump()
+        writer.writerow({k: ("" if row[k] is None else str(row[k])) for k in fields})
+    return StreamingResponse(
+        io.BytesIO(output.getvalue().encode()),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=insights.csv"},
+    )
 
 
 # --- Workout Step Parsing (delegated to app.adherence) ---

--- a/frontend/src/components/settings/SettingsView.css
+++ b/frontend/src/components/settings/SettingsView.css
@@ -130,3 +130,14 @@
   font-size: 0.78rem;
   color: #e74c3c;
 }
+
+.export-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+
+.export-btn {
+  text-decoration: none;
+  text-align: center;
+}

--- a/frontend/src/components/settings/SettingsView.tsx
+++ b/frontend/src/components/settings/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { RefreshCw } from 'lucide-react'
+import { Download, RefreshCw } from 'lucide-react'
 import { useSettings, useTriggerSync, useAiConfig, useSetAiConfig } from '../../api/hooks'
 import AthleteProfileSection from './AthleteProfileSection'
 import ThresholdEstimateSection from './ThresholdEstimateSection'
@@ -64,6 +64,29 @@ function AiBackendSection() {
   )
 }
 
+const EXPORT_LINKS = [
+  { label: 'Activities CSV', url: '/api/v1/export/activities?format=csv', filename: 'activities.csv' },
+  { label: 'Activities JSON', url: '/api/v1/export/activities?format=json', filename: 'activities.json' },
+  { label: 'Insights CSV', url: '/api/v1/export/insights?format=csv', filename: 'insights.csv' },
+  { label: 'Insights JSON', url: '/api/v1/export/insights?format=json', filename: 'insights.json' },
+]
+
+function DataExportSection() {
+  return (
+    <section className="settings-section">
+      <h2 className="section-title">Data Export</h2>
+      <div className="export-buttons">
+        {EXPORT_LINKS.map(({ label, url, filename }) => (
+          <a key={url} href={url} download={filename} className="sync-btn export-btn">
+            <Download size={16} />
+            {label}
+          </a>
+        ))}
+      </div>
+    </section>
+  )
+}
+
 export default function SettingsView() {
   const { data, isLoading } = useSettings()
   const syncMutation = useTriggerSync()
@@ -84,6 +107,9 @@ export default function SettingsView() {
 
       {/* AI backend selector */}
       <AiBackendSection />
+
+      {/* Data export */}
+      <DataExportSection />
 
       {/* Database stats */}
       <section className="settings-section">


### PR DESCRIPTION
## Summary

- **Backend**: adds `GET /api/v1/export/activities?format=csv|json` and `GET /api/v1/export/insights?format=csv|json` — both return a downloadable file via `Content-Disposition: attachment`
- **Frontend**: adds a "Data Export" section in Settings with four anchor-tag download buttons (Activities CSV, Activities JSON, Insights CSV, Insights JSON)

## What changed

| File | Change |
|---|---|
| `app/api.py` | Two new export endpoints using `csv.DictWriter` / `json.dumps` + FastAPI `StreamingResponse`/`Response` |
| `frontend/src/components/settings/SettingsView.tsx` | `DataExportSection` component with `<a download>` links styled as buttons |
| `frontend/src/components/settings/SettingsView.css` | `.export-buttons` (2-column grid) + `.export-btn` styles |

## Test plan

- [ ] `GET /api/v1/export/activities?format=csv` returns a CSV file with header row and one row per activity
- [ ] `GET /api/v1/export/activities?format=json` returns a JSON array of activity objects
- [ ] `GET /api/v1/export/insights?format=csv` and `?format=json` behave equivalently for insights
- [ ] Settings page shows "Data Export" section with four buttons that trigger browser downloads
- [ ] TypeScript type check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ScieX5BhFm2m987RPs2fn

---
_Generated by [Claude Code](https://claude.ai/code/session_013ScieX5BhFm2m987RPs2fn)_