### PR TITLE
Fix light theme color issues in zone inputs and workout step headers

### DIFF
--- a/frontend/src/components/activity-detail/AdherenceCard.css
+++ b/frontend/src/components/activity-detail/AdherenceCard.css
@@ -68,7 +68,7 @@
 
 .adherence-actual {
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--text);
 }
 
 .adherence-delta {

--- a/frontend/src/components/settings/ThresholdEstimateSection.css
+++ b/frontend/src/components/settings/ThresholdEstimateSection.css
@@ -45,7 +45,7 @@
 
 .te-label {
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--text);
   display: flex;
   flex-direction: column;
 }
@@ -58,7 +58,7 @@
 
 .te-value {
   font-variant-numeric: tabular-nums;
-  color: var(--text-primary);
+  color: var(--text);
 }
 
 .te-current {

--- a/frontend/src/components/settings/ZoneConfigSection.css
+++ b/frontend/src/components/settings/ZoneConfigSection.css
@@ -26,7 +26,7 @@
 .zone-type-title {
   font-weight: 600;
   font-size: 0.9rem;
-  color: var(--text-primary);
+  color: var(--text);
 }
 
 .zone-type-threshold {
@@ -82,20 +82,20 @@
 }
 
 .zone-name-input {
-  background: var(--surface-2, #1e1e2e);
-  border: 1px solid var(--border, #2d2d44);
+  background: var(--bg-input);
+  border: 1px solid var(--border);
   border-radius: 6px;
-  color: var(--text-primary);
+  color: var(--text);
   font-size: 0.82rem;
   padding: 4px 8px;
   width: 100%;
 }
 
 .zone-pct-input {
-  background: var(--surface-2, #1e1e2e);
-  border: 1px solid var(--border, #2d2d44);
+  background: var(--bg-input);
+  border: 1px solid var(--border);
   border-radius: 6px;
-  color: var(--text-primary);
+  color: var(--text);
   font-size: 0.82rem;
   padding: 4px 6px;
   text-align: right;

--- a/frontend/src/components/today/WorkoutSteps.css
+++ b/frontend/src/components/today/WorkoutSteps.css
@@ -28,6 +28,11 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.sw-section-header--repeat .sw-section-label,
+.sw-section-header--session .sw-section-label {
   color: rgba(255, 255, 255, 0.9);
 }
 


### PR DESCRIPTION
- ZoneConfigSection: replace undefined --surface-2/#1e1e2e and --text-primary
  with --bg-input and --text so inputs render correctly in both themes
- WorkoutSteps: scope white label color to gradient section headers only;
  Warm-Up/Cool Down headers now use --text-muted against their neutral bg
- ThresholdEstimateSection, AdherenceCard: fix --text-primary → --text

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BwDwHnSs7rhTH3nmevVvAh