### PR TITLE
fix: add gap between adherence and secondary stats sections

### DIFF
--- a/frontend/src/components/activity-detail/ActivityDetailView.tsx
+++ b/frontend/src/components/activity-detail/ActivityDetailView.tsx
@@ -102,7 +102,11 @@ export default function ActivityDetailView() {
         )}
 
         {/* Secondary stats */}
-        {secondaryStats.length > 0 && <StatGrid stats={secondaryStats} columns={3} />}
+        {secondaryStats.length > 0 && (
+          <section className="detail-section">
+            <StatGrid stats={secondaryStats} columns={3} />
+          </section>
+        )}
 
         {/* Running dynamics */}
         {dynamicsStats.length > 0 && (


### PR DESCRIPTION
Secondary stats StatGrid was not wrapped in a detail-section, causing
it to render flush against the adherence card with no spacing.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015EXsocNefG6p8aP7Gkg2ys