### PR TITLE
Exclude rest periods from workout adherence distance and pace

### DIFF
--- a/app/adherence.py
+++ b/app/adherence.py
@@ -34,8 +34,7 @@ def _format_pace(meters_per_sec: float) -> str:
     if meters_per_sec <= 0:
         return ""
     pace_sec_per_km = 1000.0 / meters_per_sec
-    mins = int(pace_sec_per_km // 60)
-    secs = int(pace_sec_per_km % 60)
+    mins, secs = divmod(int(round(pace_sec_per_km)), 60)
     return f"{mins}:{secs:02d}/km"
 
 
@@ -215,6 +214,86 @@ def _parse_pace_display(pace_display: str) -> float | None:
     return _parse_single_pace(pace_str)
 
 
+# Lap intensity types that represent rest/recovery (not running distance).
+_REST_INTENSITY_TYPES = {"REST", "RECOVERY"}
+
+
+def _step_distance_m(step: WorkoutStepResponse, pace_sec_per_km: float | None) -> float | None:
+    """Distance contribution of a single step.
+
+    Distance-based steps return their value directly. Time-based steps are
+    converted to distance using ``pace_sec_per_km`` (the step's own target pace
+    or a fallback). Returns ``None`` when the step has no measurable distance
+    (e.g. a time-based step with no pace available, or a lap-button step).
+    """
+    if step.end_condition == "distance" and step.end_condition_value:
+        return step.end_condition_value
+    if step.end_condition == "time" and step.end_condition_value and pace_sec_per_km:
+        return step.end_condition_value / pace_sec_per_km * 1000.0
+    return None
+
+
+def _actual_from_splits(
+    activity: Activity,
+) -> tuple[float | None, float | None, float | None]:
+    """Derive running/rest distance and running-only pace from Garmin laps.
+
+    Reads ``activity.splits_json`` (``lapDTOs``) and classifies each lap by its
+    ``intensityType``: REST/RECOVERY laps count as rest, everything else as
+    running. Returns ``(running_dist_m, rest_dist_m, running_pace_sec_per_km)``.
+
+    Falls back to the activity totals (whole-activity distance and average
+    pace, no rest split) when per-lap data is unavailable or unusable.
+    """
+    running_dist = 0.0
+    rest_dist = 0.0
+    running_dur = 0.0
+    saw_lap = False
+
+    if activity.splits_json:
+        try:
+            data = json.loads(activity.splits_json)
+        except (json.JSONDecodeError, TypeError):
+            data = None
+        laps = data.get("lapDTOs") if isinstance(data, dict) else None
+        if isinstance(laps, list):
+            for lap in laps:
+                if not isinstance(lap, dict):
+                    continue
+                dist = lap.get("distance")
+                if not isinstance(dist, (int, float)) or dist <= 0:
+                    continue
+                saw_lap = True
+                intensity = str(lap.get("intensityType") or "").upper()
+                if intensity in _REST_INTENSITY_TYPES:
+                    rest_dist += dist
+                else:
+                    running_dist += dist
+                    dur = (
+                        lap.get("duration")
+                        or lap.get("movingDuration")
+                        or lap.get("elapsedDuration")
+                    )
+                    if isinstance(dur, (int, float)) and dur > 0:
+                        running_dur += dur
+
+    if not saw_lap:
+        # Fallback: no per-lap data — use whole-activity totals, no rest split.
+        actual_pace_sec = (
+            activity.avg_pace_min_km * 60 if activity.avg_pace_min_km else None
+        )
+        return activity.distance_m, None, actual_pace_sec
+
+    running_pace_sec = (
+        running_dur / (running_dist / 1000.0) if running_dist > 0 and running_dur > 0 else None
+    )
+    return (
+        running_dist or None,
+        rest_dist or None,
+        running_pace_sec,
+    )
+
+
 def compute_adherence(
     activity: Activity,
     workout_steps: list[WorkoutStepResponse],
@@ -228,13 +307,9 @@ def compute_adherence(
 
     flat = _flatten_steps(workout_steps)
 
-    # --- Planned distance (sum of all distance-based steps, including recovery) ---
-    planned_distance_m: float | None = None
-    for step in flat:
-        if step.end_condition == "distance" and step.end_condition_value:
-            planned_distance_m = (planned_distance_m or 0.0) + step.end_condition_value
-
     # --- Planned pace: first interval step with a concrete pace target ---
+    # Computed first so it can serve as the fallback pace when converting
+    # time-based steps (warmup/cooldown/intervals given in time) to distance.
     planned_pace_display: str | None = None
     planned_pace_sec: float | None = None
     for step in flat:
@@ -244,6 +319,23 @@ def compute_adherence(
                 planned_pace_display = step.target_display
                 planned_pace_sec = parsed
                 break
+
+    # --- Planned distance: running periods only (warmup + cooldown + intervals).
+    # Rest/recovery is excluded and tracked separately. Time-based running steps
+    # are converted to distance via their own target pace, falling back to the
+    # workout's planned interval pace. ---
+    planned_distance_m: float | None = None
+    planned_rest_distance_m: float | None = None
+    for step in flat:
+        step_pace = _parse_pace_display(step.target_display) if step.target_display else None
+        pace = step_pace or planned_pace_sec
+        dist = _step_distance_m(step, pace)
+        if dist is None:
+            continue
+        if step.activity_type == "rest":
+            planned_rest_distance_m = (planned_rest_distance_m or 0.0) + dist
+        else:
+            planned_distance_m = (planned_distance_m or 0.0) + dist
 
     # --- Planned interval count (unique interval steps after expansion) ---
     planned_intervals = sum(1 for s in flat if s.step_type == "interval") or None
@@ -258,19 +350,19 @@ def compute_adherence(
         except (json.JSONDecodeError, TypeError):
             pass
 
-    # --- Actual pace display ---
-    actual_pace_display: str | None = None
-    actual_pace_sec: float | None = None
-    if activity.avg_pace_min_km:
-        p_min = int(activity.avg_pace_min_km)
-        p_sec = int((activity.avg_pace_min_km - p_min) * 60)
-        actual_pace_display = f"{p_min}:{p_sec:02d}/km"
-        actual_pace_sec = activity.avg_pace_min_km * 60
+    # --- Actual running distance / rest distance / running-only pace ---
+    actual_distance_m, actual_rest_distance_m, actual_pace_sec = _actual_from_splits(activity)
 
-    # --- Distance adherence ---
+    actual_pace_display: str | None = None
+    if actual_pace_sec:
+        p_min = int(actual_pace_sec // 60)
+        p_sec = int(actual_pace_sec % 60)
+        actual_pace_display = f"{p_min}:{p_sec:02d}/km"
+
+    # --- Distance adherence (running-only on both sides) ---
     distance_pct: float | None = None
-    if planned_distance_m and activity.distance_m:
-        distance_pct = min(100.0, (activity.distance_m / planned_distance_m) * 100.0)
+    if planned_distance_m and actual_distance_m:
+        distance_pct = min(100.0, (actual_distance_m / planned_distance_m) * 100.0)
 
     # --- Pace delta (positive = slower than plan) ---
     pace_delta_sec: float | None = None
@@ -301,10 +393,14 @@ def compute_adherence(
         summary_parts.append(f"{delta_str}/km {direction} than target")
     if not summary_parts:
         summary_parts.append("Workout completed (no distance/pace plan to compare)")
+    if actual_rest_distance_m:
+        summary_parts.append(f"{int(round(actual_rest_distance_m))} m in rest")
 
     return WorkoutAdherence(
         planned_distance_m=planned_distance_m,
-        actual_distance_m=activity.distance_m,
+        planned_rest_distance_m=planned_rest_distance_m,
+        actual_distance_m=actual_distance_m,
+        actual_rest_distance_m=actual_rest_distance_m,
         distance_pct=round(distance_pct, 1) if distance_pct is not None else None,
         planned_pace_display=planned_pace_display,
         actual_pace_display=actual_pace_display,
@@ -320,9 +416,14 @@ def format_adherence_context(adherence: WorkoutAdherence) -> str:
     """Format adherence data as a markdown section for the AI coach."""
     lines = [f"## Workout Adherence\n{adherence.summary}"]
     if adherence.planned_distance_m is not None and adherence.actual_distance_m is not None:
+        rest_note = (
+            f" (+{int(round(adherence.actual_rest_distance_m))} m rest)"
+            if adherence.actual_rest_distance_m
+            else ""
+        )
         lines.append(
-            f"Distance: planned {adherence.planned_distance_m / 1000:.2f} km"
-            f" / actual {adherence.actual_distance_m / 1000:.2f} km"
+            f"Distance (running only): planned {adherence.planned_distance_m / 1000:.2f} km"
+            f" / actual {adherence.actual_distance_m / 1000:.2f} km{rest_note}"
             + (f" ({adherence.distance_pct:.0f}%)" if adherence.distance_pct is not None else "")
         )
     if adherence.planned_pace_display and adherence.actual_pace_display:

--- a/app/adherence.py
+++ b/app/adherence.py
@@ -217,6 +217,11 @@ def _parse_pace_display(pace_display: str) -> float | None:
 # Lap intensity types that represent rest/recovery (not running distance).
 _REST_INTENSITY_TYPES = {"REST", "RECOVERY"}
 
+# Lap intensity types that are run at an easy, untargeted pace. They count
+# toward running distance but are excluded from the pace comparison, which is
+# anchored on the workout's interval/tempo target pace.
+_EASY_INTENSITY_TYPES = {"WARMUP", "WARM_UP", "COOLDOWN", "COOL_DOWN"}
+
 
 def _step_distance_m(step: WorkoutStepResponse, pace_sec_per_km: float | None) -> float | None:
     """Distance contribution of a single step.
@@ -236,18 +241,30 @@ def _step_distance_m(step: WorkoutStepResponse, pace_sec_per_km: float | None) -
 def _actual_from_splits(
     activity: Activity,
 ) -> tuple[float | None, float | None, float | None]:
-    """Derive running/rest distance and running-only pace from Garmin laps.
+    """Derive running/rest distance and work-interval pace from Garmin laps.
 
     Reads ``activity.splits_json`` (``lapDTOs``) and classifies each lap by its
-    ``intensityType``: REST/RECOVERY laps count as rest, everything else as
-    running. Returns ``(running_dist_m, rest_dist_m, running_pace_sec_per_km)``.
+    ``intensityType``:
+
+    - REST/RECOVERY → rest distance (excluded from distance and pace).
+    - WARMUP/COOLDOWN → count toward running distance but NOT toward the pace
+      average (they're run easy with no pace target, so including them would
+      unfairly drag the average away from the interval/tempo target).
+    - everything else (ACTIVE/INTERVAL/untyped) → "work" laps that drive both
+      running distance and the pace average.
+
+    Returns ``(running_dist_m, rest_dist_m, work_pace_sec_per_km)``. The pace
+    falls back to all running laps when no work laps are distinguishable.
 
     Falls back to the activity totals (whole-activity distance and average
     pace, no rest split) when per-lap data is unavailable or unusable.
     """
-    running_dist = 0.0
+    running_dist = 0.0          # all non-rest distance (warmup + cooldown + work)
     rest_dist = 0.0
-    running_dur = 0.0
+    work_dist = 0.0             # work-interval distance only (for pace)
+    work_dur = 0.0
+    run_dist = 0.0              # all running distance/duration (pace fallback)
+    run_dur = 0.0
     saw_lap = False
 
     if activity.splits_json:
@@ -267,15 +284,19 @@ def _actual_from_splits(
                 intensity = str(lap.get("intensityType") or "").upper()
                 if intensity in _REST_INTENSITY_TYPES:
                     rest_dist += dist
-                else:
-                    running_dist += dist
-                    dur = (
-                        lap.get("duration")
-                        or lap.get("movingDuration")
-                        or lap.get("elapsedDuration")
-                    )
-                    if isinstance(dur, (int, float)) and dur > 0:
-                        running_dur += dur
+                    continue
+                running_dist += dist
+                dur = (
+                    lap.get("duration")
+                    or lap.get("movingDuration")
+                    or lap.get("elapsedDuration")
+                )
+                dur = dur if isinstance(dur, (int, float)) and dur > 0 else 0.0
+                run_dist += dist
+                run_dur += dur
+                if intensity not in _EASY_INTENSITY_TYPES:
+                    work_dist += dist
+                    work_dur += dur
 
     if not saw_lap:
         # Fallback: no per-lap data — use whole-activity totals, no rest split.
@@ -284,13 +305,19 @@ def _actual_from_splits(
         )
         return activity.distance_m, None, actual_pace_sec
 
-    running_pace_sec = (
-        running_dur / (running_dist / 1000.0) if running_dist > 0 and running_dur > 0 else None
-    )
+    # Pace from work intervals only; fall back to all running laps when no work
+    # laps are distinguishable (e.g. a steady run with only warmup/cooldown).
+    if work_dist > 0 and work_dur > 0:
+        pace_sec = work_dur / (work_dist / 1000.0)
+    elif run_dist > 0 and run_dur > 0:
+        pace_sec = run_dur / (run_dist / 1000.0)
+    else:
+        pace_sec = None
+
     return (
         running_dist or None,
         rest_dist or None,
-        running_pace_sec,
+        pace_sec,
     )
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -57,8 +57,10 @@ class FeedbackRequest(BaseModel):
 
 
 class WorkoutAdherence(BaseModel):
-    planned_distance_m: float | None = None
-    actual_distance_m: float | None = None
+    planned_distance_m: float | None = None    # running periods only (rest excluded)
+    planned_rest_distance_m: float | None = None
+    actual_distance_m: float | None = None     # running distance (rest excluded)
+    actual_rest_distance_m: float | None = None  # distance covered during rest laps
     distance_pct: float | None = None          # actual / planned × 100, capped at 100
     planned_pace_display: str | None = None    # e.g. "4:30/km"
     actual_pace_display: str | None = None     # e.g. "4:38/km"

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -30,8 +30,10 @@ export interface FeedbackRequest {
 }
 
 export interface WorkoutAdherence {
-  planned_distance_m: number | null
-  actual_distance_m: number | null
+  planned_distance_m: number | null        // running periods only (rest excluded)
+  planned_rest_distance_m: number | null
+  actual_distance_m: number | null         // running distance (rest excluded)
+  actual_rest_distance_m: number | null    // distance covered during rest laps
   distance_pct: number | null
   planned_pace_display: string | null
   actual_pace_display: string | null

--- a/frontend/src/components/activity-detail/AdherenceCard.tsx
+++ b/frontend/src/components/activity-detail/AdherenceCard.tsx
@@ -52,7 +52,10 @@ export default function AdherenceCard({ adherence }: Props) {
                 {((adherence.planned_distance_m ?? 0) / 1000).toFixed(2)} km planned
               </span>
               <span className="adherence-actual">
-                {((adherence.actual_distance_m ?? 0) / 1000).toFixed(2)} km actual
+                {((adherence.actual_distance_m ?? 0) / 1000).toFixed(2)} km
+                {adherence.actual_rest_distance_m
+                  ? ` (+${Math.round(adherence.actual_rest_distance_m)} m rest)`
+                  : ''} actual
               </span>
               {adherence.distance_pct !== null && (
                 <span

--- a/tests/test_adherence.py
+++ b/tests/test_adherence.py
@@ -19,10 +19,11 @@ def make_steps(raw_list):
 
 
 class FakeActivity:
-    def __init__(self, distance_m=None, avg_pace_min_km=None, laps_json=None):
+    def __init__(self, distance_m=None, avg_pace_min_km=None, laps_json=None, splits_json=None):
         self.distance_m = distance_m
         self.avg_pace_min_km = avg_pace_min_km
         self.laps_json = laps_json
+        self.splits_json = splits_json
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +210,131 @@ def test_compute_adherence_no_distance_no_pace():
     assert result.planned_pace_display is None
     assert result.adherence_score == 100.0
     assert "no distance" in result.summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Rest-aware distance & pace (running-only)
+# ---------------------------------------------------------------------------
+
+def test_planned_distance_excludes_rest():
+    """Rest steps are excluded from planned distance and tracked separately."""
+    steps = make_steps([
+        {"stepType": "warmup", "endCondition": "distance", "endConditionValue": 1000},
+        {"stepType": "repeat", "repeatCount": 4, "workoutSteps": [
+            {"stepType": "interval", "endCondition": "distance", "endConditionValue": 1000,
+             "targetType": "pace", "targetValueOne": 1000 / 240},  # 4:00/km
+            {"stepType": "rest", "endCondition": "distance", "endConditionValue": 200},
+        ]},
+        {"stepType": "cooldown", "endCondition": "distance", "endConditionValue": 1000},
+    ])
+    activity = FakeActivity(distance_m=6800.0)
+    result = adh.compute_adherence(activity, steps)
+
+    # running = 1000 warmup + 4×1000 intervals + 1000 cooldown = 6000
+    assert result.planned_distance_m == pytest.approx(6000.0)
+    # rest = 4 × 200 = 800
+    assert result.planned_rest_distance_m == pytest.approx(800.0)
+
+
+def test_planned_distance_time_based_running_interval():
+    """A running interval given in time is converted to distance via its pace."""
+    steps = make_steps([
+        {"stepType": "repeat", "repeatCount": 6, "workoutSteps": [
+            {"stepType": "interval", "endCondition": "time", "endConditionValue": 60,
+             "targetType": "pace", "targetValueOne": 1000 / 240},  # 4:00/km → 250 m/min
+            {"stepType": "rest", "endCondition": "time", "endConditionValue": 90},
+        ]},
+    ])
+    activity = FakeActivity(distance_m=1500.0)
+    result = adh.compute_adherence(activity, steps)
+
+    # 6 × (60s at 4:00/km = 250 m) = 1500 m running
+    assert result.planned_distance_m == pytest.approx(1500.0)
+
+
+def test_time_interval_without_pace_uses_planned_pace_fallback():
+    """A time-based step with no target falls back to the workout's planned pace."""
+    steps = make_steps([
+        {"stepType": "warm_up", "endCondition": "time", "endConditionValue": 240},  # no pace
+        {"stepType": "interval", "endCondition": "distance", "endConditionValue": 3000,
+         "targetType": "pace", "targetValueOne": 1000 / 240},  # 4:00/km
+    ])
+    activity = FakeActivity(distance_m=4000.0)
+    result = adh.compute_adherence(activity, steps)
+
+    # warmup 240s @ 4:00/km (fallback) = 1000 m, + 3000 m interval = 4000 m
+    assert result.planned_distance_m == pytest.approx(4000.0)
+
+
+def test_actual_from_splits_rest_and_running_pace():
+    """Actual running/rest distance and running-only pace come from lapDTOs."""
+    steps = make_steps([
+        {"stepType": "interval", "endCondition": "distance", "endConditionValue": 6000,
+         "targetType": "pace", "targetValueOne": 1000 / 240},  # 4:00/km plan
+    ])
+    laps = {"lapDTOs": [
+        {"distance": 3000, "duration": 720, "intensityType": "ACTIVE"},   # 4:00/km
+        {"distance": 245, "duration": 90, "intensityType": "REST"},
+        {"distance": 3000, "duration": 720, "intensityType": "ACTIVE"},   # 4:00/km
+        {"distance": 245, "duration": 90, "intensityType": "RECOVERY"},
+    ]}
+    activity = FakeActivity(
+        distance_m=6490.0, avg_pace_min_km=5.0,  # overall avg slower (includes rest)
+        splits_json=json.dumps(laps),
+    )
+    result = adh.compute_adherence(activity, steps)
+
+    assert result.actual_distance_m == pytest.approx(6000.0)        # running only
+    assert result.actual_rest_distance_m == pytest.approx(490.0)    # rest laps
+    assert result.actual_pace_display == "4:00/km"                  # running-only, not 5:00
+    assert result.pace_delta_sec_per_km == pytest.approx(0.0, abs=1.0)
+    assert "490 m in rest" in result.summary
+
+
+def test_worked_example_8km_plus_490m_rest():
+    """Reproduce the target: 8.00 km planned / 8.00 km (+490 m rest) actual."""
+    steps = make_steps([
+        {"stepType": "warmup", "endCondition": "distance", "endConditionValue": 1000},
+        {"stepType": "repeat", "repeatCount": 6, "workoutSteps": [
+            {"stepType": "interval", "endCondition": "distance", "endConditionValue": 1000,
+             "targetType": "pace", "targetValueOne": 1000 / 240},
+            {"stepType": "rest", "endCondition": "time", "endConditionValue": 90},
+        ]},
+        {"stepType": "cooldown", "endCondition": "distance", "endConditionValue": 1000},
+    ])
+    # 6 running laps + warmup + cooldown = 8 running laps (8 km), 6 rest laps (490 m)
+    lap_dtos = (
+        [{"distance": 1000, "duration": 240, "intensityType": "WARMUP"}]
+        + [
+            lap
+            for _ in range(6)
+            for lap in (
+                {"distance": 1000, "duration": 240, "intensityType": "INTERVAL"},
+                {"distance": 81.67, "duration": 90, "intensityType": "REST"},
+            )
+        ]
+        + [{"distance": 1000, "duration": 240, "intensityType": "COOLDOWN"}]
+    )
+    activity = FakeActivity(distance_m=8490.0, splits_json=json.dumps({"lapDTOs": lap_dtos}))
+    result = adh.compute_adherence(activity, steps)
+
+    assert result.planned_distance_m == pytest.approx(8000.0)
+    assert f"{result.actual_distance_m / 1000:.2f}" == "8.00"
+    assert int(round(result.actual_rest_distance_m)) == 490
+    assert result.distance_pct == 100.0
+
+
+def test_actual_fallback_no_splits_uses_totals():
+    """Without lapDTOs, actual falls back to activity totals (no rest split)."""
+    steps = make_steps([
+        {"stepType": "interval", "endCondition": "distance", "endConditionValue": 5000},
+    ])
+    activity = FakeActivity(distance_m=4800.0, avg_pace_min_km=4.5)
+    result = adh.compute_adherence(activity, steps)
+
+    assert result.actual_distance_m == 4800.0
+    assert result.actual_rest_distance_m is None
+    assert result.actual_pace_display == "4:30/km"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_adherence.py
+++ b/tests/test_adherence.py
@@ -337,6 +337,49 @@ def test_actual_fallback_no_splits_uses_totals():
     assert result.actual_pace_display == "4:30/km"
 
 
+def test_actual_pace_excludes_warmup_cooldown():
+    """Warmup/cooldown laps count toward distance but not the pace average.
+
+    The intervals are run on target (4:00/km) while the warmup/cooldown are
+    easy (6:00/km). Pace adherence should reflect the on-target intervals, not
+    a blended average dragged slower by the easy laps.
+    """
+    steps = make_steps([
+        {"stepType": "warmup", "endCondition": "distance", "endConditionValue": 1000},
+        {"stepType": "interval", "endCondition": "distance", "endConditionValue": 4000,
+         "targetType": "pace", "targetValueOne": 1000 / 240},  # 4:00/km plan
+        {"stepType": "cooldown", "endCondition": "distance", "endConditionValue": 1000},
+    ])
+    laps = {"lapDTOs": [
+        {"distance": 1000, "duration": 360, "intensityType": "WARMUP"},    # 6:00/km
+        {"distance": 4000, "duration": 960, "intensityType": "INTERVAL"},  # 4:00/km
+        {"distance": 1000, "duration": 360, "intensityType": "COOLDOWN"},  # 6:00/km
+    ]}
+    activity = FakeActivity(distance_m=6000.0, splits_json=json.dumps(laps))
+    result = adh.compute_adherence(activity, steps)
+
+    assert result.actual_distance_m == pytest.approx(6000.0)  # incl. warmup/cooldown
+    assert result.actual_pace_display == "4:00/km"            # work intervals only
+    assert result.pace_delta_sec_per_km == pytest.approx(0.0, abs=1.0)
+    assert result.adherence_score >= 95.0
+
+
+def test_actual_pace_fallback_when_no_work_laps():
+    """With only warmup/cooldown laps, pace falls back to all running laps."""
+    steps = make_steps([
+        {"stepType": "interval", "endCondition": "distance", "endConditionValue": 5000,
+         "targetType": "pace", "targetValueOne": 1000 / 270},  # 4:30/km plan
+    ])
+    laps = {"lapDTOs": [
+        {"distance": 2500, "duration": 675, "intensityType": "WARMUP"},   # 4:30/km
+        {"distance": 2500, "duration": 675, "intensityType": "COOLDOWN"}, # 4:30/km
+    ]}
+    activity = FakeActivity(distance_m=5000.0, splits_json=json.dumps(laps))
+    result = adh.compute_adherence(activity, steps)
+
+    assert result.actual_pace_display == "4:30/km"
+
+
 # ---------------------------------------------------------------------------
 # format_adherence_context
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adherence now reflects running only. Planned distance sums running steps
(warmup, cooldown, intervals) and excludes rest/recovery; running intervals
given in time are converted to distance via their target pace (falling back
to the workout's planned pace). Actual running distance, rest distance, and a
running-only pace are derived from Garmin's per-lap data (lapDTOs), with rest
classified by intensityType (REST/RECOVERY). Rest distance is surfaced
separately, e.g. "8.00 km planned / 8.00 km (+490 m rest) actual".

Falls back to whole-activity totals when per-lap data is unavailable.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M9vkToYTAhq1iFAGnycJYP