### PR TITLE
feat: Phase 1 — identity layer (Cloudflare Access JWT + User model)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,14 @@ GARMIN_TOKEN_DIR=/data/garmin_tokens
 ACTIVITY_POLL_MINUTES=5
 DAILY_SYNC_HOUR=7
 AI_MODEL=claude-sonnet-4-6
+
+# Auth / multi-user (Phase 1+)
+# Set AUTH_ENABLED=true when running behind Cloudflare Access.
+# CF_ACCESS_TEAM_DOMAIN and CF_ACCESS_AUD are required when auth is enabled.
+# ENCRYPTION_KEY is required for Phase 2 (per-user Garmin creds); generate once with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+AUTH_ENABLED=false
+CF_ACCESS_TEAM_DOMAIN=myteam.cloudflareaccess.com
+CF_ACCESS_AUD=
+DEV_USER_EMAIL=
+ENCRYPTION_KEY=

--- a/app/api.py
+++ b/app/api.py
@@ -11,6 +11,7 @@ from fastapi.responses import Response, StreamingResponse
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from app.auth import get_current_user
 from app.database import get_db
 from app.models import (
     Activity,
@@ -22,6 +23,7 @@ from app.models import (
     SyncStatus,
     TrainingPlan,
     TrainingPlanDay,
+    User,
     ZoneConfig,
 )
 from app.schemas import (
@@ -46,6 +48,7 @@ from app.schemas import (
     TrainingPlanResponse,
     TrainingPlanWeek,
     TrainingReadiness,
+    UserResponse,
     WeeklyMileage,
     WorkoutAdherence,
     WorkoutStepResponse,
@@ -63,7 +66,16 @@ from app.utils import safe_json_loads, parse_activity_charts, calculate_age
 
 logger = logging.getLogger(__name__)
 
-api_router = APIRouter(prefix="/api/v1", tags=["api"])
+api_router = APIRouter(
+    prefix="/api/v1",
+    tags=["api"],
+    dependencies=[Depends(get_current_user)],
+)
+
+@api_router.get("/me", response_model=UserResponse)
+def api_me(current_user: User = Depends(get_current_user)):
+    return current_user
+
 
 AVAILABLE_MODELS: dict[str, list[str]] = {
     "claude": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,89 @@
+import json
+import logging
+import time
+
+import httpx
+import jwt
+from fastapi import Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.database import get_db
+from app.models import User
+
+logger = logging.getLogger(__name__)
+
+_jwks_cache: dict = {}
+_jwks_fetched_at: float = 0
+_JWKS_TTL = 3600  # seconds
+
+
+def _get_jwks() -> dict:
+    global _jwks_cache, _jwks_fetched_at
+    now = time.time()
+    if _jwks_cache and (now - _jwks_fetched_at) < _JWKS_TTL:
+        return _jwks_cache
+    url = f"https://{settings.cf_access_team_domain}/cdn-cgi/access/certs"
+    resp = httpx.get(url, timeout=10)
+    resp.raise_for_status()
+    _jwks_cache = resp.json()
+    _jwks_fetched_at = now
+    return _jwks_cache
+
+
+def verify_cf_access_jwt(token: str) -> str:
+    """Verify a Cloudflare Access JWT and return the verified email claim."""
+    jwks = _get_jwks()
+    try:
+        header = jwt.get_unverified_header(token)
+        kid = header.get("kid")
+        public_key = None
+        for k in jwks.get("keys", []):
+            if k.get("kid") == kid:
+                public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(k))
+                break
+        if public_key is None:
+            raise HTTPException(status_code=401, detail="Unknown JWT key ID")
+        payload = jwt.decode(
+            token,
+            public_key,
+            algorithms=["RS256"],
+            audience=settings.cf_access_aud,
+        )
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="JWT expired")
+    except jwt.InvalidTokenError as exc:
+        raise HTTPException(status_code=401, detail=f"Invalid JWT: {exc}")
+
+    email = payload.get("email")
+    if not email:
+        raise HTTPException(status_code=401, detail="JWT missing email claim")
+    return email
+
+
+def _upsert_user(db: Session, email: str) -> User:
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        user = User(email=email)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+    return user
+
+
+def get_current_user(request: Request, db: Session = Depends(get_db)) -> User:
+    """FastAPI dependency: resolve the authenticated user for the current request.
+
+    When auth_enabled=False (dev/CI), falls back to a synthetic dev user so
+    the test suite and local runs work without a Cloudflare dependency.
+    """
+    if not settings.auth_enabled:
+        email = settings.dev_user_email or settings.garmin_email or "dev@localhost"
+        return _upsert_user(db, email)
+
+    token = request.headers.get("Cf-Access-Jwt-Assertion")
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing Cf-Access-Jwt-Assertion header")
+
+    email = verify_cf_access_jwt(token)
+    return _upsert_user(db, email)

--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,13 @@ class Settings(BaseSettings):
     daily_sync_hour: int = 7
     ai_model: str = "claude-sonnet-4-6"
 
+    # Auth / multi-user
+    auth_enabled: bool = False
+    cf_access_team_domain: str = ""  # e.g. "myteam.cloudflareaccess.com"
+    cf_access_aud: str = ""          # AUD tag from Cloudflare Access app
+    dev_user_email: str = ""         # fallback identity when auth_enabled=False
+    encryption_key: str = ""         # Fernet key for storing Garmin passwords (Phase 2)
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -20,6 +20,15 @@ def _utcnow():
     return datetime.now(timezone.utc)
 
 
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    email = Column(String(255), unique=True, nullable=False, index=True)
+    full_name = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=_utcnow)
+
+
 class Activity(Base):
     __tablename__ = "activities"
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -50,6 +50,14 @@ class MetricZoneResponse(BaseModel):
         from_attributes = True
 
 
+class UserResponse(BaseModel):
+    email: str
+    full_name: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
 class FeedbackRequest(BaseModel):
     rating: Literal["good", "bad"]
     tags: list[str] | None = None

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -17,11 +17,19 @@ import type {
   AthleteProfileRequest,
   TrainingLoadResponse,
   TrainingPlanResponse,
+  UserResponse,
   ZoneConfigBulkUpdate,
   ZoneConfigsResponse,
   ThresholdEstimateResponse,
   ThresholdApplyRequest,
 } from './types'
+
+export function useMe() {
+  return useQuery({
+    queryKey: ['me'],
+    queryFn: () => apiGet<UserResponse>('/me'),
+  })
+}
 
 export function useToday(date: string) {
   return useQuery({

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,3 +1,8 @@
+export interface UserResponse {
+  email: string
+  full_name: string | null
+}
+
 export interface ActivitySummary {
   id: number
   garmin_id: number | null

--- a/frontend/src/components/settings/SettingsView.tsx
+++ b/frontend/src/components/settings/SettingsView.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Download, RefreshCw } from 'lucide-react'
-import { useSettings, useTriggerSync, useAiConfig, useSetAiConfig } from '../../api/hooks'
+import { useSettings, useTriggerSync, useAiConfig, useSetAiConfig, useMe } from '../../api/hooks'
 import AthleteProfileSection from './AthleteProfileSection'
 import ThresholdEstimateSection from './ThresholdEstimateSection'
 import ZoneConfigSection from './ZoneConfigSection'
@@ -87,6 +87,19 @@ function DataExportSection() {
   )
 }
 
+function AccountSection() {
+  const { data } = useMe()
+  if (!data) return null
+  return (
+    <section className="settings-section">
+      <h2 className="section-title">Account</h2>
+      <div className="card">
+        <span className="settings-account-email">Signed in as {data.email}</span>
+      </div>
+    </section>
+  )
+}
+
 export default function SettingsView() {
   const { data, isLoading } = useSettings()
   const syncMutation = useTriggerSync()
@@ -96,6 +109,9 @@ export default function SettingsView() {
 
   return (
     <div className="settings-view">
+      {/* Signed-in account */}
+      <AccountSection />
+
       {/* Athlete profile */}
       <AthleteProfileSection />
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pydantic-settings==2.7.0
 httpx==0.28.1
 python-multipart==0.0.20
 pytz==2024.2
+PyJWT[crypto]>=2.8.0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,147 @@
+"""Tests for the Phase 1 identity layer (app/auth.py)."""
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app import models  # noqa: F401 - ensure models register on Base.metadata
+from app.api import api_router
+from app.auth import _upsert_user, get_current_user
+from app.config import settings
+from app.database import Base, get_db
+from app.models import User
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    yield sessionmaker(bind=engine)
+    engine.dispose()
+
+
+@pytest.fixture
+def db(session_factory):
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def client(session_factory):
+    app = FastAPI()
+    app.include_router(api_router)
+
+    def override_get_db():
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# _upsert_user
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_user_creates_on_first_call(db):
+    user = _upsert_user(db, "alice@example.com")
+    assert user.id is not None
+    assert user.email == "alice@example.com"
+
+
+def test_upsert_user_returns_same_row(db):
+    u1 = _upsert_user(db, "bob@example.com")
+    u2 = _upsert_user(db, "bob@example.com")
+    assert u1.id == u2.id
+
+
+# ---------------------------------------------------------------------------
+# get_current_user — dev mode (auth_enabled=False)
+# ---------------------------------------------------------------------------
+
+
+def test_dev_mode_uses_dev_user_email(db, monkeypatch):
+    monkeypatch.setattr(settings, "auth_enabled", False)
+    monkeypatch.setattr(settings, "dev_user_email", "devuser@test.com")
+    req = MagicMock()
+    user = get_current_user(req, db)
+    assert user.email == "devuser@test.com"
+
+
+def test_dev_mode_falls_back_to_garmin_email(db, monkeypatch):
+    monkeypatch.setattr(settings, "auth_enabled", False)
+    monkeypatch.setattr(settings, "dev_user_email", "")
+    monkeypatch.setattr(settings, "garmin_email", "garmin@test.com")
+    req = MagicMock()
+    user = get_current_user(req, db)
+    assert user.email == "garmin@test.com"
+
+
+def test_dev_mode_falls_back_to_localhost(db, monkeypatch):
+    monkeypatch.setattr(settings, "auth_enabled", False)
+    monkeypatch.setattr(settings, "dev_user_email", "")
+    monkeypatch.setattr(settings, "garmin_email", "")
+    req = MagicMock()
+    user = get_current_user(req, db)
+    assert user.email == "dev@localhost"
+
+
+# ---------------------------------------------------------------------------
+# get_current_user — auth mode (auth_enabled=True)
+# ---------------------------------------------------------------------------
+
+
+def test_auth_mode_missing_header_raises_401(db, monkeypatch):
+    monkeypatch.setattr(settings, "auth_enabled", True)
+    req = MagicMock()
+    req.headers.get.return_value = None
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        get_current_user(req, db)
+    assert exc_info.value.status_code == 401
+
+
+def test_auth_mode_valid_token_creates_user(db, monkeypatch):
+    monkeypatch.setattr(settings, "auth_enabled", True)
+    req = MagicMock()
+    req.headers.get.return_value = "fake-token"
+    with patch("app.auth.verify_cf_access_jwt", return_value="cf@example.com"):
+        user = get_current_user(req, db)
+    assert user.email == "cf@example.com"
+
+
+# ---------------------------------------------------------------------------
+# /me endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_me_endpoint_returns_email(client, monkeypatch):
+    monkeypatch.setattr(settings, "auth_enabled", False)
+    monkeypatch.setattr(settings, "dev_user_email", "me@test.com")
+    resp = client.get("/api/v1/me")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["email"] == "me@test.com"
+    assert "full_name" in data


### PR DESCRIPTION
## Summary

Implements Phase 1 of the multi-user plan (`docs/multi_user_plan.md`): verified identity on every request, with zero behaviour change when `auth_enabled=false` (default). Phases 2–3 (per-user Garmin creds + data isolation) can land on top of this.

- **`app/auth.py`** (new): `verify_cf_access_jwt` fetches+caches the team JWKS, verifies RS256 signature, `aud`, and expiry via PyJWT. `get_current_user` FastAPI dependency: when `auth_enabled=false` it falls back to `dev_user_email` → `garmin_email` → `"dev@localhost"`, keeping local dev and CI green with no Cloudflare dependency. When `auth_enabled=true` it reads `Cf-Access-Jwt-Assertion`, verifies it, and upserts the `User` row.
- **`app/models.py`**: new `User` table (`id`, `email` unique, `full_name`, `created_at`). Created automatically by `Base.metadata.create_all` on first startup.
- **`app/config.py`**: five new settings — `auth_enabled`, `cf_access_team_domain`, `cf_access_aud`, `dev_user_email`, `encryption_key` (the last is a placeholder for Phase 2 Fernet key).
- **`app/api.py`**: `dependencies=[Depends(get_current_user)]` at router level enforces auth on all routes; new `GET /api/v1/me` returns `{email, full_name}`.
- **`app/schemas.py`**: `UserResponse` schema.
- **`requirements.txt`**: `PyJWT[crypto]>=2.8.0` for RS256 JWK verification.
- **`.env.example`**: documents new env vars with generation instructions for `ENCRYPTION_KEY`.
- **Frontend**: `useMe` hook + `AccountSection` in `SettingsView` shows "Signed in as {email}".
- **`tests/test_auth.py`**: 8 new tests — `_upsert_user`, dev-mode fallback chain, auth-mode 401 on missing header, auth-mode user creation (mocked), `/me` endpoint.

## Test plan

- [x] CI backend tests pass (182 existing + 8 new)
- [x] `auth_enabled=false`: app starts, `/api/v1/me` returns dev email, all existing endpoints unaffected
- [x] `auth_enabled=true` + valid `Cf-Access-Jwt-Assertion`: `/api/v1/me` returns the Google email from the JWT
- [x] `auth_enabled=true` + missing/forged header: all API routes return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiUnze6gYvTS6eEQVmoCUF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiUnze6gYvTS6eEQVmoCUF)_