### PR TITLE
P1-2: HRV sync into readiness + fix overnight-data date attribution

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -280,6 +280,11 @@ def _format_daily_context(summary: DailySummary) -> str:
         parts.append(f"Avg Stress: {summary.stress_avg}")
     if summary.body_battery_high is not None:
         parts.append(f"Body Battery: {summary.body_battery_low}-{summary.body_battery_high}")
+    if summary.hrv_avg is not None:
+        hrv = f"HRV (overnight): {summary.hrv_avg:.0f} ms"
+        if summary.hrv_status:
+            hrv += f" ({summary.hrv_status.title()})"
+        parts.append(hrv)
     if summary.total_calories:
         parts.append(f"Calories: {summary.total_calories:,}")
     if summary.intensity_minutes:

--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,10 @@ class Settings(BaseSettings):
     garmin_token_dir: str = "/data/garmin_tokens"
     activity_poll_minutes: int = 5
     daily_sync_hour: int = 7
+    # Each daily run syncs today plus the prior (window-1) days, so last night's
+    # overnight stats land on the wake-up day while earlier days' full-day totals
+    # finalize the morning after.
+    daily_sync_window_days: int = 3
     ai_model: str = "claude-sonnet-4-6"
 
     # Auth / multi-user

--- a/app/database.py
+++ b/app/database.py
@@ -91,6 +91,26 @@ def _migrate_db():
     except Exception:
         logger.debug("Migration skipped (table may not exist yet)")
 
+    new_daily_summary_columns = {
+        "hrv_avg": "FLOAT",
+        "hrv_weekly_avg": "FLOAT",
+        "hrv_status": "VARCHAR(20)",
+    }
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(daily_summaries)")).fetchall()
+            existing = {row[1] for row in rows}
+            added = []
+            for col, dtype in new_daily_summary_columns.items():
+                if col not in existing:
+                    conn.execute(text(f"ALTER TABLE daily_summaries ADD COLUMN {col} {dtype}"))
+                    added.append(col)
+            conn.commit()
+            if added:
+                logger.info("Migrated daily_summaries table: added %s", ", ".join(added))
+    except Exception:
+        logger.debug("Migration skipped (daily_summaries table may not exist yet)")
+
     new_profile_columns = {"threshold_power": "INTEGER"}
     try:
         with engine.connect() as conn:

--- a/app/garmin_sync.py
+++ b/app/garmin_sync.py
@@ -265,7 +265,16 @@ def sync_activities() -> list[Activity]:
     return new_activities
 
 
-def _daily_summary_fields(stats: dict, stress_avg, sleep_seconds, sleep_score, raw: dict) -> dict:
+def _daily_summary_fields(
+    stats: dict,
+    stress_avg,
+    sleep_seconds,
+    sleep_score,
+    raw: dict,
+    hrv_avg=None,
+    hrv_weekly_avg=None,
+    hrv_status=None,
+) -> dict:
     """Build field dict for DailySummary create/update."""
     return {
         "steps": stats.get("totalSteps"),
@@ -283,6 +292,9 @@ def _daily_summary_fields(stats: dict, stress_avg, sleep_seconds, sleep_score, r
             + (stats.get("vigorousIntensityMinutes") or 0)
         ),
         "floors_climbed": stats.get("floorsAscended"),
+        "hrv_avg": hrv_avg,
+        "hrv_weekly_avg": hrv_weekly_avg,
+        "hrv_status": hrv_status,
         "raw_json": json.dumps(raw, default=str),
         "synced_at": datetime.now(timezone.utc),
         "ai_analyzed": False,
@@ -318,6 +330,10 @@ def sync_daily_summary(target_date: date | None = None) -> DailySummary | None:
                 raw["stress"] = client.get_all_day_stress(date_str)
             except Exception:
                 pass
+            try:
+                raw["hrv"] = client.get_hrv_data(date_str)
+            except Exception:
+                pass
 
             sleep_seconds = None
             sleep_score = None
@@ -330,7 +346,26 @@ def sync_daily_summary(target_date: date | None = None) -> DailySummary | None:
             if stats.get("averageStressLevel"):
                 stress_avg = stats["averageStressLevel"]
 
-            fields = _daily_summary_fields(stats, stress_avg, sleep_seconds, sleep_score, raw)
+            # Overnight HRV is attributed by Garmin to the wake-up day (same date).
+            hrv_avg = None
+            hrv_weekly_avg = None
+            hrv_status = None
+            if raw.get("hrv"):
+                hrv_summary = (raw["hrv"] or {}).get("hrvSummary", {}) or {}
+                hrv_avg = hrv_summary.get("lastNightAvg")
+                hrv_weekly_avg = hrv_summary.get("weeklyAvg")
+                hrv_status = hrv_summary.get("status")
+
+            fields = _daily_summary_fields(
+                stats,
+                stress_avg,
+                sleep_seconds,
+                sleep_score,
+                raw,
+                hrv_avg=hrv_avg,
+                hrv_weekly_avg=hrv_weekly_avg,
+                hrv_status=hrv_status,
+            )
 
             existing = db.query(DailySummary).filter(DailySummary.date == target_date).first()
             if existing:
@@ -520,12 +555,14 @@ def backfill_daily_summaries():
                 logger.info("Daily summary backfill already complete")
                 return
 
-            start_days_ago = 1
+            # Start at 0 (today) so a fresh start also captures last night's
+            # sleep/HRV, which Garmin attributes to today's wake-up date.
+            start_days_ago = 0
             if status and status != "complete":
                 try:
                     start_days_ago = int(status)
                 except ValueError:
-                    start_days_ago = 1
+                    start_days_ago = 0
 
             today = date.today()
             for days_ago in range(start_days_ago, 366):

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ import os
 import threading
 
 from contextlib import asynccontextmanager
+from datetime import date, timedelta
 
 from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_EXECUTED
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -62,7 +63,14 @@ def _scheduled_activity_sync():
 
 
 def _scheduled_daily_sync():
-    """Scheduled job: sync daily summary and trigger AI."""
+    """Scheduled job: sync a rolling window of daily summaries and trigger AI.
+
+    Garmin attributes overnight metrics (sleep, HRV, resting HR) to the wake-up
+    day, so we sync *today* to capture last night's data on the correct date, and
+    re-sync the prior days in the window so their full-day totals finalize. AI
+    analysis runs only on today's (newest) summary to avoid re-analyzing days that
+    were already covered on previous runs.
+    """
     from app.garmin_sync import sync_athlete_profile, sync_daily_summary
     from app.ai_coach import analyze_daily_summary
 
@@ -71,12 +79,20 @@ def _scheduled_daily_sync():
     except Exception:
         logger.exception("Athlete profile sync failed")
 
-    summary = sync_daily_summary()
-    if summary:
+    window = max(1, settings.daily_sync_window_days)
+    today = date.today()
+    today_summary = None
+    for offset in range(window):
+        target = today - timedelta(days=offset)
+        summary = sync_daily_summary(target)
+        if offset == 0:
+            today_summary = summary
+
+    if today_summary:
         try:
-            analyze_daily_summary(summary)
+            analyze_daily_summary(today_summary)
         except Exception:
-            logger.exception("AI analysis failed for daily summary %s", summary.id)
+            logger.exception("AI analysis failed for daily summary %s", today_summary.id)
 
 
 def _scheduled_weekly_review():

--- a/app/models.py
+++ b/app/models.py
@@ -120,6 +120,10 @@ class DailySummary(Base):
     body_battery_low = Column(Integer)
     intensity_minutes = Column(Integer)
     floors_climbed = Column(Integer)
+    # Overnight HRV (heart-rate variability), attributed to the wake-up day
+    hrv_avg = Column(Float)              # last-night average HRV (ms)
+    hrv_weekly_avg = Column(Float)       # personal 7-day baseline (ms)
+    hrv_status = Column(String(20))      # BALANCED / UNBALANCED / LOW / POOR
     raw_json = Column(Text)
     synced_at = Column(DateTime, default=_utcnow)
     ai_analyzed = Column(Boolean, default=False)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -183,6 +183,9 @@ class DailySummaryResponse(BaseModel):
     body_battery_low: int | None = None
     intensity_minutes: int | None = None
     floors_climbed: float | None = None
+    hrv_avg: float | None = None
+    hrv_weekly_avg: float | None = None
+    hrv_status: str | None = None
 
     class Config:
         from_attributes = True
@@ -262,6 +265,7 @@ class TrainingReadiness(BaseModel):
     recovery_component: int | None = None   # 0-100, from stress + body battery
     fatigue_component: int | None = None    # 0-100, ATL-based (higher = less fatigued)
     rhr_component: int | None = None        # 0-100, resting HR trend vs 7d avg
+    hrv_component: int | None = None        # 0-100, overnight HRV vs personal baseline
 
 
 class TrainingLoadResponse(BaseModel):

--- a/app/training_load.py
+++ b/app/training_load.py
@@ -231,6 +231,34 @@ def _readiness_label(score: int) -> str:
     return "Low"
 
 
+# Fallback scores when no personal HRV baseline is available, keyed on Garmin's
+# overnight HRV status enum.
+_HRV_STATUS_SCORES = {
+    "BALANCED": 85,
+    "UNBALANCED": 50,
+    "LOW": 30,
+    "POOR": 20,
+}
+
+
+def _hrv_component(daily: DailySummary | None) -> int | None:
+    """Score overnight HRV 0–100 against the athlete's personal baseline.
+
+    Prefers last-night average vs the 7-day baseline (continuous), falling back
+    to Garmin's HRV status enum when no baseline is available.
+    """
+    if daily is None or daily.hrv_avg is None:
+        return None
+    baseline = daily.hrv_weekly_avg
+    if baseline:
+        # ratio 1.0 (at baseline) → 75 ("good"); +20% → 125→cap 100; −20% → 25
+        ratio = daily.hrv_avg / baseline
+        return int(min(100, max(0, 75 + (ratio - 1.0) * 250)))
+    if daily.hrv_status:
+        return _HRV_STATUS_SCORES.get(daily.hrv_status.upper())
+    return None
+
+
 def compute_readiness(
     daily: DailySummary | None,
     load_point: TrainingLoadPoint | None,
@@ -243,12 +271,19 @@ def compute_readiness(
     - recovery_component: average of inverted stress and body_battery_high
     - fatigue_component: 100 − ATL (capped 0–100); higher = less fatigued
     - rhr_component: resting HR today vs 7-day average; lower today = better
+    - hrv_component: overnight HRV vs personal baseline; higher = better recovered
 
     Any missing component is excluded from the weighted average so a partial
     data day still yields a meaningful score.
     """
     # Weights — must sum to 1.0
-    WEIGHTS = {"sleep": 0.30, "recovery": 0.35, "fatigue": 0.25, "rhr": 0.10}
+    WEIGHTS = {
+        "sleep": 0.25,
+        "recovery": 0.25,
+        "fatigue": 0.20,
+        "rhr": 0.10,
+        "hrv": 0.20,
+    }
 
     # Sleep component
     sleep_scores: list[int] = []
@@ -284,6 +319,9 @@ def compute_readiness(
         # delta −5 → 100 pts, delta 0 → 75 pts, delta +10 → 0 pts
         rhr_component = int(min(100, max(0, 75 - delta * 7.5)))
 
+    # HRV component — last-night HRV vs personal baseline (Garmin's status factor)
+    hrv_component = _hrv_component(daily)
+
     # Weighted composite
     weighted_sum = 0.0
     total_weight = 0.0
@@ -292,6 +330,7 @@ def compute_readiness(
         (recovery_component, WEIGHTS["recovery"]),
         (fatigue_component, WEIGHTS["fatigue"]),
         (rhr_component, WEIGHTS["rhr"]),
+        (hrv_component, WEIGHTS["hrv"]),
     ):
         if comp_val is not None:
             weighted_sum += comp_val * weight
@@ -308,6 +347,7 @@ def compute_readiness(
         recovery_component=recovery_component,
         fatigue_component=fatigue_component,
         rhr_component=rhr_component,
+        hrv_component=hrv_component,
     )
 
 
@@ -336,4 +376,6 @@ def format_readiness_context(readiness: TrainingReadiness | None) -> str:
         lines.append(f"- Freshness (fatigue): {readiness.fatigue_component}/100")
     if readiness.rhr_component is not None:
         lines.append(f"- Resting HR trend: {readiness.rhr_component}/100")
+    if readiness.hrv_component is not None:
+        lines.append(f"- HRV (vs baseline): {readiness.hrv_component}/100")
     return "## Training Readiness\n" + "\n".join(lines)

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -131,6 +131,9 @@ export interface DailySummaryResponse {
   body_battery_low: number | null
   intensity_minutes: number | null
   floors_climbed: number | null
+  hrv_avg: number | null
+  hrv_weekly_avg: number | null
+  hrv_status: string | null
 }
 
 export interface DailySummaryDetail {
@@ -204,6 +207,7 @@ export interface TrainingReadiness {
   recovery_component: number | null
   fatigue_component: number | null
   rhr_component: number | null
+  hrv_component: number | null
 }
 
 export interface TrainingLoadResponse {

--- a/frontend/src/components/today/ReadinessCard.tsx
+++ b/frontend/src/components/today/ReadinessCard.tsx
@@ -52,6 +52,7 @@ export default function ReadinessCard({ readiness }: Props) {
         <ComponentBar label="Recovery" value={readiness.recovery_component} />
         <ComponentBar label="Freshness" value={readiness.fatigue_component} />
         <ComponentBar label="Resting HR" value={readiness.rhr_component} />
+        <ComponentBar label="HRV" value={readiness.hrv_component} />
       </div>
     </div>
   )

--- a/frontend/src/components/trends/WellnessTrendsView.tsx
+++ b/frontend/src/components/trends/WellnessTrendsView.tsx
@@ -25,6 +25,7 @@ const SLEEP_COLOR = '#6c5ce7'
 const RHR_COLOR = '#e17055'
 const STRESS_COLOR = '#fd79a8'
 const BATTERY_COLOR = '#00b894'
+const HRV_COLOR = '#0984e3'
 
 function avg7(data: any[], key: string): number | null {
   const vals = data.slice(-7).map(d => d[key]).filter((v: any) => v != null) as number[]
@@ -79,6 +80,7 @@ export default function WellnessTrendsView() {
     stress: s.stress_avg ?? null,
     battery_high: s.body_battery_high ?? null,
     battery_low: s.body_battery_low ?? null,
+    hrv: s.hrv_avg ?? null,
   }))
 
   const avgSleepScore = avg7(chartData, 'sleep_score')
@@ -86,6 +88,9 @@ export default function WellnessTrendsView() {
   const avgRhr = avg7(chartData, 'resting_hr')
   const avgStress = avg7(chartData, 'stress')
   const avgBatteryHigh = avg7(chartData, 'battery_high')
+  const avgHrv = avg7(chartData, 'hrv')
+  const latestHrvStatus = [...data].reverse().find(s => s.hrv_status != null)?.hrv_status ?? null
+  const hasHrv = chartData.some(d => d.hrv != null)
 
   const minTickGap = days === 30 ? 14 : days === 60 ? 20 : 28
 
@@ -278,6 +283,49 @@ export default function WellnessTrendsView() {
           </ResponsiveContainer>
         </div>
       </div>
+
+      {/* HRV (overnight) */}
+      {hasHrv && (
+        <div className="card wellness-card">
+          <div className="wellness-card-header">
+            <div className="wellness-metric-title">HRV (overnight)</div>
+            {avgHrv != null && (
+              <div className="wellness-metric-value" style={{ color: HRV_COLOR }}>
+                {avgHrv.toFixed(0)}
+                <span className="wellness-metric-unit"> ms avg · 7-day</span>
+              </div>
+            )}
+            {latestHrvStatus != null && (
+              <div className="wellness-metric-sub">Status: {latestHrvStatus.toLowerCase()}</div>
+            )}
+          </div>
+          <div className="wellness-chart">
+            <ResponsiveContainer width="100%" height={120}>
+              <ComposedChart data={chartData} margin={{ top: 4, right: 4, left: -8, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="wt-hrvFill" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={HRV_COLOR} stopOpacity={0.35} />
+                    <stop offset="100%" stopColor={HRV_COLOR} stopOpacity={0.02} />
+                  </linearGradient>
+                </defs>
+                <XAxis {...xAxisProps} />
+                <YAxis {...yAxisProps} domain={['dataMin - 5', 'dataMax + 5']} />
+                <Tooltip content={<MetricTooltip unit=" ms" />} />
+                <Area
+                  type="monotone"
+                  dataKey="hrv"
+                  stroke={HRV_COLOR}
+                  strokeWidth={2}
+                  fill="url(#wt-hrvFill)"
+                  dot={false}
+                  name="HRV"
+                  connectNulls
+                />
+              </ComposedChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/perf/seed_perf_db.py
+++ b/perf/seed_perf_db.py
@@ -265,6 +265,16 @@ def _make_activity(d: date, workout: str, garmin_id: int, with_detail: bool) -> 
 
 
 def _make_daily(d: date, trained: bool) -> DailySummary:
+    # Overnight HRV: a stable personal baseline with night-to-night variation,
+    # plus a status derived from how far last night sat from that baseline.
+    hrv_baseline = _rint(42, 58)
+    hrv_last = _rint(hrv_baseline - 10, hrv_baseline + 10)
+    if abs(hrv_last - hrv_baseline) <= 6:
+        hrv_status = "BALANCED"
+    elif hrv_last > hrv_baseline:
+        hrv_status = "UNBALANCED"
+    else:
+        hrv_status = "LOW"
     return DailySummary(
         date=d,
         steps=_rint(9000, 22000) if trained else _rint(5000, 12000),
@@ -279,6 +289,9 @@ def _make_daily(d: date, trained: bool) -> DailySummary:
         body_battery_low=_rint(5, 35),
         intensity_minutes=_rint(30, 120) if trained else _rint(0, 30),
         floors_climbed=_rint(3, 25),
+        hrv_avg=float(hrv_last),
+        hrv_weekly_avg=float(hrv_baseline),
+        hrv_status=hrv_status,
         raw_json=json.dumps({"source": "perf-seed"}),
         ai_analyzed=random.random() < 0.3,
     )

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,35 @@
+# P1-2 · HRV sync → readiness  +  overnight-data date-attribution fix
+
+## Plan
+- [x] Sync Garmin overnight HRV (`get_hrv_data`) into `DailySummary`
+      (`hrv_avg`, `hrv_weekly_avg`, `hrv_status`) + DB migration.
+- [x] Add an HRV readiness component (last-night HRV vs personal baseline, with a
+      status-enum fallback); rebalance weights to include HRV at 0.20.
+- [x] Surface HRV: Wellness-Trends chart card, Today readiness component bar, AI
+      daily-summary context line, `format_readiness_context`.
+- [x] Fix overnight date attribution: scheduled daily sync now covers a rolling
+      window (today + prior `daily_sync_window_days-1` days) so last night's
+      sleep/HRV — which Garmin dates to the wake-up day — lands on the correct date
+      the morning you sync, while earlier days' full-day totals finalize. Backfill
+      now starts at today (`days_ago=0`).
+- [x] Tests: garmin_sync HRV persistence, readiness HRV component (baseline ratio,
+      status fallback, composite fold-in), rolling-window daily sync + AI-on-today,
+      backfill-includes-today. Full suite 351 passing, coverage 83.4% (gate 80%).
+      Frontend `npm run build` (tsc) clean.
+
+## Review / findings — was sleep correctly dated?
+Garmin attributes overnight metrics (sleep, HRV, resting HR) to the **wake-up
+calendar date** (confirmed via Garmin Developer Portal `calendarDate` definition):
+sleep from the night of Jun 19→20 is dated **Jun 20**. The data the app stored was
+internally consistent (it reused Garmin's own date), but `sync_daily_summary()`
+defaulted to **yesterday** and the 7am job called it with no argument — so waking up
+on Jun 20 and syncing pulled Jun 19's row, and last night's sleep/HRV wasn't captured
+until the *next* morning. The sync **window** was a day behind. Fixed by the rolling
+window above: today's row now captures last night's overnight stats on the wake-up
+day, and prior days are re-synced so their daytime totals finalize.
+
+---
+
 # P2-2 precision upgrade — mean-maximal curves + proper CP/CV modeling
 
 Move threshold estimation off whole-activity averages and onto real

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -356,6 +356,9 @@ def test_sync_daily_summary_creates_row(db, patch_db_session, monkeypatch):
     }
     fake_client.get_heart_rates.return_value = {}
     fake_client.get_all_day_stress.return_value = {}
+    fake_client.get_hrv_data.return_value = {
+        "hrvSummary": {"lastNightAvg": 46, "weeklyAvg": 42, "status": "BALANCED"}
+    }
     monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
 
     summary = garmin_sync.sync_daily_summary(date(2026, 6, 10))
@@ -371,6 +374,9 @@ def test_sync_daily_summary_creates_row(db, patch_db_session, monkeypatch):
     assert stored.sleep_seconds == 27000
     assert stored.sleep_score == 82
     assert stored.stress_avg == 28
+    assert stored.hrv_avg == 46
+    assert stored.hrv_weekly_avg == 42
+    assert stored.hrv_status == "BALANCED"
 
 
 def test_sync_daily_summary_updates_existing(db, patch_db_session, monkeypatch):
@@ -384,6 +390,7 @@ def test_sync_daily_summary_updates_existing(db, patch_db_session, monkeypatch):
     fake_client.get_sleep_data.return_value = {}
     fake_client.get_heart_rates.return_value = {}
     fake_client.get_all_day_stress.return_value = {}
+    fake_client.get_hrv_data.return_value = {}
     monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
 
     garmin_sync.sync_daily_summary(date(2026, 6, 10))
@@ -496,6 +503,18 @@ def test_backfill_daily_summaries_completes(db, patch_db_session, monkeypatch):
 
     garmin_sync.backfill_daily_summaries()
     assert garmin_sync._get_sync_status(db, "backfill_daily") == "complete"
+
+
+def test_backfill_daily_summaries_includes_today(db, patch_db_session, monkeypatch):
+    # Garmin dates last night's sleep to the wake-up day, so backfill must start
+    # at today (days_ago=0) to capture it on a fresh start.
+    patch_db_session(garmin_sync)
+    monkeypatch.setattr(garmin_sync.time, "sleep", lambda *a, **k: None)
+    targets = []
+    monkeypatch.setattr(garmin_sync, "sync_daily_summary", lambda target: targets.append(target))
+
+    garmin_sync.backfill_daily_summaries()
+    assert date.today() in targets
 
 
 def test_backfill_daily_summaries_skips_when_complete(db, patch_db_session, monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,22 +24,43 @@ def test_scheduled_activity_sync_survives_calendar_error(monkeypatch):
     main._scheduled_activity_sync()
 
 
-def test_scheduled_daily_sync_triggers_ai(monkeypatch):
-    summary = MagicMock(id=1)
+def test_scheduled_daily_sync_syncs_window_and_analyzes_today(monkeypatch):
+    from datetime import date
+
     import app.garmin_sync as garmin_sync
     import app.ai_coach as ai_coach
-    monkeypatch.setattr(garmin_sync, "sync_daily_summary", MagicMock(return_value=summary))
+
+    monkeypatch.setattr(main.settings, "daily_sync_window_days", 3)
+    monkeypatch.setattr(garmin_sync, "sync_athlete_profile", MagicMock())
+
+    # Return a distinct summary per requested date so we can verify which one
+    # is handed to the AI (the newest — today).
+    summaries = {}
+
+    def fake_sync(target):
+        s = MagicMock(id=target.toordinal(), date=target)
+        summaries[target] = s
+        return s
+
+    sync = MagicMock(side_effect=fake_sync)
+    monkeypatch.setattr(garmin_sync, "sync_daily_summary", sync)
     analyze = MagicMock()
     monkeypatch.setattr(ai_coach, "analyze_daily_summary", analyze)
 
     main._scheduled_daily_sync()
 
-    analyze.assert_called_once_with(summary)
+    # Rolling window: today + the prior 2 days.
+    assert sync.call_count == 3
+    synced_dates = {c.args[0] for c in sync.call_args_list}
+    assert date.today() in synced_dates
+    # AI runs only on today's (newest) summary.
+    analyze.assert_called_once_with(summaries[date.today()])
 
 
 def test_scheduled_daily_sync_no_summary_skips_ai(monkeypatch):
     import app.garmin_sync as garmin_sync
     import app.ai_coach as ai_coach
+    monkeypatch.setattr(garmin_sync, "sync_athlete_profile", MagicMock())
     monkeypatch.setattr(garmin_sync, "sync_daily_summary", MagicMock(return_value=None))
     analyze = MagicMock()
     monkeypatch.setattr(ai_coach, "analyze_daily_summary", analyze)

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -20,6 +20,9 @@ def _daily(
     resting_hr=None,
     stress_avg=None,
     body_battery_high=None,
+    hrv_avg=None,
+    hrv_weekly_avg=None,
+    hrv_status=None,
 ):
     """Build a DailySummary stub with only the fields needed for readiness."""
     return DailySummary(
@@ -29,6 +32,9 @@ def _daily(
         resting_hr=resting_hr,
         stress_avg=stress_avg,
         body_battery_high=body_battery_high,
+        hrv_avg=hrv_avg,
+        hrv_weekly_avg=hrv_weekly_avg,
+        hrv_status=hrv_status,
     )
 
 
@@ -178,6 +184,65 @@ def test_rhr_component_absent_when_combined_with_other_data():
     )
     assert result is not None
     assert result.rhr_component is None
+
+
+# ---------------------------------------------------------------------------
+# HRV component
+# ---------------------------------------------------------------------------
+
+def test_hrv_at_baseline_gives_75():
+    # hrv_avg == weekly baseline → ratio 1.0 → 75
+    result = training_load.compute_readiness(
+        _daily(hrv_avg=45, hrv_weekly_avg=45), None, []
+    )
+    assert result is not None
+    assert result.hrv_component == 75
+
+
+def test_hrv_above_baseline_scores_higher():
+    # 54 vs 45 → ratio 1.2 → 75 + 50 = 125, clamped to 100
+    result = training_load.compute_readiness(
+        _daily(hrv_avg=54, hrv_weekly_avg=45), None, []
+    )
+    assert result is not None
+    assert result.hrv_component == 100
+
+
+def test_hrv_below_baseline_scores_lower():
+    # 36 vs 45 → ratio 0.8 → 75 - 50 = 25
+    result = training_load.compute_readiness(
+        _daily(hrv_avg=36, hrv_weekly_avg=45), None, []
+    )
+    assert result is not None
+    assert result.hrv_component == 25
+
+
+def test_hrv_status_fallback_when_no_baseline():
+    result = training_load.compute_readiness(
+        _daily(hrv_avg=45, hrv_status="UNBALANCED"), None, []
+    )
+    assert result is not None
+    assert result.hrv_component == 50
+
+
+def test_hrv_component_none_without_hrv_avg():
+    result = training_load.compute_readiness(
+        _daily(hrv_status="BALANCED", sleep_score=80), None, []
+    )
+    assert result is not None
+    assert result.hrv_component is None
+
+
+def test_hrv_component_folds_into_composite():
+    # Strong HRV should lift the composite versus suppressed HRV, all else equal.
+    high = training_load.compute_readiness(
+        _daily(sleep_score=70, hrv_avg=54, hrv_weekly_avg=45), None, []
+    )
+    low = training_load.compute_readiness(
+        _daily(sleep_score=70, hrv_avg=36, hrv_weekly_avg=45), None, []
+    )
+    assert high is not None and low is not None
+    assert high.score > low.score
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Sync Garmin overnight HRV (get_hrv_data -> hrvSummary.lastNightAvg/weeklyAvg/
status) into DailySummary (new hrv_avg/hrv_weekly_avg/hrv_status columns +
migration), add an HRV component to the readiness score (last-night HRV vs the
personal 7-day baseline, with a status-enum fallback; weights rebalanced to
include HRV at 0.20), and surface it in Wellness Trends, the Today readiness
card, format_readiness_context, and the AI daily-summary context.

Fix overnight date attribution: Garmin dates overnight metrics (sleep, HRV,
resting HR) to the wake-up day, but the daily job synced only "yesterday", so
last night's data wasn't captured until the next morning. The scheduled daily
sync now covers a rolling window (today + prior daily_sync_window_days-1 days)
so today's row captures last night's overnight stats while earlier days'
full-day totals finalize; AI analysis runs on today's summary. Backfill now
starts at today (days_ago=0).

Tests: HRV persistence in daily sync, HRV readiness component (baseline ratio,
status fallback, composite fold-in), rolling-window sync + AI-on-today,
backfill-includes-today. Full suite passing; frontend type-check clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gv2MdzA6USGU1yVSetZvu6