### PR TITLE
fix: exclude internal cache blobs from settings sync status display

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -528,10 +528,14 @@ def api_insights(
 
 # --- Settings ---
 
+_INTERNAL_SYNC_KEYS = {"threshold_estimate", "training_load_series"}
+
 @api_router.get("/settings", response_model=SettingsResponse)
 def api_settings(db: Session = Depends(get_db)):
     sync_statuses = {}
     for s in db.query(SyncStatus).all():
+        if s.key in _INTERNAL_SYNC_KEYS:
+            continue
         sync_statuses[s.key] = {"value": s.value, "updated_at": str(s.updated_at) if s.updated_at else None}
 
     counts = {


### PR DESCRIPTION
threshold_estimate and training_load_series are SyncStatus rows used
for memoizing computation results (raw JSON payloads), not user-facing
sync events. Filter them out of the /settings endpoint so the Sync
Status section only shows meaningful entries like last activity/daily/
calendar syncs.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzWzBJu9FmegRRDGwDUBe5