### PR TITLE
P3-3: adopt Alembic for schema migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,44 @@
+[alembic]
+# Path to the migration scripts directory (relative to this file).
+script_location = alembic
+
+# Add the project root to sys.path so that "from app..." imports work.
+prepend_sys_path = .
+
+# The database URL is set dynamically in env.py from app.config.settings,
+# so the value here is only a placeholder used by alembic --help output.
+sqlalchemy.url = sqlite:////data/running_coach.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,53 @@
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool, engine_from_config
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Import Base and all models so autogenerate detects the full schema.
+from app.database import Base  # noqa: E402
+from app import models  # noqa: E402, F401
+
+target_metadata = Base.metadata
+
+# Override the URL from app settings so CLI commands pick up the right DB.
+from app.config import settings  # noqa: E402
+
+config.set_main_option("sqlalchemy.url", f"sqlite:///{settings.db_path}")
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        render_as_batch=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    # Reuse the app engine so WAL mode / foreign-key pragmas are active.
+    from app.database import engine as app_engine
+
+    with app_engine.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            render_as_batch=True,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/e3a9b1c2d4f5_initial_schema.py
+++ b/alembic/versions/e3a9b1c2d4f5_initial_schema.py
@@ -1,0 +1,272 @@
+"""initial schema
+
+Revision ID: e3a9b1c2d4f5
+Revises:
+Create Date: 2026-06-21
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "e3a9b1c2d4f5"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("full_name", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    op.create_table(
+        "activities",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("garmin_id", sa.BigInteger(), nullable=False),
+        sa.Column("activity_type", sa.Text(), nullable=True),
+        sa.Column("name", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("duration_sec", sa.Float(), nullable=True),
+        sa.Column("distance_m", sa.Float(), nullable=True),
+        sa.Column("avg_hr", sa.Integer(), nullable=True),
+        sa.Column("max_hr", sa.Integer(), nullable=True),
+        sa.Column("avg_pace_min_km", sa.Float(), nullable=True),
+        sa.Column("calories", sa.Float(), nullable=True),
+        sa.Column("elevation_gain", sa.Float(), nullable=True),
+        sa.Column("elevation_loss", sa.Float(), nullable=True),
+        sa.Column("avg_cadence", sa.Float(), nullable=True),
+        sa.Column("avg_stride", sa.Float(), nullable=True),
+        sa.Column("training_effect_aerobic", sa.Float(), nullable=True),
+        sa.Column("training_effect_anaerobic", sa.Float(), nullable=True),
+        sa.Column("vo2max", sa.Float(), nullable=True),
+        sa.Column("avg_power", sa.Float(), nullable=True),
+        sa.Column("laps_json", sa.Text(), nullable=True),
+        sa.Column("splits_json", sa.Text(), nullable=True),
+        sa.Column("hr_zones_json", sa.Text(), nullable=True),
+        sa.Column("weather_json", sa.Text(), nullable=True),
+        sa.Column("raw_json", sa.Text(), nullable=True),
+        sa.Column("synced_at", sa.DateTime(), nullable=True),
+        sa.Column("ai_analyzed", sa.Boolean(), nullable=True),
+        sa.Column("avg_ground_contact_time", sa.Float(), nullable=True),
+        sa.Column("avg_vertical_oscillation", sa.Float(), nullable=True),
+        sa.Column("avg_vertical_ratio", sa.Float(), nullable=True),
+        sa.Column("normalized_power", sa.Float(), nullable=True),
+        sa.Column("training_stress_score", sa.Float(), nullable=True),
+        sa.Column("intensity_factor", sa.Float(), nullable=True),
+        sa.Column("avg_respiration_rate", sa.Float(), nullable=True),
+        sa.Column("max_respiration_rate", sa.Float(), nullable=True),
+        sa.Column("avg_speed", sa.Float(), nullable=True),
+        sa.Column("max_speed", sa.Float(), nullable=True),
+        sa.Column("min_hr", sa.Integer(), nullable=True),
+        sa.Column("max_elevation", sa.Float(), nullable=True),
+        sa.Column("min_elevation", sa.Float(), nullable=True),
+        sa.Column("max_cadence", sa.Float(), nullable=True),
+        sa.Column("run_time_sec", sa.Float(), nullable=True),
+        sa.Column("walk_time_sec", sa.Float(), nullable=True),
+        sa.Column("typed_splits_json", sa.Text(), nullable=True),
+        sa.Column("power_zones_json", sa.Text(), nullable=True),
+        sa.Column("mean_max_json", sa.Text(), nullable=True),
+        sa.Column("feedback_rating", sa.String(10), nullable=True),
+        sa.Column("feedback_tags", sa.Text(), nullable=True),
+        sa.Column("feedback_text", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("garmin_id"),
+    )
+    op.create_index("ix_activities_garmin_id", "activities", ["garmin_id"], unique=True)
+    op.create_index("ix_activities_started_at", "activities", ["started_at"], unique=False)
+
+    op.create_table(
+        "daily_summaries",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("steps", sa.Integer(), nullable=True),
+        sa.Column("total_calories", sa.Integer(), nullable=True),
+        sa.Column("active_calories", sa.Integer(), nullable=True),
+        sa.Column("resting_hr", sa.Integer(), nullable=True),
+        sa.Column("max_hr", sa.Integer(), nullable=True),
+        sa.Column("stress_avg", sa.Integer(), nullable=True),
+        sa.Column("sleep_seconds", sa.Integer(), nullable=True),
+        sa.Column("sleep_score", sa.Float(), nullable=True),
+        sa.Column("body_battery_high", sa.Integer(), nullable=True),
+        sa.Column("body_battery_low", sa.Integer(), nullable=True),
+        sa.Column("intensity_minutes", sa.Integer(), nullable=True),
+        sa.Column("floors_climbed", sa.Integer(), nullable=True),
+        sa.Column("hrv_avg", sa.Float(), nullable=True),
+        sa.Column("hrv_weekly_avg", sa.Float(), nullable=True),
+        sa.Column("hrv_status", sa.String(20), nullable=True),
+        sa.Column("raw_json", sa.Text(), nullable=True),
+        sa.Column("synced_at", sa.DateTime(), nullable=True),
+        sa.Column("ai_analyzed", sa.Boolean(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("date"),
+    )
+    op.create_index("ix_daily_summaries_date", "daily_summaries", ["date"], unique=True)
+
+    op.create_table(
+        "insights",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("trigger_type", sa.Text(), nullable=True),
+        sa.Column("trigger_id", sa.Integer(), nullable=True),
+        sa.Column("content", sa.Text(), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("category", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_insights_created_at", "insights", ["created_at"], unique=False)
+
+    op.create_table(
+        "races",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("distance_m", sa.Float(), nullable=True),
+        sa.Column("distance_label", sa.Text(), nullable=True),
+        sa.Column("goal_time_sec", sa.Integer(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_races_date", "races", ["date"], unique=False)
+
+    op.create_table(
+        "garmin_calendar_events",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("garmin_id", sa.String(100), nullable=False),
+        sa.Column("event_type", sa.String(50), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("distance_m", sa.Float(), nullable=True),
+        sa.Column("distance_label", sa.Text(), nullable=True),
+        sa.Column("goal_time_sec", sa.Integer(), nullable=True),
+        sa.Column("priority", sa.String(1), nullable=True),
+        sa.Column("workout_type", sa.Text(), nullable=True),
+        sa.Column("workout_description", sa.Text(), nullable=True),
+        sa.Column("raw_json", sa.Text(), nullable=True),
+        sa.Column("synced_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("garmin_id"),
+    )
+    op.create_index(
+        "ix_garmin_calendar_events_garmin_id", "garmin_calendar_events", ["garmin_id"], unique=True
+    )
+    op.create_index(
+        "ix_garmin_calendar_events_event_type", "garmin_calendar_events", ["event_type"], unique=False
+    )
+    op.create_index(
+        "ix_garmin_calendar_events_date", "garmin_calendar_events", ["date"], unique=False
+    )
+
+    op.create_table(
+        "metric_zones",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("metric_key", sa.String(50), nullable=False),
+        sa.Column("zone_name", sa.String(20), nullable=False),
+        sa.Column("zone_color", sa.String(20), nullable=False),
+        sa.Column("percentile_label", sa.String(20), nullable=False),
+        sa.Column("min_value", sa.Float(), nullable=True),
+        sa.Column("max_value", sa.Float(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_metric_zones_metric_key", "metric_zones", ["metric_key"], unique=False)
+
+    op.create_table(
+        "sync_status",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("key", sa.String(100), nullable=False),
+        sa.Column("value", sa.Text(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("key"),
+    )
+
+    op.create_table(
+        "athlete_profiles",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=True),
+        sa.Column("date_of_birth", sa.Date(), nullable=True),
+        sa.Column("weight_kg", sa.Float(), nullable=True),
+        sa.Column("goal_race", sa.Text(), nullable=True),
+        sa.Column("goal_race_date", sa.Date(), nullable=True),
+        sa.Column("threshold_pace_min_km", sa.Float(), nullable=True),
+        sa.Column("threshold_hr", sa.Integer(), nullable=True),
+        sa.Column("threshold_power", sa.Integer(), nullable=True),
+        sa.Column("max_hr", sa.Integer(), nullable=True),
+        sa.Column("resting_hr", sa.Integer(), nullable=True),
+        sa.Column("injury_history", sa.Text(), nullable=True),
+        sa.Column("weekly_availability", sa.Text(), nullable=True),
+        sa.Column("training_preferences", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "zone_configs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("zone_type", sa.String(20), nullable=False),
+        sa.Column("zone_number", sa.Integer(), nullable=False),
+        sa.Column("zone_name", sa.String(50), nullable=False),
+        sa.Column("zone_color", sa.String(20), nullable=False),
+        sa.Column("min_pct", sa.Float(), nullable=True),
+        sa.Column("max_pct", sa.Float(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("zone_type", "zone_number", name="uq_zone_type_number"),
+    )
+    op.create_index("ix_zone_configs_zone_type", "zone_configs", ["zone_type"], unique=False)
+
+    op.create_table(
+        "training_plans",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("generated_at", sa.DateTime(), nullable=True),
+        sa.Column("week_start", sa.Date(), nullable=False),
+        sa.Column("plan_weeks", sa.Integer(), nullable=True),
+        sa.Column("phase", sa.Text(), nullable=True),
+        sa.Column("overview", sa.Text(), nullable=True),
+        sa.Column("raw_json", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_training_plans_generated_at", "training_plans", ["generated_at"], unique=False)
+
+    op.create_table(
+        "training_plan_days",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("plan_id", sa.Integer(), nullable=False),
+        sa.Column("day_date", sa.Date(), nullable=False),
+        sa.Column("day_of_week", sa.Text(), nullable=False),
+        sa.Column("week_number", sa.Integer(), nullable=False),
+        sa.Column("workout_type", sa.Text(), nullable=False),
+        sa.Column("target_distance_m", sa.Float(), nullable=True),
+        sa.Column("target_pace_min_km", sa.Float(), nullable=True),
+        sa.Column("target_pace_display", sa.Text(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("week_theme", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_training_plan_days_plan_id", "training_plan_days", ["plan_id"], unique=False)
+    op.create_index("ix_training_plan_days_day_date", "training_plan_days", ["day_date"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_table("training_plan_days")
+    op.drop_table("training_plans")
+    op.drop_table("zone_configs")
+    op.drop_table("athlete_profiles")
+    op.drop_table("sync_status")
+    op.drop_table("metric_zones")
+    op.drop_table("garmin_calendar_events")
+    op.drop_table("races")
+    op.drop_table("insights")
+    op.drop_table("daily_summaries")
+    op.drop_table("activities")
+    op.drop_table("users")

--- a/app/database.py
+++ b/app/database.py
@@ -1,8 +1,9 @@
 import logging
 import os
 from contextlib import contextmanager
+from pathlib import Path
 
-from sqlalchemy import create_engine, event, text
+from sqlalchemy import create_engine, event, inspect, text
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 from app.config import settings
@@ -49,83 +50,15 @@ def db_session():
         db.close()
 
 
-def _migrate_db():
-    """Add new columns to existing tables if they don't exist."""
-    logger = logging.getLogger(__name__)
-    new_activity_columns = {
-        "avg_ground_contact_time": "FLOAT",
-        "avg_vertical_oscillation": "FLOAT",
-        "avg_vertical_ratio": "FLOAT",
-        "normalized_power": "FLOAT",
-        "training_stress_score": "FLOAT",
-        "intensity_factor": "FLOAT",
-        "avg_respiration_rate": "FLOAT",
-        "max_respiration_rate": "FLOAT",
-        "avg_speed": "FLOAT",
-        "max_speed": "FLOAT",
-        "min_hr": "INTEGER",
-        "max_elevation": "FLOAT",
-        "min_elevation": "FLOAT",
-        "max_cadence": "FLOAT",
-        "run_time_sec": "FLOAT",
-        "walk_time_sec": "FLOAT",
-        "typed_splits_json": "TEXT",
-        "power_zones_json": "TEXT",
-        "mean_max_json": "TEXT",
-        "feedback_rating": "VARCHAR(10)",
-        "feedback_tags": "TEXT",
-        "feedback_text": "TEXT",
-    }
-    try:
-        with engine.connect() as conn:
-            rows = conn.execute(text("PRAGMA table_info(activities)")).fetchall()
-            existing = {row[1] for row in rows}
-            added = []
-            for col, dtype in new_activity_columns.items():
-                if col not in existing:
-                    conn.execute(text(f"ALTER TABLE activities ADD COLUMN {col} {dtype}"))
-                    added.append(col)
-            conn.commit()
-            if added:
-                logger.info("Migrated activities table: added %s", ", ".join(added))
-    except Exception:
-        logger.debug("Migration skipped (table may not exist yet)")
+def _alembic_config():
+    from alembic.config import Config as AlembicConfig
 
-    new_daily_summary_columns = {
-        "hrv_avg": "FLOAT",
-        "hrv_weekly_avg": "FLOAT",
-        "hrv_status": "VARCHAR(20)",
-    }
-    try:
-        with engine.connect() as conn:
-            rows = conn.execute(text("PRAGMA table_info(daily_summaries)")).fetchall()
-            existing = {row[1] for row in rows}
-            added = []
-            for col, dtype in new_daily_summary_columns.items():
-                if col not in existing:
-                    conn.execute(text(f"ALTER TABLE daily_summaries ADD COLUMN {col} {dtype}"))
-                    added.append(col)
-            conn.commit()
-            if added:
-                logger.info("Migrated daily_summaries table: added %s", ", ".join(added))
-    except Exception:
-        logger.debug("Migration skipped (daily_summaries table may not exist yet)")
-
-    new_profile_columns = {"threshold_power": "INTEGER"}
-    try:
-        with engine.connect() as conn:
-            rows = conn.execute(text("PRAGMA table_info(athlete_profiles)")).fetchall()
-            existing = {row[1] for row in rows}
-            added = []
-            for col, dtype in new_profile_columns.items():
-                if col not in existing:
-                    conn.execute(text(f"ALTER TABLE athlete_profiles ADD COLUMN {col} {dtype}"))
-                    added.append(col)
-            conn.commit()
-            if added:
-                logger.info("Migrated athlete_profiles table: added %s", ", ".join(added))
-    except Exception:
-        logger.debug("Migration skipped (athlete_profiles table may not exist yet)")
+    cfg = AlembicConfig()
+    cfg.set_main_option(
+        "script_location", str(Path(__file__).parent.parent / "alembic")
+    )
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{settings.db_path}")
+    return cfg
 
 
 def _seed_metric_zones():
@@ -221,9 +154,21 @@ def _seed_zone_configs():
 
 
 def init_db():
+    from alembic import command
+    from alembic.runtime.migration import MigrationContext
+
     from app import models  # noqa: F401
 
-    Base.metadata.create_all(bind=engine)
-    _migrate_db()
+    alembic_cfg = _alembic_config()
+
+    # Baseline detection: if app tables exist but Alembic has never run, stamp
+    # the DB as already at head so we don't try to recreate existing tables.
+    with engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        if ctx.get_current_revision() is None:
+            if "activities" in inspect(engine).get_table_names():
+                command.stamp(alembic_cfg, "head")
+
+    command.upgrade(alembic_cfg, "head")
     _seed_metric_zones()
     _seed_zone_configs()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+alembic==1.18.4
 fastapi==0.115.6
 uvicorn[standard]==0.34.0
 jinja2==3.1.4

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,5 +1,6 @@
+from sqlalchemy import inspect, text
+
 from app import database
-from app.models import MetricZone
 
 
 def test_get_db_yields_and_closes(monkeypatch):
@@ -40,7 +41,6 @@ def test_init_db_seeds_metric_zones():
     # Operates on the real module engine (a local SQLite file in CI).
     database.init_db()
     with database.engine.connect() as conn:
-        from sqlalchemy import text
         count = conn.execute(text("SELECT COUNT(*) FROM metric_zones")).scalar()
     assert count and count > 0
 
@@ -48,17 +48,41 @@ def test_init_db_seeds_metric_zones():
 def test_seed_metric_zones_is_idempotent():
     database.init_db()
     with database.engine.connect() as conn:
-        from sqlalchemy import text
         first = conn.execute(text("SELECT COUNT(*) FROM metric_zones")).scalar()
     # Running again must not duplicate rows.
     database._seed_metric_zones()
     with database.engine.connect() as conn:
-        from sqlalchemy import text
         second = conn.execute(text("SELECT COUNT(*) FROM metric_zones")).scalar()
     assert first == second
 
 
-def test_migrate_db_is_safe_to_rerun():
-    # Adding already-present columns must not raise.
+def test_init_db_creates_all_tables():
     database.init_db()
-    database._migrate_db()
+    table_names = inspect(database.engine).get_table_names()
+    expected = {
+        "activities",
+        "daily_summaries",
+        "insights",
+        "races",
+        "garmin_calendar_events",
+        "metric_zones",
+        "sync_status",
+        "athlete_profiles",
+        "zone_configs",
+        "training_plans",
+        "training_plan_days",
+        "users",
+    }
+    assert expected.issubset(set(table_names))
+
+
+def test_init_db_is_idempotent():
+    # Running init_db twice must not raise (Alembic upgrade head is a no-op at head).
+    database.init_db()
+    database.init_db()
+
+
+def test_alembic_version_table_exists():
+    database.init_db()
+    table_names = inspect(database.engine).get_table_names()
+    assert "alembic_version" in table_names


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled `_migrate_db()` column-add helper in `app/database.py` with Alembic, giving the project a proper versioned migration system going forward
- Adds `alembic==1.18.4` to `requirements.txt`
- Creates `alembic/` with `env.py` (reuses the app engine so WAL/foreign-key pragmas stay active; picks up `DB_PATH` from `app.config.settings` for both programmatic and CLI use), `script.py.mako`, and an initial migration (`e3a9b1c2d4f5`) that creates all 12 current tables in full
- Updates `init_db()` to run `alembic upgrade head` programmatically; adds baseline detection that stamps pre-Alembic databases at head instead of trying to recreate existing tables
- Updates `tests/test_database.py`: drops `_migrate_db` test, adds assertions for expected tables, `alembic_version` presence, and idempotent `init_db`

## Test plan

- [ ] `pytest tests/test_database.py` — all 7 tests pass (including new Alembic-specific assertions)
- [ ] `pytest tests/` — full suite 353 tests pass, coverage gate (80%) maintained
- [ ] Fresh DB: `init_db()` runs the migration and creates all tables + `alembic_version`
- [ ] Existing pre-Alembic DB: `init_db()` stamps at head without re-running DDL
- [ ] `alembic upgrade head` from CLI works via `alembic.ini`
- [ ] `alembic revision --autogenerate -m "..."` detects future model changes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5WBrC61RFqvf1uPddFiJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5WBrC61RFqvf1uPddFiJJ)_