### PR TITLE
fix: add alembic/ to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ ./app/
+COPY alembic/ ./alembic/
 COPY static/ ./static/
 
 COPY --from=frontend-build /frontend/dist /app/frontend/dist


### PR DESCRIPTION
## Summary

- Adds `COPY alembic/ ./alembic/` to the Dockerfile so the Alembic migration scripts are present in the built image
- Without this, the app crashed on startup with `alembic.util.exc.CommandError: Path doesn't exist: /app/alembic`

## Root cause

PR #70 introduced the `alembic/` directory but the Dockerfile only had explicit `COPY app/` and `COPY static/` lines — the new `alembic/` directory was never added, so the migration scripts were absent from the container image.

## Test plan

- [ ] Docker build succeeds and `alembic/` is present at `/app/alembic/` inside the image
- [ ] App starts without the `Path doesn't exist: /app/alembic` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5WBrC61RFqvf1uPddFiJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5WBrC61RFqvf1uPddFiJJ)_