### PR TITLE
feat: P0-3 — closed-loop plan generation (adherence + readiness aware)

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -950,7 +950,92 @@ Rules:
 - Distribute load progressively: build 2 weeks, recover 1 week, then race-specific or peak.
 - Account for any upcoming races as goal events (taper if race is within 3 weeks).
 - Respect injury history — avoid high-impact volume if relevant injuries are listed.
+- When a "Current Plan Adherence" section is present, use it to shape the new plan:
+  * Adherence ≥80%: the athlete is consistent — progress load as designed.
+  * Adherence 60–79%: moderate disruption — keep similar volume but reduce the count of the
+    session type missed most often (e.g. one fewer interval day).
+  * Adherence <60%: significant disruption — scale total weekly volume down ~10–15% and
+    prioritize key quality sessions (one tempo/interval + long run) over quantity.
+  * If the same workout type is repeatedly missed, reduce or replace it with a more accessible
+    type (e.g. swap interval → tempo, or tempo → easy with strides).
+  * After multiple consecutive missed sessions, treat the first week of the new plan as a
+    rebuild week (easy/moderate volume) before resuming normal load.
 """
+
+
+def _build_plan_adherence_context(db: Session, reference_date: date) -> str | None:
+    """Build adherence summary for the most recent training plan.
+
+    For each non-rest day in the current plan that has already passed, checks
+    whether an activity was completed and notes distance adherence. Returns None
+    when there is no active plan or no past scheduled sessions yet.
+    """
+    plan = (
+        db.query(TrainingPlan)
+        .order_by(TrainingPlan.generated_at.desc())
+        .first()
+    )
+    if not plan:
+        return None
+
+    past_days = (
+        db.query(TrainingPlanDay)
+        .filter(
+            TrainingPlanDay.plan_id == plan.id,
+            TrainingPlanDay.day_date < reference_date,
+            TrainingPlanDay.workout_type != "rest",
+        )
+        .order_by(TrainingPlanDay.day_date.asc())
+        .all()
+    )
+    if not past_days:
+        return None
+
+    completed = 0
+    missed = 0
+    rows: list[str] = []
+
+    for plan_day in past_days:
+        day_start = datetime.combine(plan_day.day_date, datetime.min.time())
+        day_end = day_start + timedelta(days=1)
+        activity = (
+            db.query(Activity)
+            .filter(
+                Activity.started_at >= day_start,
+                Activity.started_at < day_end,
+            )
+            .first()
+        )
+        if activity:
+            completed += 1
+            dist_note = ""
+            if plan_day.target_distance_m and activity.distance_m:
+                pct = (activity.distance_m / plan_day.target_distance_m) * 100
+                dist_note = (
+                    f" ({pct:.0f}% of planned {plan_day.target_distance_m / 1000:.1f} km)"
+                )
+            rows.append(
+                f"- {plan_day.day_date} [{plan_day.workout_type}] COMPLETED{dist_note}"
+            )
+        else:
+            missed += 1
+            target_note = ""
+            if plan_day.target_distance_m:
+                target_note = f" (planned {plan_day.target_distance_m / 1000:.1f} km)"
+            rows.append(
+                f"- {plan_day.day_date} [{plan_day.workout_type}] MISSED{target_note}"
+            )
+
+    total = completed + missed
+    if total == 0:
+        return None
+
+    rate = (completed / total) * 100
+    lines = [
+        f"## Current Plan Adherence ({total} scheduled sessions)",
+        f"Completed: {completed}/{total} ({rate:.0f}%)",
+    ] + rows
+    return "\n".join(lines)
 
 
 def _build_plan_context(db: Session, reference_date: date) -> str:
@@ -1011,6 +1096,11 @@ def _build_plan_context(db: Session, reference_date: date) -> str:
             weeks.append(f"- Week of {week_start}: {count} runs, {(dist or 0) / 1000:.1f} km")
     if weeks:
         sections.append("## Recent Weekly Volume\n" + "\n".join(weeks))
+
+    # Adherence to the current plan
+    adherence_ctx = _build_plan_adherence_context(db, reference_date)
+    if adherence_ctx:
+        sections.append(adherence_ctx)
 
     # Upcoming races
     upcoming = (

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -13,6 +13,8 @@ from app.models import (
     Insight,
     MetricZone,
     SyncStatus,
+    TrainingPlan,
+    TrainingPlanDay,
 )
 
 
@@ -440,3 +442,153 @@ def test_weekly_review_no_activities_skips(db, patch_db_session, monkeypatch):
     ai_coach.weekly_review()
     called.assert_not_called()
     assert db.query(Insight).count() == 0
+
+
+# --- _build_plan_adherence_context (P0-3) ---
+
+def _seed_plan(db, week_start: date) -> TrainingPlan:
+    plan = TrainingPlan(
+        generated_at=datetime(2026, 6, 9, 9, 0, tzinfo=timezone.utc),
+        week_start=week_start,
+        plan_weeks=1,
+        phase="build",
+        overview="Test plan",
+    )
+    db.add(plan)
+    db.flush()
+    return plan
+
+
+def test_plan_adherence_no_plan_returns_none(db):
+    result = ai_coach._build_plan_adherence_context(db, date(2026, 6, 21))
+    assert result is None
+
+
+def test_plan_adherence_no_past_days_returns_none(db):
+    # Plan starts today — no past days yet.
+    plan = _seed_plan(db, date(2026, 6, 21))
+    db.add(TrainingPlanDay(
+        plan_id=plan.id, day_date=date(2026, 6, 21), day_of_week="Sunday",
+        week_number=1, workout_type="long", target_distance_m=20000,
+    ))
+    db.commit()
+    result = ai_coach._build_plan_adherence_context(db, date(2026, 6, 21))
+    assert result is None
+
+
+def test_plan_adherence_rest_days_excluded(db):
+    plan = _seed_plan(db, date(2026, 6, 16))
+    db.add(TrainingPlanDay(
+        plan_id=plan.id, day_date=date(2026, 6, 16), day_of_week="Monday",
+        week_number=1, workout_type="rest",
+    ))
+    db.commit()
+    result = ai_coach._build_plan_adherence_context(db, date(2026, 6, 21))
+    assert result is None
+
+
+def test_plan_adherence_completed_session(db):
+    ref = date(2026, 6, 21)
+    plan = _seed_plan(db, date(2026, 6, 16))
+    db.add(TrainingPlanDay(
+        plan_id=plan.id, day_date=date(2026, 6, 16), day_of_week="Monday",
+        week_number=1, workout_type="easy", target_distance_m=9000,
+    ))
+    # Matching activity on the planned date.
+    db.add(Activity(
+        garmin_id=10, name="Easy Run", activity_type="running",
+        started_at=datetime(2026, 6, 16, 7, 0), distance_m=9500,
+    ))
+    db.commit()
+
+    result = ai_coach._build_plan_adherence_context(db, ref)
+
+    assert result is not None
+    assert "Completed: 1/1" in result
+    assert "100%" in result
+    assert "COMPLETED" in result
+    assert "2026-06-16" in result
+    assert "[easy]" in result
+    # Distance note included because target_distance_m is set.
+    assert "planned 9.0 km" in result
+
+
+def test_plan_adherence_missed_session(db):
+    ref = date(2026, 6, 21)
+    plan = _seed_plan(db, date(2026, 6, 16))
+    db.add(TrainingPlanDay(
+        plan_id=plan.id, day_date=date(2026, 6, 17), day_of_week="Tuesday",
+        week_number=1, workout_type="interval", target_distance_m=10000,
+    ))
+    db.commit()
+
+    result = ai_coach._build_plan_adherence_context(db, ref)
+
+    assert result is not None
+    assert "Completed: 0/1" in result
+    assert "0%" in result
+    assert "MISSED" in result
+    assert "2026-06-17" in result
+    assert "[interval]" in result
+
+
+def test_plan_adherence_mixed_sessions(db):
+    ref = date(2026, 6, 21)
+    plan = _seed_plan(db, date(2026, 6, 16))
+    # Day 1: completed with activity
+    db.add(TrainingPlanDay(
+        plan_id=plan.id, day_date=date(2026, 6, 16), day_of_week="Monday",
+        week_number=1, workout_type="easy", target_distance_m=9000,
+    ))
+    db.add(Activity(
+        garmin_id=11, name="Easy Run", activity_type="running",
+        started_at=datetime(2026, 6, 16, 8, 0), distance_m=9000,
+    ))
+    # Day 2: missed
+    db.add(TrainingPlanDay(
+        plan_id=plan.id, day_date=date(2026, 6, 17), day_of_week="Tuesday",
+        week_number=1, workout_type="tempo", target_distance_m=12000,
+    ))
+    # Day 3: completed, no target distance
+    db.add(TrainingPlanDay(
+        plan_id=plan.id, day_date=date(2026, 6, 18), day_of_week="Wednesday",
+        week_number=1, workout_type="easy",
+    ))
+    db.add(Activity(
+        garmin_id=12, name="Easy Run 2", activity_type="running",
+        started_at=datetime(2026, 6, 18, 7, 0), distance_m=8000,
+    ))
+    db.commit()
+
+    result = ai_coach._build_plan_adherence_context(db, ref)
+
+    assert result is not None
+    assert "Completed: 2/3" in result
+    assert "67%" in result
+    assert "COMPLETED" in result
+    assert "MISSED" in result
+
+
+def test_build_plan_context_includes_adherence(db):
+    ref = date(2026, 6, 21)
+    plan = _seed_plan(db, date(2026, 6, 16))
+    db.add(TrainingPlanDay(
+        plan_id=plan.id, day_date=date(2026, 6, 17), day_of_week="Tuesday",
+        week_number=1, workout_type="tempo", target_distance_m=11000,
+    ))
+    db.add(Activity(
+        garmin_id=20, name="Tempo Run", activity_type="running",
+        started_at=datetime(2026, 6, 17, 7, 0), distance_m=11000,
+    ))
+    db.commit()
+
+    context = ai_coach._build_plan_context(db, ref)
+
+    assert "## Current Plan Adherence" in context
+    assert "COMPLETED" in context
+    assert "Completed: 1/1" in context
+
+
+def test_build_plan_context_no_adherence_when_no_plan(db):
+    context = ai_coach._build_plan_context(db, date(2026, 6, 21))
+    assert "## Current Plan Adherence" not in context


### PR DESCRIPTION
## Summary

- **`app/ai_coach.py`** — new `_build_plan_adherence_context` helper queries the most recent `TrainingPlan`, matches each past non-rest `TrainingPlanDay` to an executed `Activity` on that date, and formats a per-session COMPLETED/MISSED summary with distance-adherence percentages.
- **`app/ai_coach.py`** — wired into `_build_plan_context` (called by `generate_training_plan`) so the AI sees plan adherence before generating the next 4-week block.
- **`app/ai_coach.py`** — extended `_PLAN_SYSTEM_PROMPT` with adherence-aware rules: ≥80% → progress normally; 60–79% → reduce the most-missed session type; <60% → scale volume ~10–15%; repeated consecutive misses → begin new block as a rebuild week.
- **`tests/test_ai_coach.py`** — 8 new tests covering all branches of `_build_plan_adherence_context` and its inclusion in `_build_plan_context`.

## What this closes (from `docs/IMPROVEMENT_PLAN.md`)

**P0-3 · Closed-loop plan generation** — previously the plan was regenerated weekly from profile/load/volume but was blind to whether the athlete actually completed the prescribed sessions. The plan is now genuinely adaptive: it reads the current block's adherence record and shapes the next block accordingly (Runna/Garmin DSW parity).

No new routes or schema migrations needed — all data (`TrainingPlan`, `TrainingPlanDay`, `Activity`) already exists in the DB.

## Test plan

- [ ] Full test suite: 353 passing, coverage 85% (gate 80%)
- [ ] Perf suite: 31 passing, unchanged (plan generation is stubbed there)
- [ ] `_build_plan_adherence_context` returns `None` gracefully when: no plan, plan starts today (no past days), all days are rest days
- [ ] COMPLETED rows include distance-adherence percentage when `target_distance_m` is set
- [ ] MISSED rows include planned distance note
- [ ] Mixed sessions produce correct completion rate
- [ ] `_build_plan_context` includes the adherence section when plan data exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvFKVUMriA7c7bH54f6T7R

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvFKVUMriA7c7bH54f6T7R)_