### PR TITLE
feat: P1-1 — plan realignment after missed sessions

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -1195,6 +1195,75 @@ def _parse_pace_display(pace_str: str) -> float | None:
         return None
 
 
+_REALIGNMENT_MISSED_THRESHOLD = 2  # Show banner when this many sessions are missed
+
+
+def detect_plan_realignment(db: Session, reference_date: date) -> dict:
+    """Return realignment state for the current plan.
+
+    Looks at all past non-rest TrainingPlanDay rows that lack a matching
+    Activity. When the missed count reaches _REALIGNMENT_MISSED_THRESHOLD and
+    the user has not dismissed the banner (via SyncStatus), sets should_prompt
+    to True.
+    """
+    plan = (
+        db.query(TrainingPlan)
+        .order_by(TrainingPlan.generated_at.desc())
+        .first()
+    )
+    empty = {"should_prompt": False, "missed_count": 0, "total_scheduled": 0, "missed_sessions": []}
+    if not plan:
+        return empty
+
+    dismiss_row = db.query(SyncStatus).filter(
+        SyncStatus.key == "plan_realignment_dismissed_until"
+    ).first()
+    dismissed = False
+    if dismiss_row and dismiss_row.value:
+        try:
+            dismissed = date.fromisoformat(dismiss_row.value) > reference_date
+        except ValueError:
+            pass
+
+    past_days = (
+        db.query(TrainingPlanDay)
+        .filter(
+            TrainingPlanDay.plan_id == plan.id,
+            TrainingPlanDay.day_date < reference_date,
+            TrainingPlanDay.workout_type != "rest",
+        )
+        .order_by(TrainingPlanDay.day_date.asc())
+        .all()
+    )
+
+    missed_sessions: list[dict] = []
+    for plan_day in past_days:
+        day_start = datetime.combine(plan_day.day_date, datetime.min.time())
+        day_end = day_start + timedelta(days=1)
+        activity = (
+            db.query(Activity)
+            .filter(
+                Activity.started_at >= day_start,
+                Activity.started_at < day_end,
+            )
+            .first()
+        )
+        if not activity:
+            missed_sessions.append({
+                "date": plan_day.day_date,
+                "workout_type": plan_day.workout_type,
+                "target_distance_km": plan_day.target_distance_m / 1000 if plan_day.target_distance_m else None,
+            })
+
+    missed_count = len(missed_sessions)
+    return {
+        "should_prompt": missed_count >= _REALIGNMENT_MISSED_THRESHOLD and not dismissed,
+        "missed_count": missed_count,
+        "total_scheduled": len(past_days),
+        "missed_sessions": missed_sessions,
+    }
+
+
 def generate_training_plan(reference_date: date | None = None) -> TrainingPlan | None:
     """Generate and persist a 4-week AI training plan.
 

--- a/app/api.py
+++ b/app/api.py
@@ -47,6 +47,9 @@ from app.schemas import (
     SettingsResponse,
     TodayResponse,
     TrainingLoadResponse,
+    MissedPlanSession,
+    PlanRealignmentRequest,
+    PlanRealignmentStatus,
     TrainingPlanDayResponse,
     TrainingPlanResponse,
     TrainingPlanWeek,
@@ -852,6 +855,61 @@ def api_generate_training_plan():
     plan = generate_training_plan()
     if plan is None:
         raise HTTPException(status_code=500, detail="Plan generation failed — check AI config")
+    with make_session() as fresh_db:
+        db_plan = fresh_db.query(TrainingPlan).filter(TrainingPlan.id == plan.id).first()
+        if not db_plan:
+            raise HTTPException(status_code=500, detail="Plan not found after generation")
+        return _build_plan_response(db_plan, fresh_db)
+
+
+@api_router.get("/training-plan/realignment-status", response_model=PlanRealignmentStatus)
+def api_get_realignment_status(db: Session = Depends(get_db)):
+    """Return whether the current plan has enough missed sessions to warrant realignment."""
+    from app.ai_coach import detect_plan_realignment
+    result = detect_plan_realignment(db, date.today())
+    return PlanRealignmentStatus(
+        should_prompt=result["should_prompt"],
+        missed_count=result["missed_count"],
+        total_scheduled=result["total_scheduled"],
+        missed_sessions=[
+            MissedPlanSession(
+                date=s["date"],
+                workout_type=s["workout_type"],
+                target_distance_km=s["target_distance_km"],
+            )
+            for s in result["missed_sessions"]
+        ],
+    )
+
+
+@api_router.post("/training-plan/realign")
+def api_realign_plan(body: PlanRealignmentRequest, db: Session = Depends(get_db)):
+    """Handle plan realignment: regenerate the plan or dismiss the banner for 7 days."""
+    if body.action == "dismiss":
+        dismiss_until = (date.today() + timedelta(days=7)).isoformat()
+        row = db.query(SyncStatus).filter(
+            SyncStatus.key == "plan_realignment_dismissed_until"
+        ).first()
+        if row:
+            row.value = dismiss_until
+        else:
+            db.add(SyncStatus(key="plan_realignment_dismissed_until", value=dismiss_until))
+        db.commit()
+        return {"status": "dismissed", "until": dismiss_until}
+
+    # action == "regenerate"
+    from app.ai_coach import generate_training_plan
+    from app.database import db_session as make_session
+    plan = generate_training_plan()
+    if plan is None:
+        raise HTTPException(status_code=500, detail="Plan generation failed — check AI config")
+    # Clear dismiss snooze after generating a new plan
+    row = db.query(SyncStatus).filter(
+        SyncStatus.key == "plan_realignment_dismissed_until"
+    ).first()
+    if row:
+        db.delete(row)
+        db.commit()
     with make_session() as fresh_db:
         db_plan = fresh_db.query(TrainingPlan).filter(TrainingPlan.id == plan.id).first()
         if not db_plan:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -475,3 +475,20 @@ class TrainingPlanResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class MissedPlanSession(BaseModel):
+    date: date
+    workout_type: str
+    target_distance_km: float | None = None
+
+
+class PlanRealignmentStatus(BaseModel):
+    should_prompt: bool
+    missed_count: int
+    total_scheduled: int
+    missed_sessions: list[MissedPlanSession] = []
+
+
+class PlanRealignmentRequest(BaseModel):
+    action: Literal["regenerate", "dismiss"]

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -11,6 +11,7 @@ import type {
   FeedbackRequest,
   InsightResponse,
   PerformanceCurveResponse,
+  PlanRealignmentStatus,
   SettingsResponse,
   AiConfigResponse,
   AiConfigRequest,
@@ -252,5 +253,24 @@ export function usePerformanceCurve(days = 90) {
   return useQuery({
     queryKey: ['performance-curve', days],
     queryFn: () => apiGet<PerformanceCurveResponse>(`/performance-curve?days=${days}`),
+  })
+}
+
+export function useRealignmentStatus() {
+  return useQuery({
+    queryKey: ['realignment-status'],
+    queryFn: () => apiGet<PlanRealignmentStatus>('/training-plan/realignment-status'),
+  })
+}
+
+export function useRealignPlan() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (action: 'regenerate' | 'dismiss') =>
+      apiPost<unknown>('/training-plan/realign', { action }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['training-plan'] })
+      qc.invalidateQueries({ queryKey: ['realignment-status'] })
+    },
   })
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -378,6 +378,19 @@ export interface TrainingPlanResponse {
   weeks: TrainingPlanWeek[]
 }
 
+export interface MissedPlanSession {
+  date: string
+  workout_type: string
+  target_distance_km: number | null
+}
+
+export interface PlanRealignmentStatus {
+  should_prompt: boolean
+  missed_count: number
+  total_scheduled: number
+  missed_sessions: MissedPlanSession[]
+}
+
 export interface PerformanceCurvePoint {
   duration_sec: number
   actual_value: number

--- a/frontend/src/components/plan/PlanView.css
+++ b/frontend/src/components/plan/PlanView.css
@@ -314,3 +314,65 @@
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+/* Realignment banner */
+.realignment-banner {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  background: color-mix(in srgb, var(--color-tempo) 12%, var(--bg-card));
+  border: 1px solid color-mix(in srgb, var(--color-tempo) 40%, transparent);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  margin-bottom: 14px;
+}
+
+.realignment-icon {
+  flex-shrink: 0;
+  color: var(--color-tempo);
+  margin-top: 1px;
+}
+
+.realignment-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.realignment-msg {
+  font-size: 0.86rem;
+  color: var(--text);
+  line-height: 1.4;
+}
+
+.realignment-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.realignment-btn {
+  font-size: 0.8rem;
+  padding: 6px 14px;
+}
+
+.realignment-dismiss {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s;
+}
+
+.realignment-dismiss:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.realignment-dismiss:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/plan/PlanView.tsx
+++ b/frontend/src/components/plan/PlanView.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { ClipboardList, RefreshCw, ChevronLeft, ChevronRight } from 'lucide-react'
-import { useTrainingPlan, useGenerateTrainingPlan } from '../../api/hooks'
+import { ClipboardList, RefreshCw, ChevronLeft, ChevronRight, AlertTriangle } from 'lucide-react'
+import { useTrainingPlan, useGenerateTrainingPlan, useRealignmentStatus, useRealignPlan } from '../../api/hooks'
 import type { TrainingPlanDay, TrainingPlanWeek } from '../../api/types'
 import './PlanView.css'
 
@@ -68,6 +68,42 @@ function DayCard({ day }: { day: TrainingPlanDay }) {
   )
 }
 
+function RealignmentBanner() {
+  const { data: status } = useRealignmentStatus()
+  const { mutate: realign, isPending } = useRealignPlan()
+
+  if (!status?.should_prompt) return null
+
+  return (
+    <div className="realignment-banner">
+      <AlertTriangle size={16} className="realignment-icon" />
+      <div className="realignment-body">
+        <span className="realignment-msg">
+          {status.missed_count} planned session{status.missed_count !== 1 ? 's' : ''} missed.
+          Regenerate to adapt your plan?
+        </span>
+        <div className="realignment-actions">
+          <button
+            className="btn-primary realignment-btn"
+            onClick={() => realign('regenerate')}
+            disabled={isPending}
+          >
+            {isPending ? <RefreshCw size={13} className="spin" /> : null}
+            Regenerate Plan
+          </button>
+          <button
+            className="realignment-dismiss"
+            onClick={() => realign('dismiss')}
+            disabled={isPending}
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function WeekView({ week }: { week: TrainingPlanWeek }) {
   return (
     <div className="plan-week">
@@ -122,6 +158,8 @@ export default function PlanView() {
 
   return (
     <div className="plan-view">
+      <RealignmentBanner />
+
       <div className="plan-header">
         <div className="plan-meta">
           {plan.phase && (

--- a/frontend/src/components/today/TodayView.css
+++ b/frontend/src/components/today/TodayView.css
@@ -82,3 +82,73 @@
     grid-template-columns: repeat(4, 1fr);
   }
 }
+
+/* Realignment banner */
+.today-realignment-banner {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  background: color-mix(in srgb, var(--color-tempo) 12%, var(--bg-card));
+  border: 1px solid color-mix(in srgb, var(--color-tempo) 40%, transparent);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+}
+
+.today-realignment-icon {
+  flex-shrink: 0;
+  color: var(--color-tempo);
+  margin-top: 1px;
+}
+
+.today-realignment-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.today-realignment-msg {
+  font-size: 0.86rem;
+  color: var(--text);
+  line-height: 1.4;
+}
+
+.today-realignment-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.today-realignment-btn {
+  font-size: 0.8rem;
+  padding: 6px 14px;
+}
+
+.today-realignment-dismiss {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s;
+}
+
+.today-realignment-dismiss:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.today-realignment-dismiss:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/frontend/src/components/today/TodayView.tsx
+++ b/frontend/src/components/today/TodayView.tsx
@@ -1,5 +1,5 @@
 import { useDateContext } from '../../App'
-import { useToday } from '../../api/hooks'
+import { useToday, useRealignmentStatus, useRealignPlan } from '../../api/hooks'
 import { formatDateKey, format, isToday as checkIsToday } from '../../utils/date'
 import { formatDuration } from '../../utils/formatting'
 import WorkoutCard from './WorkoutCard'
@@ -8,6 +8,7 @@ import WeekOverview from './WeekOverview'
 import TrainingLoadChart from './TrainingLoadChart'
 import ReadinessCard from './ReadinessCard'
 import InsightsList from './InsightsList'
+import { AlertTriangle, RefreshCw } from 'lucide-react'
 import './TodayView.css'
 
 function formatPriority(priority: string | null): string | null {
@@ -17,6 +18,44 @@ function formatPriority(priority: string | null): string | null {
   return null
 }
 
+function TodayRealignmentBanner() {
+  const { data: status } = useRealignmentStatus()
+  const { mutate: realign, isPending } = useRealignPlan()
+
+  if (!status?.should_prompt) return null
+
+  return (
+    <section className="today-section">
+      <div className="today-realignment-banner">
+        <AlertTriangle size={16} className="today-realignment-icon" />
+        <div className="today-realignment-body">
+          <span className="today-realignment-msg">
+            {status.missed_count} planned session{status.missed_count !== 1 ? 's' : ''} missed.
+            Regenerate to adapt your plan?
+          </span>
+          <div className="today-realignment-actions">
+            <button
+              className="btn-primary today-realignment-btn"
+              onClick={() => realign('regenerate')}
+              disabled={isPending}
+            >
+              {isPending ? <RefreshCw size={13} className="spin" /> : null}
+              Regenerate
+            </button>
+            <button
+              className="today-realignment-dismiss"
+              onClick={() => realign('dismiss')}
+              disabled={isPending}
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
 export default function TodayView() {
   const { selectedDate } = useDateContext()
   const dateKey = formatDateKey(selectedDate)
@@ -24,12 +63,12 @@ export default function TodayView() {
 
   if (isLoading) return <div className="spinner" />
 
-  const dateLabel = checkIsToday(selectedDate)
-    ? 'Today'
-    : format(selectedDate, 'EEEE, d MMM')
+  const isViewingToday = checkIsToday(selectedDate)
+  const dateLabel = isViewingToday ? 'Today' : format(selectedDate, 'EEEE, d MMM')
 
   return (
     <div className="today-view">
+      {isViewingToday && <TodayRealignmentBanner />}
       {/* Today's workouts */}
       <section className="today-section">
         <h2 className="section-title">{dateLabel}'s workouts</h2>

--- a/perf/test_perf_endpoints.py
+++ b/perf/test_perf_endpoints.py
@@ -105,6 +105,10 @@ def test_get_training_plan(benchmark, client):
     _ok(benchmark(lambda: client.get("/api/v1/training-plan")))
 
 
+def test_get_realignment_status(benchmark, client):
+    _ok(benchmark(lambda: client.get("/api/v1/training-plan/realignment-status")))
+
+
 def test_export_activities_csv(benchmark, client):
     _ok(benchmark(lambda: client.get("/api/v1/export/activities", params={"format": "csv"})))
 
@@ -150,6 +154,12 @@ def test_apply_threshold_estimate(benchmark, client):
 def test_generate_training_plan(benchmark, client):
     # AI generation is stubbed; this measures persistence + serialization.
     _ok(benchmark(lambda: client.post("/api/v1/training-plan/generate")))
+
+
+def test_trigger_realignment_dismiss(benchmark, client):
+    # Dismiss is idempotent; measures the SyncStatus upsert path.
+    _ok(benchmark(lambda: client.post(
+        "/api/v1/training-plan/realign", json={"action": "dismiss"})))
 
 
 def test_trigger_analysis(benchmark, client, ids):

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -592,3 +592,120 @@ def test_build_plan_context_includes_adherence(db):
 def test_build_plan_context_no_adherence_when_no_plan(db):
     context = ai_coach._build_plan_context(db, date(2026, 6, 21))
     assert "## Current Plan Adherence" not in context
+
+
+# --- detect_plan_realignment ---
+
+def _seed_plan_with_days(db, plan_start, days_config):
+    """Seed a TrainingPlan with specified day configs [{date, workout_type, dist_m}]."""
+    plan = TrainingPlan(
+        generated_at=datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc),
+        week_start=plan_start,
+        plan_weeks=4,
+    )
+    db.add(plan)
+    db.flush()
+    for cfg in days_config:
+        db.add(TrainingPlanDay(
+            plan_id=plan.id,
+            day_date=cfg["date"],
+            day_of_week=cfg["date"].strftime("%A"),
+            week_number=1,
+            workout_type=cfg.get("workout_type", "easy"),
+            target_distance_m=cfg.get("dist_m"),
+        ))
+    db.commit()
+    return plan
+
+
+def test_detect_realignment_no_plan(db):
+    ref = date(2026, 6, 21)
+    result = ai_coach.detect_plan_realignment(db, ref)
+    assert result["should_prompt"] is False
+    assert result["missed_count"] == 0
+    assert result["missed_sessions"] == []
+
+
+def test_detect_realignment_below_threshold(db):
+    ref = date(2026, 6, 21)
+    _seed_plan_with_days(db, date(2026, 6, 16), [
+        {"date": date(2026, 6, 17), "workout_type": "easy", "dist_m": 8000},
+    ])
+    result = ai_coach.detect_plan_realignment(db, ref)
+    # 1 missed < threshold of 2
+    assert result["should_prompt"] is False
+    assert result["missed_count"] == 1
+    assert result["total_scheduled"] == 1
+
+
+def test_detect_realignment_at_threshold(db):
+    ref = date(2026, 6, 21)
+    _seed_plan_with_days(db, date(2026, 6, 16), [
+        {"date": date(2026, 6, 17), "workout_type": "easy"},
+        {"date": date(2026, 6, 18), "workout_type": "tempo"},
+    ])
+    result = ai_coach.detect_plan_realignment(db, ref)
+    assert result["should_prompt"] is True
+    assert result["missed_count"] == 2
+    assert result["total_scheduled"] == 2
+    assert len(result["missed_sessions"]) == 2
+
+
+def test_detect_realignment_rest_days_excluded(db):
+    ref = date(2026, 6, 21)
+    _seed_plan_with_days(db, date(2026, 6, 16), [
+        {"date": date(2026, 6, 17), "workout_type": "rest"},
+        {"date": date(2026, 6, 18), "workout_type": "rest"},
+        {"date": date(2026, 6, 19), "workout_type": "rest"},
+    ])
+    result = ai_coach.detect_plan_realignment(db, ref)
+    # Only rest days → no scheduled workout sessions
+    assert result["should_prompt"] is False
+    assert result["missed_count"] == 0
+    assert result["total_scheduled"] == 0
+
+
+def test_detect_realignment_completed_sessions_reduce_count(db):
+    ref = date(2026, 6, 21)
+    _seed_plan_with_days(db, date(2026, 6, 16), [
+        {"date": date(2026, 6, 17), "workout_type": "easy", "dist_m": 8000},
+        {"date": date(2026, 6, 18), "workout_type": "tempo", "dist_m": 10000},
+        {"date": date(2026, 6, 19), "workout_type": "interval", "dist_m": 12000},
+    ])
+    # Complete only the first session
+    db.add(Activity(
+        garmin_id=501, name="Easy Run", activity_type="running",
+        started_at=datetime(2026, 6, 17, 8, 0), distance_m=8200,
+    ))
+    db.commit()
+    result = ai_coach.detect_plan_realignment(db, ref)
+    assert result["total_scheduled"] == 3
+    assert result["missed_count"] == 2
+    assert result["should_prompt"] is True
+
+
+def test_detect_realignment_dismissed_suppresses_prompt(db):
+    ref = date(2026, 6, 21)
+    _seed_plan_with_days(db, date(2026, 6, 16), [
+        {"date": date(2026, 6, 17), "workout_type": "easy"},
+        {"date": date(2026, 6, 18), "workout_type": "tempo"},
+    ])
+    # Simulate dismiss: set snooze date to future
+    db.add(SyncStatus(key="plan_realignment_dismissed_until", value="2026-06-28"))
+    db.commit()
+    result = ai_coach.detect_plan_realignment(db, ref)
+    assert result["should_prompt"] is False
+    assert result["missed_count"] == 2  # still detected, just suppressed
+
+
+def test_detect_realignment_expired_dismiss_prompts(db):
+    ref = date(2026, 6, 21)
+    _seed_plan_with_days(db, date(2026, 6, 16), [
+        {"date": date(2026, 6, 17), "workout_type": "easy"},
+        {"date": date(2026, 6, 18), "workout_type": "tempo"},
+    ])
+    # Dismiss expired in the past
+    db.add(SyncStatus(key="plan_realignment_dismissed_until", value="2026-06-14"))
+    db.commit()
+    result = ai_coach.detect_plan_realignment(db, ref)
+    assert result["should_prompt"] is True

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -10,6 +10,8 @@ from app.models import (
     GarminCalendarEvent,
     Insight,
     SyncStatus,
+    TrainingPlan,
+    TrainingPlanDay,
 )
 
 
@@ -294,3 +296,144 @@ def test_trigger_sync_accepted(client, no_threads, sync_type):
 
 def test_trigger_sync_unknown(client, no_threads):
     assert client.post("/api/v1/sync/bogus").status_code == 400
+
+
+# --- /training-plan/realignment-status ---
+
+def _seed_plan_and_days(db, days_config):
+    """Helper: seed a TrainingPlan + past days; returns plan."""
+    from datetime import timezone
+    plan = TrainingPlan(
+        generated_at=datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc),
+        week_start=date(2026, 6, 16),
+        plan_weeks=4,
+    )
+    db.add(plan)
+    db.flush()
+    for cfg in days_config:
+        db.add(TrainingPlanDay(
+            plan_id=plan.id,
+            day_date=cfg["date"],
+            day_of_week=cfg["date"].strftime("%A"),
+            week_number=1,
+            workout_type=cfg.get("workout_type", "easy"),
+            target_distance_m=cfg.get("dist_m"),
+        ))
+    db.commit()
+    return plan
+
+
+def test_realignment_status_no_plan(client):
+    resp = client.get("/api/v1/training-plan/realignment-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["should_prompt"] is False
+    assert body["missed_count"] == 0
+    assert body["missed_sessions"] == []
+
+
+def test_realignment_status_below_threshold(client, db):
+    _seed_plan_and_days(db, [
+        {"date": date(2026, 6, 17), "workout_type": "easy"},
+    ])
+    resp = client.get("/api/v1/training-plan/realignment-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["should_prompt"] is False
+    assert body["missed_count"] == 1
+
+
+def test_realignment_status_at_threshold(client, db):
+    _seed_plan_and_days(db, [
+        {"date": date(2026, 6, 17), "workout_type": "easy", "dist_m": 8000},
+        {"date": date(2026, 6, 18), "workout_type": "tempo", "dist_m": 10000},
+    ])
+    resp = client.get("/api/v1/training-plan/realignment-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["should_prompt"] is True
+    assert body["missed_count"] == 2
+    assert len(body["missed_sessions"]) == 2
+    assert body["missed_sessions"][0]["workout_type"] == "easy"
+    assert body["missed_sessions"][0]["target_distance_km"] == pytest.approx(8.0)
+
+
+def test_realignment_status_dismissed(client, db):
+    _seed_plan_and_days(db, [
+        {"date": date(2026, 6, 17), "workout_type": "easy"},
+        {"date": date(2026, 6, 18), "workout_type": "tempo"},
+    ])
+    db.add(SyncStatus(key="plan_realignment_dismissed_until", value="2099-01-01"))
+    db.commit()
+    resp = client.get("/api/v1/training-plan/realignment-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["should_prompt"] is False
+    assert body["missed_count"] == 2  # detected but suppressed
+
+
+# --- /training-plan/realign ---
+
+def test_realign_dismiss(client, db):
+    resp = client.post("/api/v1/training-plan/realign", json={"action": "dismiss"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "dismissed"
+    assert "until" in body
+    row = db.query(SyncStatus).filter(
+        SyncStatus.key == "plan_realignment_dismissed_until"
+    ).first()
+    assert row is not None
+    assert row.value == body["until"]
+
+
+def test_realign_dismiss_idempotent(client, db):
+    # Two dismissals: second should overwrite first.
+    client.post("/api/v1/training-plan/realign", json={"action": "dismiss"})
+    db.expire_all()
+    first = db.query(SyncStatus).filter(
+        SyncStatus.key == "plan_realignment_dismissed_until"
+    ).first().value
+    client.post("/api/v1/training-plan/realign", json={"action": "dismiss"})
+    db.expire_all()
+    second = db.query(SyncStatus).filter(
+        SyncStatus.key == "plan_realignment_dismissed_until"
+    ).first().value
+    assert second == first  # same date since both calls happen on the same day
+
+
+def test_realign_regenerate(client, db, monkeypatch, patch_db_session):
+    import app.database as _app_db
+    plan = _seed_plan_and_days(db, [])
+    # Stub the AI generation to return the existing plan's id
+    class _FakePlan:
+        id = plan.id
+    monkeypatch.setattr("app.ai_coach.generate_training_plan", lambda *a, **kw: _FakePlan())
+    # Redirect db_session (used by the endpoint's make_session) to the test DB
+    patch_db_session(_app_db)
+    resp = client.post("/api/v1/training-plan/realign", json={"action": "regenerate"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "id" in body
+
+
+def test_realign_regenerate_clears_dismiss(client, db, monkeypatch, patch_db_session):
+    import app.database as _app_db
+    plan = _seed_plan_and_days(db, [])
+    db.add(SyncStatus(key="plan_realignment_dismissed_until", value="2099-01-01"))
+    db.commit()
+    class _FakePlan:
+        id = plan.id
+    monkeypatch.setattr("app.ai_coach.generate_training_plan", lambda *a, **kw: _FakePlan())
+    patch_db_session(_app_db)
+    client.post("/api/v1/training-plan/realign", json={"action": "regenerate"})
+    db.expire_all()
+    row = db.query(SyncStatus).filter(
+        SyncStatus.key == "plan_realignment_dismissed_until"
+    ).first()
+    assert row is None
+
+
+def test_realign_invalid_action(client):
+    resp = client.post("/api/v1/training-plan/realign", json={"action": "bogus"})
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Detects when 2+ scheduled non-rest plan sessions have passed without a matching activity and surfaces a "Regenerate / Dismiss" banner on both the **Plan** and **Today** views
- `GET /api/v1/training-plan/realignment-status` — returns `should_prompt`, `missed_count`, `total_scheduled`, and the list of missed sessions
- `POST /api/v1/training-plan/realign` — `"regenerate"` triggers an AI plan re-gen (which already has full adherence context), `"dismiss"` snoozes the banner for 7 days via `SyncStatus`
- Threshold is 2 missed sessions; rest days are excluded; dismiss is cleared when a new plan is generated

## What changed

**Backend (`app/`)**
- `ai_coach.py` — `detect_plan_realignment()` helper; 7-day dismiss check via `SyncStatus`
- `api.py` — two new endpoints: `GET /training-plan/realignment-status`, `POST /training-plan/realign`
- `schemas.py` — `MissedPlanSession`, `PlanRealignmentStatus`, `PlanRealignmentRequest`

**Frontend (`frontend/src/`)**
- `api/types.ts` — `MissedPlanSession`, `PlanRealignmentStatus` types
- `api/hooks.ts` — `useRealignmentStatus()`, `useRealignPlan()` hooks
- `components/plan/PlanView.tsx` + `PlanView.css` — `RealignmentBanner` component
- `components/today/TodayView.tsx` + `TodayView.css` — `TodayRealignmentBanner` (shown only when viewing today)

**Tests**
- 7 unit tests for `detect_plan_realignment` covering threshold, dismiss snooze, rest-day exclusion, and completed-session filtering
- 9 endpoint tests for both new routes including dismiss idempotency and regenerate flow
- 2 new perf benchmarks: `test_get_realignment_status`, `test_trigger_realignment_dismiss`
- All 396 unit tests + 33 perf tests pass

## Test plan

- [ ] Seed a plan with 2+ past non-rest days and no matching activities → banner appears on Plan and Today views
- [ ] Click "Dismiss" → banner disappears for 7 days
- [ ] Click "Regenerate Plan" → new AI plan is generated, banner clears
- [ ] Plan with only rest days or all sessions completed → no banner
- [ ] Historical date view → banner not shown (Today view only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XfC6YeTp9HBNQBb9Uk3yo

---
_Generated by [Claude Code](https://claude.ai/code/session_011XfC6YeTp9HBNQBb9Uk3yo)_