### PR TITLE
feat(p2-1): time-in-zone / intensity distribution view

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -13,6 +13,7 @@ from sqlalchemy import func
 from app import training_load
 from app import threshold as threshold_mod
 from app import adherence as adherence_mod
+from app import intensity as intensity_mod
 from app.config import settings
 from app.database import db_session
 from app.models import (
@@ -439,6 +440,17 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
             )
     if weeks:
         sections.append("## Weekly Volume (last 8 weeks)\n" + "\n".join(weeks))
+
+    # Intensity distribution (HR zones, last 4 weeks)
+    try:
+        intensity_weeks = intensity_mod.aggregate_weekly_intensity(
+            db, days=56, zone_type="hr", as_of=reference_date
+        )
+        intensity_context = intensity_mod.format_intensity_context(intensity_weeks, zone_type="hr")
+        if intensity_context:
+            sections.append(intensity_context)
+    except Exception:
+        logger.debug("Intensity context skipped", exc_info=True)
 
     # Recent daily summaries (last 7 days)
     recent_days = (

--- a/app/api.py
+++ b/app/api.py
@@ -39,6 +39,8 @@ from app.schemas import (
     DailySummaryResponse,
     FeedbackRequest,
     InsightResponse,
+    IntensityTrendsResponse,
+    IntensityWeek,
     MetricZoneResponse,
     PerformanceCurvePoint,
     PerformanceCurveResponse,
@@ -68,6 +70,7 @@ from app.schemas import (
 from app import training_load
 from app import threshold as threshold_mod
 from app import adherence as adherence_mod
+from app import intensity as intensity_mod
 from app.utils import safe_json_loads, parse_activity_charts, calculate_age
 
 logger = logging.getLogger(__name__)
@@ -270,6 +273,21 @@ def api_wellness_trends(
         .all()
     )
     return [DailySummaryResponse.model_validate(s) for s in summaries]
+
+
+# --- Intensity Trends ---
+
+@api_router.get("/intensity-trends", response_model=IntensityTrendsResponse)
+def api_intensity_trends(
+    days: int = Query(90, ge=7, le=365),
+    zone_type: str = Query("hr"),
+    db: Session = Depends(get_db),
+):
+    if zone_type not in ("hr", "power"):
+        zone_type = "hr"
+    weeks_data = intensity_mod.aggregate_weekly_intensity(db, days=days, zone_type=zone_type)
+    weeks = [IntensityWeek(**w) for w in weeks_data]
+    return IntensityTrendsResponse(weeks=weeks, zone_type=zone_type, days=days)
 
 
 # --- Activities ---

--- a/app/intensity.py
+++ b/app/intensity.py
@@ -1,0 +1,207 @@
+"""Time-in-zone and intensity distribution aggregation.
+
+Computes weekly summaries of time spent in each HR or power zone from
+per-activity zone data (hr_zones_json / power_zones_json stored by Garmin
+sync). Falls back gracefully to stored zone totals for runs without detail
+streams, giving full-history coverage.
+
+The polarization split maps zones 1–2 → easy, zone 3 → moderate,
+zones 4–5 → hard, matching the 80/20 polarized training model.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.models import Activity, ZoneConfig
+
+logger = logging.getLogger(__name__)
+
+
+def compute_zone_distribution_from_streams(
+    streams: dict,
+    zone_configs: list[ZoneConfig],
+    threshold: float | None,
+    metric: str,
+) -> dict[int, float]:
+    """Classify per-sample stream data into threshold-anchored zones.
+
+    Returns ``{zone_number: seconds}`` using the supplied ZoneConfig list.
+    ``metric`` must be a key in ``streams`` (``"hr"`` or ``"speed"``).
+    For pace zones the metric is ``"speed"`` in m/s; the ZoneConfig
+    boundaries are in min/km so each sample is converted before comparison.
+    """
+    if not zone_configs or not threshold or threshold <= 0:
+        return {}
+
+    time_series = streams.get("time", [])
+    value_series = streams.get(metric, [])
+    if not time_series or not value_series:
+        return {}
+
+    zone_secs: dict[int, float] = {cfg.zone_number: 0.0 for cfg in zone_configs}
+    configs_sorted = sorted(zone_configs, key=lambda z: z.zone_number)
+    n = len(time_series)
+
+    for i in range(1, n):
+        t0 = time_series[i - 1]
+        t1 = time_series[i]
+        v = value_series[i]
+        if not isinstance(t0, (int, float)) or not isinstance(t1, (int, float)):
+            continue
+        if not isinstance(v, (int, float)):
+            continue
+        dt = t1 - t0
+        if dt <= 0:
+            continue
+
+        if metric == "speed":
+            if v <= 0:
+                continue
+            sample_val = (1000.0 / v) / 60.0  # m/s → min/km
+        else:
+            sample_val = float(v)
+
+        for cfg in configs_sorted:
+            above_min = cfg.min_pct is None or sample_val >= threshold * cfg.min_pct / 100
+            below_max = cfg.max_pct is None or sample_val < threshold * cfg.max_pct / 100
+            if above_min and below_max:
+                zone_secs[cfg.zone_number] = zone_secs.get(cfg.zone_number, 0.0) + dt
+                break
+
+    return {k: round(v, 1) for k, v in zone_secs.items() if v > 0}
+
+
+def _parse_garmin_zones(zones_json: str | None) -> dict[int, float]:
+    """Parse Garmin's stored zone JSON into {zone_number: seconds}."""
+    if not zones_json:
+        return {}
+    try:
+        zones = json.loads(zones_json)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    if not isinstance(zones, list):
+        return {}
+    result: dict[int, float] = {}
+    for z in zones:
+        if not isinstance(z, dict):
+            continue
+        num = z.get("zoneNumber")
+        secs = z.get("secsInZone")
+        if isinstance(num, int) and isinstance(secs, (int, float)) and secs > 0:
+            result[num] = float(secs)
+    return result
+
+
+def _polarization(zone_secs: dict[int, float]) -> tuple[float | None, float | None, float | None]:
+    """Return (easy_pct, moderate_pct, hard_pct) for zones 1–5."""
+    total = sum(zone_secs.values())
+    if total <= 0:
+        return None, None, None
+    easy = zone_secs.get(1, 0) + zone_secs.get(2, 0)
+    moderate = zone_secs.get(3, 0)
+    hard = zone_secs.get(4, 0) + zone_secs.get(5, 0)
+    return (
+        round(100 * easy / total, 1),
+        round(100 * moderate / total, 1),
+        round(100 * hard / total, 1),
+    )
+
+
+def aggregate_weekly_intensity(
+    db: Session,
+    days: int = 90,
+    zone_type: str = "hr",
+    as_of: date | None = None,
+) -> list[dict]:
+    """Aggregate per-activity zone data into weekly buckets.
+
+    Uses ``hr_zones_json`` (zone_type="hr") or ``power_zones_json``
+    (zone_type="power"). Returns a list of weekly dicts sorted oldest→newest,
+    each with ``week_start``, ``zone_seconds``, ``total_seconds``,
+    ``easy_pct``, ``moderate_pct``, ``hard_pct``.
+    """
+    ref = as_of or date.today()
+    cutoff = datetime.combine(ref - timedelta(days=days), datetime.min.time())
+    ref_dt = datetime.combine(ref + timedelta(days=1), datetime.min.time())
+
+    json_col = Activity.hr_zones_json if zone_type == "hr" else Activity.power_zones_json
+
+    rows = (
+        db.query(Activity.started_at, json_col)
+        .filter(
+            Activity.started_at >= cutoff,
+            Activity.started_at < ref_dt,
+            json_col.isnot(None),
+        )
+        .order_by(Activity.started_at.asc())
+        .all()
+    )
+
+    weeks: dict[date, dict[int, float]] = {}
+    for started_at, zones_json in rows:
+        if not isinstance(started_at, datetime):
+            continue
+        act_date = started_at.date()
+        week_start = act_date - timedelta(days=act_date.weekday())
+        zone_secs = _parse_garmin_zones(zones_json)
+        if not zone_secs:
+            continue
+        if week_start not in weeks:
+            weeks[week_start] = {}
+        bucket = weeks[week_start]
+        for z_num, secs in zone_secs.items():
+            bucket[z_num] = bucket.get(z_num, 0.0) + secs
+
+    result = []
+    for week_start in sorted(weeks):
+        zone_secs = weeks[week_start]
+        total = sum(zone_secs.values())
+        easy_pct, moderate_pct, hard_pct = _polarization(zone_secs)
+        result.append({
+            "week_start": week_start,
+            "zone_seconds": {str(k): round(v, 1) for k, v in sorted(zone_secs.items())},
+            "total_seconds": round(total, 1),
+            "easy_pct": easy_pct,
+            "moderate_pct": moderate_pct,
+            "hard_pct": hard_pct,
+        })
+    return result
+
+
+def format_intensity_context(weeks: list[dict], zone_type: str = "hr") -> str:
+    """Format weekly intensity distribution for AI coaching context.
+
+    Shows the last 4 weeks so the coach can judge whether training is
+    polarized, grey-zone dominated, or high-intensity biased.
+    """
+    if not weeks:
+        return ""
+    recent = weeks[-4:]
+    lines = [
+        f"## Intensity Distribution ({zone_type.upper()} zones, last {len(recent)} weeks)"
+    ]
+    for w in recent:
+        total_min = w["total_seconds"] / 60
+        zone_parts = [
+            f"Z{k}: {v / 60:.0f}m"
+            for k, v in sorted((int(k), v) for k, v in w["zone_seconds"].items())
+            if v > 0
+        ]
+        polar = ""
+        if w["easy_pct"] is not None:
+            polar = (
+                f" | Easy:{w['easy_pct']:.0f}%"
+                f" Mod:{w['moderate_pct']:.0f}%"
+                f" Hard:{w['hard_pct']:.0f}%"
+            )
+        week_str = w["week_start"].isoformat() if isinstance(w["week_start"], date) else w["week_start"]
+        lines.append(
+            f"- Week of {week_str}: {total_min:.0f}min total"
+            f" ({', '.join(zone_parts)}){polar}"
+        )
+    return "\n".join(lines)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -492,3 +492,18 @@ class PlanRealignmentStatus(BaseModel):
 
 class PlanRealignmentRequest(BaseModel):
     action: Literal["regenerate", "dismiss"]
+
+
+class IntensityWeek(BaseModel):
+    week_start: date
+    zone_seconds: dict[str, float]
+    total_seconds: float
+    easy_pct: float | None = None
+    moderate_pct: float | None = None
+    hard_pct: float | None = None
+
+
+class IntensityTrendsResponse(BaseModel):
+    weeks: list[IntensityWeek] = []
+    zone_type: str
+    days: int

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -10,6 +10,7 @@ import type {
   CalendarEvent,
   FeedbackRequest,
   InsightResponse,
+  IntensityTrendsResponse,
   PerformanceCurveResponse,
   PlanRealignmentStatus,
   SettingsResponse,
@@ -260,6 +261,13 @@ export function useRealignmentStatus() {
   return useQuery({
     queryKey: ['realignment-status'],
     queryFn: () => apiGet<PlanRealignmentStatus>('/training-plan/realignment-status'),
+  })
+}
+
+export function useIntensityTrends(days = 90, zoneType = 'hr') {
+  return useQuery({
+    queryKey: ['intensity-trends', days, zoneType],
+    queryFn: () => apiGet<IntensityTrendsResponse>(`/intensity-trends?days=${days}&zone_type=${zoneType}`),
   })
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -415,3 +415,18 @@ export interface PerformanceCurveResponse {
   lookback_days: number
   activities_analyzed: number
 }
+
+export interface IntensityWeek {
+  week_start: string
+  zone_seconds: Record<string, number>  // zone_number (as string) → seconds
+  total_seconds: number
+  easy_pct: number | null   // zones 1–2
+  moderate_pct: number | null  // zone 3
+  hard_pct: number | null   // zones 4–5
+}
+
+export interface IntensityTrendsResponse {
+  weeks: IntensityWeek[]
+  zone_type: string
+  days: number
+}

--- a/frontend/src/components/trends/IntensityTrendsView.tsx
+++ b/frontend/src/components/trends/IntensityTrendsView.tsx
@@ -1,0 +1,279 @@
+import { useState } from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts'
+import { useIntensityTrends } from '../../api/hooks'
+import { useTheme } from '../../App'
+import { getChartTickColor, getChartTooltipStyle } from '../../utils/theme'
+import type { IntensityWeek } from '../../api/types'
+
+type Days = 28 | 56 | 84
+type ZoneType = 'hr' | 'power'
+
+const DAY_OPTIONS: { label: string; value: Days }[] = [
+  { label: '4w', value: 28 },
+  { label: '8w', value: 56 },
+  { label: '12w', value: 84 },
+]
+
+const ZONE_COLORS: Record<string, string> = {
+  '1': '#2ecc71',
+  '2': '#27ae60',
+  '3': '#f39c12',
+  '4': '#e67e22',
+  '5': '#e74c3c',
+}
+
+const ZONE_LABELS: Record<string, string> = {
+  '1': 'Z1',
+  '2': 'Z2',
+  '3': 'Z3',
+  '4': 'Z4',
+  '5': 'Z5',
+}
+
+function formatMinutes(secs: number): string {
+  const m = Math.round(secs / 60)
+  return `${m}m`
+}
+
+function weekLabel(isoDate: string): string {
+  const d = new Date(isoDate + 'T00:00:00')
+  return `${d.getMonth() + 1}/${d.getDate()}`
+}
+
+function buildChartData(weeks: IntensityWeek[]) {
+  return weeks.map(w => {
+    const row: Record<string, any> = { week: weekLabel(w.week_start) }
+    for (const [zone, secs] of Object.entries(w.zone_seconds)) {
+      row[`zone_${zone}`] = Math.round(secs / 60)
+    }
+    row._easy_pct = w.easy_pct
+    row._moderate_pct = w.moderate_pct
+    row._hard_pct = w.hard_pct
+    row._total_min = Math.round(w.total_seconds / 60)
+    return row
+  })
+}
+
+function PolarizationBar({ easy, moderate, hard }: { easy: number; moderate: number; hard: number }) {
+  return (
+    <div style={{ display: 'flex', height: 8, borderRadius: 4, overflow: 'hidden', gap: 1 }}>
+      <div style={{ flex: easy, background: '#27ae60' }} title={`Easy ${easy.toFixed(0)}%`} />
+      <div style={{ flex: moderate, background: '#f39c12' }} title={`Moderate ${moderate.toFixed(0)}%`} />
+      <div style={{ flex: hard, background: '#e74c3c' }} title={`Hard ${hard.toFixed(0)}%`} />
+    </div>
+  )
+}
+
+export default function IntensityTrendsView() {
+  const [days, setDays] = useState<Days>(56)
+  const [zoneType, setZoneType] = useState<ZoneType>('hr')
+  const { data, isLoading } = useIntensityTrends(days, zoneType)
+  const { theme } = useTheme()
+  const tickColor = getChartTickColor(theme)
+  const tooltipStyle = getChartTooltipStyle(theme)
+
+  const allZones = ['1', '2', '3', '4', '5']
+
+  if (isLoading) {
+    return <div style={{ padding: 32, textAlign: 'center', color: 'var(--text-muted)' }}>Loading...</div>
+  }
+
+  const weeks = data?.weeks ?? []
+
+  if (weeks.length === 0) {
+    return (
+      <div style={{ padding: 32, textAlign: 'center', color: 'var(--text-muted)', fontSize: '0.9rem' }}>
+        No zone data available for this period. Sync activities with Garmin to populate zone data.
+      </div>
+    )
+  }
+
+  const chartData = buildChartData(weeks)
+
+  // Average polarization across all weeks
+  const weeksWithPolar = weeks.filter(w => w.easy_pct !== null)
+  const avgEasy = weeksWithPolar.length
+    ? weeksWithPolar.reduce((s, w) => s + (w.easy_pct ?? 0), 0) / weeksWithPolar.length
+    : null
+  const avgMod = weeksWithPolar.length
+    ? weeksWithPolar.reduce((s, w) => s + (w.moderate_pct ?? 0), 0) / weeksWithPolar.length
+    : null
+  const avgHard = weeksWithPolar.length
+    ? weeksWithPolar.reduce((s, w) => s + (w.hard_pct ?? 0), 0) / weeksWithPolar.length
+    : null
+
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      {/* Controls */}
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '12px 16px',
+        gap: 8,
+      }}>
+        <div style={{ display: 'flex', gap: 4 }}>
+          {DAY_OPTIONS.map(opt => (
+            <button
+              key={opt.value}
+              onClick={() => setDays(opt.value)}
+              style={{
+                padding: '4px 10px',
+                borderRadius: 6,
+                border: '1px solid var(--border)',
+                background: days === opt.value ? 'var(--accent)' : 'transparent',
+                color: days === opt.value ? '#fff' : 'var(--text-muted)',
+                fontSize: '0.78rem',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <div style={{ display: 'flex', gap: 4 }}>
+          {(['hr', 'power'] as ZoneType[]).map(zt => (
+            <button
+              key={zt}
+              onClick={() => setZoneType(zt)}
+              style={{
+                padding: '4px 10px',
+                borderRadius: 6,
+                border: '1px solid var(--border)',
+                background: zoneType === zt ? 'var(--accent)' : 'transparent',
+                color: zoneType === zt ? '#fff' : 'var(--text-muted)',
+                fontSize: '0.78rem',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                textTransform: 'uppercase',
+              }}
+            >
+              {zt}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Stacked bar chart */}
+      <div style={{ padding: '0 8px' }}>
+        <div className="card" style={{ padding: '16px 8px 8px' }}>
+          <p style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: 8, paddingLeft: 8 }}>
+            Weekly time in zone (minutes)
+          </p>
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={chartData} margin={{ left: 0, right: 8, top: 4, bottom: 4 }}>
+              <XAxis
+                dataKey="week"
+                tick={{ fontSize: 10, fill: tickColor }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                tick={{ fontSize: 10, fill: tickColor }}
+                axisLine={false}
+                tickLine={false}
+                width={28}
+              />
+              <Tooltip
+                contentStyle={tooltipStyle}
+                formatter={(value: number, name: string) => {
+                  const zoneNum = name.replace('zone_', '')
+                  const label = ZONE_LABELS[zoneNum] ?? name
+                  return [`${value}m`, label]
+                }}
+              />
+              <Legend
+                wrapperStyle={{ fontSize: 11, paddingTop: 4 }}
+                formatter={(value: string) => {
+                  const zoneNum = value.replace('zone_', '')
+                  return ZONE_LABELS[zoneNum] ?? value
+                }}
+              />
+              {allZones.map(zone => (
+                <Bar
+                  key={zone}
+                  dataKey={`zone_${zone}`}
+                  stackId="zones"
+                  fill={ZONE_COLORS[zone]}
+                  name={`zone_${zone}`}
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* Polarization summary */}
+      {avgEasy !== null && avgMod !== null && avgHard !== null && (
+        <div style={{ padding: '12px 16px 0' }}>
+          <div className="card" style={{ padding: 16 }}>
+            <p style={{ fontSize: '0.78rem', color: 'var(--text-muted)', marginBottom: 10 }}>
+              Average polarization
+            </p>
+            <PolarizationBar easy={avgEasy} moderate={avgMod} hard={avgHard} />
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 8, fontSize: '0.75rem' }}>
+              <span style={{ color: '#27ae60' }}>Easy {avgEasy.toFixed(0)}%</span>
+              <span style={{ color: '#f39c12' }}>Moderate {avgMod.toFixed(0)}%</span>
+              <span style={{ color: '#e74c3c' }}>Hard {avgHard.toFixed(0)}%</span>
+            </div>
+            <p style={{
+              fontSize: '0.73rem',
+              color: 'var(--text-muted)',
+              marginTop: 10,
+              lineHeight: 1.4,
+            }}>
+              {avgEasy >= 75
+                ? 'Well-polarized training — 80/20 distribution maintained.'
+                : avgMod >= 30
+                  ? 'Grey-zone heavy — consider shifting moderate volume to easy or hard.'
+                  : 'High intensity bias — ensure adequate easy recovery volume.'}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Per-week breakdown table */}
+      <div style={{ padding: '12px 16px 0' }}>
+        <div className="card" style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.75rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                <th style={{ textAlign: 'left', padding: '8px 12px', color: 'var(--text-muted)', fontWeight: 500 }}>Week</th>
+                {allZones.map(z => (
+                  <th key={z} style={{ textAlign: 'right', padding: '8px 8px', color: ZONE_COLORS[z], fontWeight: 500 }}>
+                    Z{z}
+                  </th>
+                ))}
+                <th style={{ textAlign: 'right', padding: '8px 12px', color: 'var(--text-muted)', fontWeight: 500 }}>Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {weeks.slice().reverse().map(w => (
+                <tr key={w.week_start} style={{ borderBottom: '1px solid var(--border)' }}>
+                  <td style={{ padding: '7px 12px', color: 'var(--text)' }}>{weekLabel(w.week_start)}</td>
+                  {allZones.map(z => (
+                    <td key={z} style={{ textAlign: 'right', padding: '7px 8px', color: 'var(--text-muted)' }}>
+                      {w.zone_seconds[z] ? formatMinutes(w.zone_seconds[z]) : '—'}
+                    </td>
+                  ))}
+                  <td style={{ textAlign: 'right', padding: '7px 12px', color: 'var(--text)', fontWeight: 500 }}>
+                    {formatMinutes(w.total_seconds)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/trends/TrendsView.tsx
+++ b/frontend/src/components/trends/TrendsView.tsx
@@ -1,8 +1,15 @@
 import { useState } from 'react'
 import WellnessTrendsView from './WellnessTrendsView'
 import PerformanceCurveView from './PerformanceCurveView'
+import IntensityTrendsView from './IntensityTrendsView'
 
-type Tab = 'wellness' | 'performance'
+type Tab = 'wellness' | 'intensity' | 'performance'
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: 'wellness', label: 'Wellness' },
+  { id: 'intensity', label: 'Intensity' },
+  { id: 'performance', label: 'Performance' },
+]
 
 export default function TrendsView() {
   const [tab, setTab] = useState<Tab>('wellness')
@@ -16,44 +23,31 @@ export default function TrendsView() {
         padding: '0 16px',
         background: 'var(--surface)',
       }}>
-        <button
-          onClick={() => setTab('wellness')}
-          style={{
-            flex: 1,
-            padding: '10px 0',
-            border: 'none',
-            background: 'transparent',
-            color: tab === 'wellness' ? 'var(--accent)' : 'var(--text-muted)',
-            fontWeight: tab === 'wellness' ? 700 : 400,
-            fontSize: '0.82rem',
-            cursor: 'pointer',
-            borderBottom: tab === 'wellness' ? '2px solid var(--accent)' : '2px solid transparent',
-            fontFamily: 'inherit',
-            transition: 'color 0.15s',
-          }}
-        >
-          Wellness
-        </button>
-        <button
-          onClick={() => setTab('performance')}
-          style={{
-            flex: 1,
-            padding: '10px 0',
-            border: 'none',
-            background: 'transparent',
-            color: tab === 'performance' ? 'var(--accent)' : 'var(--text-muted)',
-            fontWeight: tab === 'performance' ? 700 : 400,
-            fontSize: '0.82rem',
-            cursor: 'pointer',
-            borderBottom: tab === 'performance' ? '2px solid var(--accent)' : '2px solid transparent',
-            fontFamily: 'inherit',
-            transition: 'color 0.15s',
-          }}
-        >
-          Performance
-        </button>
+        {TABS.map(t => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            style={{
+              flex: 1,
+              padding: '10px 0',
+              border: 'none',
+              background: 'transparent',
+              color: tab === t.id ? 'var(--accent)' : 'var(--text-muted)',
+              fontWeight: tab === t.id ? 700 : 400,
+              fontSize: '0.82rem',
+              cursor: 'pointer',
+              borderBottom: tab === t.id ? '2px solid var(--accent)' : '2px solid transparent',
+              fontFamily: 'inherit',
+              transition: 'color 0.15s',
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
       </div>
-      {tab === 'wellness' ? <WellnessTrendsView /> : <PerformanceCurveView />}
+      {tab === 'wellness' && <WellnessTrendsView />}
+      {tab === 'intensity' && <IntensityTrendsView />}
+      {tab === 'performance' && <PerformanceCurveView />}
     </div>
   )
 }

--- a/perf/test_perf_endpoints.py
+++ b/perf/test_perf_endpoints.py
@@ -101,6 +101,10 @@ def test_performance_curve(benchmark, client):
     _ok(benchmark(lambda: client.get("/api/v1/performance-curve", params={"days": 90})))
 
 
+def test_intensity_trends(benchmark, client):
+    _ok(benchmark(lambda: client.get("/api/v1/intensity-trends", params={"days": 90, "zone_type": "hr"})))
+
+
 def test_get_training_plan(benchmark, client):
     _ok(benchmark(lambda: client.get("/api/v1/training-plan")))
 

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -1,0 +1,218 @@
+"""Tests for app.intensity — time-in-zone aggregation and context formatting."""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+
+import pytest
+
+from app.intensity import (
+    _parse_garmin_zones,
+    _polarization,
+    aggregate_weekly_intensity,
+    compute_zone_distribution_from_streams,
+    format_intensity_context,
+)
+from app.models import Activity, ZoneConfig
+
+
+def _zone_configs(zone_type: str = "hr") -> list[ZoneConfig]:
+    bounds = [(None, 75), (75, 85), (85, 95), (95, 105), (105, None)]
+    return [
+        ZoneConfig(
+            zone_type=zone_type,
+            zone_number=i + 1,
+            zone_name=f"Zone {i + 1}",
+            zone_color="#fff",
+            min_pct=lo,
+            max_pct=hi,
+        )
+        for i, (lo, hi) in enumerate(bounds)
+    ]
+
+
+def _make_activity(db, day: date, hr_zones: dict | None = None):
+    zones_json = json.dumps([
+        {"zoneNumber": k, "secsInZone": v}
+        for k, v in (hr_zones or {1: 600, 2: 1200, 3: 300, 4: 60, 5: 30}).items()
+    ])
+    act = Activity(
+        garmin_id=abs(hash(str(day))) % (10**9),
+        activity_type="running",
+        name="Easy Run",
+        started_at=datetime.combine(day, datetime.min.time()),
+        hr_zones_json=zones_json,
+    )
+    db.add(act)
+    db.flush()
+    return act
+
+
+class TestParseGarminZones:
+    def test_valid_json(self):
+        raw = json.dumps([
+            {"zoneNumber": 1, "secsInZone": 600},
+            {"zoneNumber": 2, "secsInZone": 1200},
+            {"zoneNumber": 3, "secsInZone": 0},
+        ])
+        result = _parse_garmin_zones(raw)
+        assert result == {1: 600.0, 2: 1200.0}
+
+    def test_none_input(self):
+        assert _parse_garmin_zones(None) == {}
+
+    def test_invalid_json(self):
+        assert _parse_garmin_zones("not-json") == {}
+
+    def test_non_list(self):
+        assert _parse_garmin_zones(json.dumps({"a": 1})) == {}
+
+
+class TestPolarization:
+    def test_well_polarized(self):
+        secs = {1: 3600, 2: 3600, 3: 600, 4: 600, 5: 600}
+        easy, mod, hard = _polarization(secs)
+        assert easy == pytest.approx(80.0, abs=0.5)
+        assert mod == pytest.approx(7.0, abs=1)
+        assert hard == pytest.approx(13.0, abs=1)
+
+    def test_empty(self):
+        assert _polarization({}) == (None, None, None)
+
+    def test_only_easy(self):
+        easy, mod, hard = _polarization({1: 1000, 2: 1000})
+        assert easy == 100.0
+        assert mod == 0.0
+        assert hard == 0.0
+
+
+class TestComputeZoneDistributionFromStreams:
+    def _make_streams(self, hr_vals: list[float]) -> dict:
+        n = len(hr_vals)
+        return {
+            "time": list(range(n)),
+            "hr": hr_vals,
+            "speed": [3.0] * n,
+        }
+
+    def test_basic_hr_classification(self):
+        configs = _zone_configs("hr")
+        threshold = 160.0
+        # All samples at 128 bpm → 80% of 160 → Zone 2 (75–85%)
+        streams = self._make_streams([128.0] * 10)
+        result = compute_zone_distribution_from_streams(streams, configs, threshold, "hr")
+        assert 2 in result
+        assert result[2] > 0
+
+    def test_no_threshold(self):
+        configs = _zone_configs("hr")
+        streams = self._make_streams([130.0] * 5)
+        assert compute_zone_distribution_from_streams(streams, configs, None, "hr") == {}
+
+    def test_empty_configs(self):
+        streams = self._make_streams([130.0] * 5)
+        assert compute_zone_distribution_from_streams(streams, [], 160.0, "hr") == {}
+
+    def test_mixed_zones(self):
+        configs = _zone_configs("hr")
+        threshold = 160.0
+        # 5 samples at 112 (70% → Zone 1) and 5 at 152 (95% → Zone 4)
+        hr_vals = [112.0] * 5 + [152.0] * 5
+        streams = self._make_streams(hr_vals)
+        result = compute_zone_distribution_from_streams(streams, configs, threshold, "hr")
+        assert 1 in result
+        assert 4 in result
+
+
+class TestAggregateWeeklyIntensity:
+    def test_basic_aggregation(self, db):
+        today = date(2026, 6, 16)  # Monday
+        _make_activity(db, today)
+        _make_activity(db, today + timedelta(days=1))
+        db.commit()
+
+        weeks = aggregate_weekly_intensity(db, days=14, zone_type="hr", as_of=today + timedelta(days=2))
+        assert len(weeks) >= 1
+        week = weeks[-1]
+        assert "zone_seconds" in week
+        assert week["total_seconds"] > 0
+        assert week["easy_pct"] is not None
+
+    def test_empty_result(self, db):
+        weeks = aggregate_weekly_intensity(db, days=7, zone_type="hr", as_of=date(2000, 1, 1))
+        assert weeks == []
+
+    def test_power_zones_fallback(self, db):
+        today = date(2026, 6, 16)
+        zones_json = json.dumps([
+            {"zoneNumber": 1, "secsInZone": 300},
+            {"zoneNumber": 2, "secsInZone": 600},
+        ])
+        act = Activity(
+            garmin_id=99999,
+            activity_type="running",
+            name="Run",
+            started_at=datetime.combine(today, datetime.min.time()),
+            power_zones_json=zones_json,
+        )
+        db.add(act)
+        db.commit()
+
+        weeks = aggregate_weekly_intensity(db, days=7, zone_type="power", as_of=today + timedelta(days=1))
+        assert len(weeks) == 1
+        assert weeks[0]["total_seconds"] == 900.0
+
+    def test_weeks_sorted_ascending(self, db):
+        monday = date(2026, 6, 8)
+        for offset in [0, 7]:
+            _make_activity(db, monday + timedelta(days=offset))
+        db.commit()
+
+        weeks = aggregate_weekly_intensity(db, days=21, zone_type="hr", as_of=monday + timedelta(days=14))
+        starts = [w["week_start"] for w in weeks]
+        assert starts == sorted(starts)
+
+
+class TestFormatIntensityContext:
+    def _make_week(self, week_start: date, easy: float, mod: float, hard: float) -> dict:
+        total = easy + mod + hard
+        return {
+            "week_start": week_start,
+            "zone_seconds": {"1": easy * 0.6, "2": easy * 0.4, "3": mod, "4": hard * 0.7, "5": hard * 0.3},
+            "total_seconds": total,
+            "easy_pct": round(100 * easy / total, 1),
+            "moderate_pct": round(100 * mod / total, 1),
+            "hard_pct": round(100 * hard / total, 1),
+        }
+
+    def test_output_contains_weeks(self):
+        weeks = [self._make_week(date(2026, 6, 1) + timedelta(weeks=i), 5400, 600, 600) for i in range(4)]
+        ctx = format_intensity_context(weeks)
+        assert "Intensity Distribution" in ctx
+        assert "Week of" in ctx
+
+    def test_empty_weeks(self):
+        assert format_intensity_context([]) == ""
+
+    def test_shows_at_most_4_weeks(self):
+        weeks = [self._make_week(date(2026, 1, 1) + timedelta(weeks=i), 5400, 600, 600) for i in range(10)]
+        ctx = format_intensity_context(weeks)
+        assert ctx.count("Week of") == 4
+
+    def test_api_endpoint(self, client):
+        resp = client.get("/api/v1/intensity-trends", params={"days": 30, "zone_type": "hr"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "weeks" in body
+        assert body["zone_type"] == "hr"
+        assert body["days"] == 30
+
+    def test_api_endpoint_power(self, client):
+        resp = client.get("/api/v1/intensity-trends", params={"days": 30, "zone_type": "power"})
+        assert resp.status_code == 200
+        assert resp.json()["zone_type"] == "power"
+
+    def test_api_endpoint_invalid_zone_type_defaults_to_hr(self, client):
+        resp = client.get("/api/v1/intensity-trends", params={"days": 30, "zone_type": "invalid"})
+        assert resp.status_code == 200
+        assert resp.json()["zone_type"] == "hr"


### PR DESCRIPTION
## Summary

Implements **P2-1 — Time-in-zone / intensity distribution** from the improvement plan.

- **`app/intensity.py`** (new): aggregates Garmin `hr_zones_json` / `power_zones_json` into weekly buckets, computes polarization split (easy Z1–2 / moderate Z3 / hard Z4–5), and formats an AI coaching context block.
- **`GET /api/v1/intensity-trends`**: returns per-week zone breakdowns with polarization percentages; params `days` (7–365) and `zone_type` (hr / power).
- **`app/ai_coach.py`**: injects a 4-week intensity distribution section into `_build_context` so the coach can judge whether training is polarized, grey-zone heavy, or high-intensity biased.
- **Frontend** (`IntensityTrendsView.tsx`): stacked bar chart of weekly minutes per zone, polarization summary bar, per-week breakdown table, with 4w/8w/12w and HR/Power toggles. A third "Intensity" tab added to `TrendsView`.
- **`perf/test_perf_endpoints.py`**: `test_intensity_trends` benchmark added.
- **`tests/test_intensity.py`**: 21 new unit + integration tests.

## Test plan

- [ ] All 417 tests pass (`python -m pytest tests/`)
- [ ] All 34 perf tests pass (`pytest perf/ --benchmark-disable`)
- [ ] `GET /api/v1/intensity-trends?days=90&zone_type=hr` returns `weeks`, `zone_type`, `days`
- [ ] Trends view shows "Intensity" tab with stacked bar chart
- [ ] Polarization bar and commentary render correctly
- [ ] Per-week table sorts newest first
- [ ] HR / Power toggle and 4w/8w/12w selector both work
- [ ] Empty state renders when no zone data available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oyAzchRbEPQrD6MJwS7P9

---
_Generated by [Claude Code](https://claude.ai/code/session_018oyAzchRbEPQrD6MJwS7P9)_