### PR TITLE
Phase 3 — multi-user data isolation

### DIFF
--- a/alembic/versions/c3d4e5f6a7b8_add_user_id_data_isolation.py
+++ b/alembic/versions/c3d4e5f6a7b8_add_user_id_data_isolation.py
@@ -1,0 +1,150 @@
+"""add user_id to all data tables (multi-user data isolation)
+
+Phase 3 of the multi-user plan: every data row is keyed on a user. Existing
+rows are backfilled to the primary/bootstrap user (id=1) via a server_default,
+and single-tenant uniqueness (date, garmin_id, sync key, …) becomes per-user.
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-06-23
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Data tables that gain a ``user_id`` scoping column. ``metric_zones`` is global
+# reference data and is intentionally excluded.
+_USER_SCOPED_TABLES = [
+    "activities",
+    "daily_summaries",
+    "insights",
+    "races",
+    "garmin_calendar_events",
+    "athlete_profiles",
+    "zone_configs",
+    "training_plans",
+    "training_plan_days",
+    "sync_status",
+]
+
+
+# Naming convention so batch mode can target the unnamed UNIQUE constraints the
+# initial schema declared (e.g. ``UniqueConstraint("date")`` → "uq_<table>_<col>").
+_NAMING = {"uq": "uq_%(table_name)s_%(column_0_name)s"}
+
+
+def upgrade() -> None:
+    # users.garmin_needs_reauth — set when a cron sync can't re-auth a user.
+    op.add_column(
+        "users",
+        sa.Column(
+            "garmin_needs_reauth",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+    # Add user_id to every data table; server_default="1" backfills all existing
+    # rows to the primary user so nothing is orphaned.
+    for table in _USER_SCOPED_TABLES:
+        op.add_column(
+            table,
+            sa.Column("user_id", sa.Integer(), nullable=False, server_default="1"),
+        )
+        op.create_index(f"ix_{table}_user_id", table, ["user_id"])
+
+    # --- Rework single-tenant uniqueness into per-user uniqueness -----------
+    # The initial schema put BOTH a unique index and an unnamed UNIQUE table
+    # constraint on these single columns, so each must be reworked: demote the
+    # index to a plain lookup index and replace the constraint with a composite.
+
+    # activities.garmin_id → unique per (user_id, garmin_id).
+    op.drop_index("ix_activities_garmin_id", table_name="activities")
+    op.create_index("ix_activities_garmin_id", "activities", ["garmin_id"])
+    with op.batch_alter_table("activities", naming_convention=_NAMING) as batch_op:
+        batch_op.drop_constraint("uq_activities_garmin_id", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_activities_user_garmin", ["user_id", "garmin_id"]
+        )
+
+    # daily_summaries.date → unique per (user_id, date).
+    op.drop_index("ix_daily_summaries_date", table_name="daily_summaries")
+    op.create_index("ix_daily_summaries_date", "daily_summaries", ["date"])
+    with op.batch_alter_table("daily_summaries", naming_convention=_NAMING) as batch_op:
+        batch_op.drop_constraint("uq_daily_summaries_date", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_daily_summaries_user_date", ["user_id", "date"]
+        )
+
+    # garmin_calendar_events.garmin_id → unique per (user_id, garmin_id).
+    op.drop_index(
+        "ix_garmin_calendar_events_garmin_id", table_name="garmin_calendar_events"
+    )
+    op.create_index(
+        "ix_garmin_calendar_events_garmin_id", "garmin_calendar_events", ["garmin_id"]
+    )
+    with op.batch_alter_table(
+        "garmin_calendar_events", naming_convention=_NAMING
+    ) as batch_op:
+        batch_op.drop_constraint(
+            "uq_garmin_calendar_events_garmin_id", type_="unique"
+        )
+        batch_op.create_unique_constraint(
+            "uq_garmin_calendar_user_garmin", ["user_id", "garmin_id"]
+        )
+
+    # athlete_profiles: one profile per user (no prior uniqueness existed).
+    op.create_index(
+        "uq_athlete_profiles_user", "athlete_profiles", ["user_id"], unique=True
+    )
+
+    # zone_configs: the named (zone_type, zone_number) unique becomes per-user.
+    with op.batch_alter_table("zone_configs") as batch_op:
+        batch_op.drop_constraint("uq_zone_type_number", type_="unique")
+        batch_op.create_unique_constraint(
+            "uq_zone_type_number", ["user_id", "zone_type", "zone_number"]
+        )
+
+    # sync_status: the global unique on ``key`` becomes per-user.
+    with op.batch_alter_table("sync_status", naming_convention=_NAMING) as batch_op:
+        batch_op.drop_constraint("uq_sync_status_key", type_="unique")
+        batch_op.create_unique_constraint("uq_sync_status_user_key", ["user_id", "key"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("sync_status") as batch_op:
+        batch_op.drop_constraint("uq_sync_status_user_key", type_="unique")
+        batch_op.create_unique_constraint("uq_sync_status_key", ["key"])
+
+    with op.batch_alter_table("zone_configs") as batch_op:
+        batch_op.drop_constraint("uq_zone_type_number", type_="unique")
+        batch_op.create_unique_constraint("uq_zone_type_number", ["zone_type", "zone_number"])
+
+    op.drop_index("uq_athlete_profiles_user", table_name="athlete_profiles")
+
+    with op.batch_alter_table("garmin_calendar_events") as batch_op:
+        batch_op.drop_constraint("uq_garmin_calendar_user_garmin", type_="unique")
+        batch_op.create_unique_constraint("uq_garmin_calendar_events_garmin_id", ["garmin_id"])
+
+    with op.batch_alter_table("daily_summaries") as batch_op:
+        batch_op.drop_constraint("uq_daily_summaries_user_date", type_="unique")
+        batch_op.create_unique_constraint("uq_daily_summaries_date", ["date"])
+
+    with op.batch_alter_table("activities") as batch_op:
+        batch_op.drop_constraint("uq_activities_user_garmin", type_="unique")
+        batch_op.create_unique_constraint("uq_activities_garmin_id", ["garmin_id"])
+
+    for table in _USER_SCOPED_TABLES:
+        op.drop_index(f"ix_{table}_user_id", table_name=table)
+        op.drop_column(table, "user_id")
+
+    op.drop_column("users", "garmin_needs_reauth")

--- a/alembic/versions/c3d4e5f6a7b8_add_user_id_data_isolation.py
+++ b/alembic/versions/c3d4e5f6a7b8_add_user_id_data_isolation.py
@@ -4,6 +4,16 @@ Phase 3 of the multi-user plan: every data row is keyed on a user. Existing
 rows are backfilled to the primary/bootstrap user (id=1) via a server_default,
 and single-tenant uniqueness (date, garmin_id, sync key, …) becomes per-user.
 
+This migration is written to be **idempotent and topology-agnostic**: it
+inspects the live schema and only applies the steps still missing. That matters
+because a DB may have reached the previous head two different ways — through the
+Alembic migrations (which declared *both* a unique index and an unnamed UNIQUE
+table constraint on columns like ``garmin_id``/``date``) or through an older
+``Base.metadata.create_all`` that was later ``stamp``ed (which produced only a
+unique *index* for ``unique=True, index=True`` columns and no table constraint).
+SQLite runs DDL non-transactionally, so a partially-applied earlier attempt must
+also be safely resumable.
+
 Revision ID: c3d4e5f6a7b8
 Revises: b2c3d4e5f6a7
 Create Date: 2026-06-23
@@ -13,6 +23,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 revision: str = "c3d4e5f6a7b8"
 down_revision: Union[str, None] = "b2c3d4e5f6a7"
@@ -35,116 +46,201 @@ _USER_SCOPED_TABLES = [
     "sync_status",
 ]
 
-
-# Naming convention so batch mode can target the unnamed UNIQUE constraints the
-# initial schema declared (e.g. ``UniqueConstraint("date")`` → "uq_<table>_<col>").
+# Names the reflected unnamed UNIQUE constraints so batch mode can drop them.
 _NAMING = {"uq": "uq_%(table_name)s_%(column_0_name)s"}
 
 
-def upgrade() -> None:
-    # users.garmin_needs_reauth — set when a cron sync can't re-auth a user.
-    op.add_column(
-        "users",
-        sa.Column(
-            "garmin_needs_reauth",
-            sa.Boolean(),
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
-    )
+# --- introspection helpers --------------------------------------------------
 
-    # Add user_id to every data table; server_default="1" backfills all existing
+def _has_column(insp, table: str, col: str) -> bool:
+    return any(c["name"] == col for c in insp.get_columns(table))
+
+
+def _index_names(insp, table: str) -> set:
+    return {ix["name"] for ix in insp.get_indexes(table)}
+
+
+def _unique_indexes_on(insp, table: str, cols: list) -> list:
+    return [
+        ix["name"]
+        for ix in insp.get_indexes(table)
+        if ix.get("unique") and list(ix.get("column_names") or []) == cols
+    ]
+
+
+def _unique_constraints_on(insp, table: str, cols: list) -> list:
+    return [
+        uc
+        for uc in insp.get_unique_constraints(table)
+        if list(uc.get("column_names") or []) == cols
+    ]
+
+
+def _has_composite_unique(insp, table: str, cols: list) -> bool:
+    """True if ``cols`` are already enforced unique (as an index or constraint)."""
+    if _unique_indexes_on(insp, table, cols):
+        return True
+    return bool(_unique_constraints_on(insp, table, cols))
+
+
+# --- uniqueness rework ------------------------------------------------------
+
+def _rework_single_col_unique(
+    table: str, col: str, composite_name: str, lookup_index: str
+) -> None:
+    """Replace per-table uniqueness on ``col`` with ``(user_id, col)``.
+
+    Handles both schema topologies and is a no-op once already applied.
+    """
+    insp = inspect(op.get_bind())
+    if _has_composite_unique(insp, table, ["user_id", col]):
+        return  # already reworked
+
+    # Demote any unique index on the single column to a plain lookup index.
+    for ix_name in _unique_indexes_on(insp, table, [col]):
+        op.drop_index(ix_name, table_name=table)
+    insp = inspect(op.get_bind())
+    if lookup_index not in _index_names(insp, table):
+        op.create_index(lookup_index, table, [col])
+
+    # Drop any table-level UNIQUE constraint on the single column (the
+    # migration-built topology), then add the composite. When none exists (the
+    # create_all topology), enforce the composite with a unique index instead.
+    constraints = _unique_constraints_on(insp, table, [col])
+    if constraints:
+        with op.batch_alter_table(table, naming_convention=_NAMING) as batch_op:
+            for uc in constraints:
+                batch_op.drop_constraint(uc.get("name") or f"uq_{table}_{col}", type_="unique")
+            batch_op.create_unique_constraint(composite_name, ["user_id", col])
+    else:
+        op.create_index(composite_name, table, ["user_id", col], unique=True)
+
+
+def _replace_table_unique(
+    table: str, old_cols: list, new_name: str, new_cols: list
+) -> None:
+    """Replace a table-level UNIQUE on ``old_cols`` with one on ``new_cols``."""
+    insp = inspect(op.get_bind())
+    if _has_composite_unique(insp, table, new_cols):
+        return
+    constraints = _unique_constraints_on(insp, table, old_cols)
+    with op.batch_alter_table(table, naming_convention=_NAMING) as batch_op:
+        for uc in constraints:
+            batch_op.drop_constraint(
+                uc.get("name") or f"uq_{table}_{old_cols[0]}", type_="unique"
+            )
+        batch_op.create_unique_constraint(new_name, new_cols)
+
+
+def upgrade() -> None:
+    insp = inspect(op.get_bind())
+
+    # users.garmin_needs_reauth — set when a cron sync can't re-auth a user.
+    if not _has_column(insp, "users", "garmin_needs_reauth"):
+        op.add_column(
+            "users",
+            sa.Column(
+                "garmin_needs_reauth",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+        )
+
+    # Add user_id to every data table; server_default="1" backfills existing
     # rows to the primary user so nothing is orphaned.
     for table in _USER_SCOPED_TABLES:
-        op.add_column(
-            table,
-            sa.Column("user_id", sa.Integer(), nullable=False, server_default="1"),
-        )
-        op.create_index(f"ix_{table}_user_id", table, ["user_id"])
+        insp = inspect(op.get_bind())
+        if not _has_column(insp, table, "user_id"):
+            op.add_column(
+                table,
+                sa.Column("user_id", sa.Integer(), nullable=False, server_default="1"),
+            )
+        if f"ix_{table}_user_id" not in _index_names(inspect(op.get_bind()), table):
+            op.create_index(f"ix_{table}_user_id", table, ["user_id"])
 
-    # --- Rework single-tenant uniqueness into per-user uniqueness -----------
-    # The initial schema put BOTH a unique index and an unnamed UNIQUE table
-    # constraint on these single columns, so each must be reworked: demote the
-    # index to a plain lookup index and replace the constraint with a composite.
-
-    # activities.garmin_id → unique per (user_id, garmin_id).
-    op.drop_index("ix_activities_garmin_id", table_name="activities")
-    op.create_index("ix_activities_garmin_id", "activities", ["garmin_id"])
-    with op.batch_alter_table("activities", naming_convention=_NAMING) as batch_op:
-        batch_op.drop_constraint("uq_activities_garmin_id", type_="unique")
-        batch_op.create_unique_constraint(
-            "uq_activities_user_garmin", ["user_id", "garmin_id"]
-        )
-
-    # daily_summaries.date → unique per (user_id, date).
-    op.drop_index("ix_daily_summaries_date", table_name="daily_summaries")
-    op.create_index("ix_daily_summaries_date", "daily_summaries", ["date"])
-    with op.batch_alter_table("daily_summaries", naming_convention=_NAMING) as batch_op:
-        batch_op.drop_constraint("uq_daily_summaries_date", type_="unique")
-        batch_op.create_unique_constraint(
-            "uq_daily_summaries_user_date", ["user_id", "date"]
-        )
-
-    # garmin_calendar_events.garmin_id → unique per (user_id, garmin_id).
-    op.drop_index(
-        "ix_garmin_calendar_events_garmin_id", table_name="garmin_calendar_events"
+    # Rework single-tenant uniqueness into per-user uniqueness.
+    _rework_single_col_unique(
+        "activities", "garmin_id", "uq_activities_user_garmin", "ix_activities_garmin_id"
     )
-    op.create_index(
-        "ix_garmin_calendar_events_garmin_id", "garmin_calendar_events", ["garmin_id"]
+    _rework_single_col_unique(
+        "daily_summaries", "date", "uq_daily_summaries_user_date", "ix_daily_summaries_date"
     )
-    with op.batch_alter_table(
-        "garmin_calendar_events", naming_convention=_NAMING
-    ) as batch_op:
-        batch_op.drop_constraint(
-            "uq_garmin_calendar_events_garmin_id", type_="unique"
-        )
-        batch_op.create_unique_constraint(
-            "uq_garmin_calendar_user_garmin", ["user_id", "garmin_id"]
-        )
-
-    # athlete_profiles: one profile per user (no prior uniqueness existed).
-    op.create_index(
-        "uq_athlete_profiles_user", "athlete_profiles", ["user_id"], unique=True
+    _rework_single_col_unique(
+        "garmin_calendar_events", "garmin_id",
+        "uq_garmin_calendar_user_garmin", "ix_garmin_calendar_events_garmin_id",
     )
 
-    # zone_configs: the named (zone_type, zone_number) unique becomes per-user.
-    with op.batch_alter_table("zone_configs") as batch_op:
-        batch_op.drop_constraint("uq_zone_type_number", type_="unique")
-        batch_op.create_unique_constraint(
-            "uq_zone_type_number", ["user_id", "zone_type", "zone_number"]
-        )
+    # athlete_profiles: one profile per user.
+    if "uq_athlete_profiles_user" not in _index_names(inspect(op.get_bind()), "athlete_profiles"):
+        if not _has_composite_unique(inspect(op.get_bind()), "athlete_profiles", ["user_id"]):
+            op.create_index(
+                "uq_athlete_profiles_user", "athlete_profiles", ["user_id"], unique=True
+            )
 
-    # sync_status: the global unique on ``key`` becomes per-user.
-    with op.batch_alter_table("sync_status", naming_convention=_NAMING) as batch_op:
-        batch_op.drop_constraint("uq_sync_status_key", type_="unique")
-        batch_op.create_unique_constraint("uq_sync_status_user_key", ["user_id", "key"])
+    # zone_configs + sync_status: replace the table-level unique with a per-user one.
+    _replace_table_unique(
+        "zone_configs", ["zone_type", "zone_number"],
+        "uq_zone_type_number", ["user_id", "zone_type", "zone_number"],
+    )
+    _replace_table_unique(
+        "sync_status", ["key"], "uq_sync_status_user_key", ["user_id", "key"]
+    )
 
 
 def downgrade() -> None:
-    with op.batch_alter_table("sync_status") as batch_op:
-        batch_op.drop_constraint("uq_sync_status_user_key", type_="unique")
-        batch_op.create_unique_constraint("uq_sync_status_key", ["key"])
+    # Best-effort reverse: collapse the per-user uniques back to single-tenant.
+    # Only meaningful for genuinely single-user data.
+    _replace_table_unique_back("sync_status", ["user_id", "key"], "uq_sync_status_key", ["key"])
+    _replace_table_unique_back(
+        "zone_configs", ["user_id", "zone_type", "zone_number"],
+        "uq_zone_type_number", ["zone_type", "zone_number"],
+    )
 
-    with op.batch_alter_table("zone_configs") as batch_op:
-        batch_op.drop_constraint("uq_zone_type_number", type_="unique")
-        batch_op.create_unique_constraint("uq_zone_type_number", ["zone_type", "zone_number"])
+    insp = inspect(op.get_bind())
+    if "uq_athlete_profiles_user" in _index_names(insp, "athlete_profiles"):
+        op.drop_index("uq_athlete_profiles_user", table_name="athlete_profiles")
 
-    op.drop_index("uq_athlete_profiles_user", table_name="athlete_profiles")
-
-    with op.batch_alter_table("garmin_calendar_events") as batch_op:
-        batch_op.drop_constraint("uq_garmin_calendar_user_garmin", type_="unique")
-        batch_op.create_unique_constraint("uq_garmin_calendar_events_garmin_id", ["garmin_id"])
-
-    with op.batch_alter_table("daily_summaries") as batch_op:
-        batch_op.drop_constraint("uq_daily_summaries_user_date", type_="unique")
-        batch_op.create_unique_constraint("uq_daily_summaries_date", ["date"])
-
-    with op.batch_alter_table("activities") as batch_op:
-        batch_op.drop_constraint("uq_activities_user_garmin", type_="unique")
-        batch_op.create_unique_constraint("uq_activities_garmin_id", ["garmin_id"])
+    _restore_single_col_unique("garmin_calendar_events", "garmin_id", "uq_garmin_calendar_user_garmin")
+    _restore_single_col_unique("daily_summaries", "date", "uq_daily_summaries_user_date")
+    _restore_single_col_unique("activities", "garmin_id", "uq_activities_user_garmin")
 
     for table in _USER_SCOPED_TABLES:
-        op.drop_index(f"ix_{table}_user_id", table_name=table)
-        op.drop_column(table, "user_id")
+        insp = inspect(op.get_bind())
+        if f"ix_{table}_user_id" in _index_names(insp, table):
+            op.drop_index(f"ix_{table}_user_id", table_name=table)
+        if _has_column(insp, table, "user_id"):
+            op.drop_column(table, "user_id")
 
-    op.drop_column("users", "garmin_needs_reauth")
+    insp = inspect(op.get_bind())
+    if _has_column(insp, "users", "garmin_needs_reauth"):
+        op.drop_column("users", "garmin_needs_reauth")
+
+
+def _replace_table_unique_back(table, old_cols, new_name, new_cols) -> None:
+    insp = inspect(op.get_bind())
+    if not _has_composite_unique(insp, table, old_cols):
+        return
+    with op.batch_alter_table(table, naming_convention=_NAMING) as batch_op:
+        for uc in _unique_constraints_on(insp, table, old_cols):
+            batch_op.drop_constraint(uc.get("name"), type_="unique")
+        batch_op.create_unique_constraint(new_name, new_cols)
+
+
+def _restore_single_col_unique(table, col, composite_name) -> None:
+    insp = inspect(op.get_bind())
+    # Drop composite (index or constraint form), restore single-col unique index.
+    for ix_name in _unique_indexes_on(insp, table, ["user_id", col]):
+        op.drop_index(ix_name, table_name=table)
+    insp = inspect(op.get_bind())
+    if _unique_constraints_on(insp, table, ["user_id", col]):
+        with op.batch_alter_table(table, naming_convention=_NAMING) as batch_op:
+            for uc in _unique_constraints_on(insp, table, ["user_id", col]):
+                batch_op.drop_constraint(uc.get("name") or composite_name, type_="unique")
+    insp = inspect(op.get_bind())
+    if not _has_composite_unique(insp, table, [col]):
+        # mirror the lookup index back to unique
+        for ix in inspect(op.get_bind()).get_indexes(table):
+            if list(ix.get("column_names") or []) == [col]:
+                op.drop_index(ix["name"], table_name=table)
+        op.create_index(f"ix_{table}_{col}", table, [col], unique=True)

--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -17,6 +17,7 @@ from app import intensity as intensity_mod
 from app.config import settings
 from app.database import db_session
 from app.models import (
+    DEFAULT_USER_ID,
     Activity,
     AthleteProfile,
     DailySummary,
@@ -336,12 +337,19 @@ def _format_athlete_profile_context(profile: AthleteProfile, reference_date: dat
     return "## Athlete Profile\n" + "\n".join(lines)
 
 
-def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_date: date | None = None) -> str:
+def _build_context(
+    db: Session,
+    trigger_type: str,
+    trigger_data: str,
+    reference_date: date | None = None,
+    user_id: int = DEFAULT_USER_ID,
+) -> str:
     """Build full context for AI analysis.
 
     Args:
         reference_date: The date to use as "today" for temporal context.
                         Defaults to date.today() if not provided.
+        user_id: Scope all data to this user.
     """
     if reference_date is None:
         reference_date = date.today()
@@ -350,7 +358,7 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
     sections = [f"## Current Data\n{trigger_data}"]
 
     # Athlete profile (baseline personalization — lands right after Current Data)
-    profile = db.query(AthleteProfile).first()
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == user_id).first()
     if profile:
         profile_context = _format_athlete_profile_context(profile, reference_date)
         if profile_context:
@@ -359,7 +367,7 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
     # Auto-derived thresholds — surface only the ones the athlete hasn't set so the
     # AI still has a reference for Critical Power / threshold pace / LTHR.
     try:
-        estimate = threshold_mod.estimate_thresholds(db)
+        estimate = threshold_mod.estimate_thresholds(db, user_id=user_id)
         estimate_context = threshold_mod.format_threshold_estimate_context(estimate, profile)
         if estimate_context:
             sections.insert(min(2, len(sections)), estimate_context)
@@ -367,17 +375,22 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
         logger.debug("Threshold estimate skipped", exc_info=True)
 
     # Training load (Fitness/Fatigue/Form) as of the reference date
-    load_point = training_load.current_load(db, as_of=reference_date)
+    load_point = training_load.current_load(db, as_of=reference_date, user_id=user_id)
     load_context = training_load.format_training_load_context(load_point)
     if load_context:
         sections.insert(2 if len(sections) > 1 else 1, load_context)
 
     # Training readiness (composite of sleep, stress, body battery, acute load)
-    today_summary = db.query(DailySummary).filter(DailySummary.date == reference_date).first()
+    today_summary = (
+        db.query(DailySummary)
+        .filter(DailySummary.user_id == user_id, DailySummary.date == reference_date)
+        .first()
+    )
     rhr_cutoff = reference_date - timedelta(days=7)
     recent_rhr_rows = (
         db.query(DailySummary.resting_hr)
         .filter(
+            DailySummary.user_id == user_id,
             DailySummary.date >= rhr_cutoff,
             DailySummary.date < reference_date,
             DailySummary.resting_hr.isnot(None),
@@ -395,7 +408,7 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
     cutoff = ref_datetime - timedelta(days=14)
     recent_activities = (
         db.query(Activity)
-        .filter(Activity.started_at >= cutoff)
+        .filter(Activity.user_id == user_id, Activity.started_at >= cutoff)
         .order_by(Activity.started_at.desc())
         .limit(15)
         .all()
@@ -427,6 +440,7 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
                 func.sum(Activity.duration_sec),
             )
             .filter(
+                Activity.user_id == user_id,
                 Activity.started_at >= datetime.combine(week_start, datetime.min.time()),
                 Activity.started_at < datetime.combine(week_end, datetime.min.time()),
             )
@@ -444,7 +458,7 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
     # Intensity distribution (HR zones, last 4 weeks)
     try:
         intensity_weeks = intensity_mod.aggregate_weekly_intensity(
-            db, days=56, zone_type="hr", as_of=reference_date
+            db, days=56, zone_type="hr", as_of=reference_date, user_id=user_id
         )
         intensity_context = intensity_mod.format_intensity_context(intensity_weeks, zone_type="hr")
         if intensity_context:
@@ -455,6 +469,7 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
     # Recent daily summaries (last 7 days)
     recent_days = (
         db.query(DailySummary)
+        .filter(DailySummary.user_id == user_id)
         .order_by(DailySummary.date.desc())
         .limit(7)
         .all()
@@ -477,6 +492,7 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
     upcoming_races = (
         db.query(GarminCalendarEvent)
         .filter(
+            GarminCalendarEvent.user_id == user_id,
             GarminCalendarEvent.event_type == "race",
             GarminCalendarEvent.date >= reference_date,
         )
@@ -504,6 +520,7 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
     next_training = (
         db.query(GarminCalendarEvent)
         .filter(
+            GarminCalendarEvent.user_id == user_id,
             GarminCalendarEvent.event_type == "workout",
             GarminCalendarEvent.date >= date.today(),
         )
@@ -522,6 +539,7 @@ def _build_context(db: Session, trigger_type: str, trigger_data: str, reference_
     # Recent insights (last 3) to avoid repetition
     recent_insights = (
         db.query(Insight)
+        .filter(Insight.user_id == user_id)
         .order_by(Insight.created_at.desc())
         .limit(3)
         .all()
@@ -604,18 +622,28 @@ def _call_gemini(context: str, trigger_type: str, model: str) -> tuple[str, str,
     return content, summary, category
 
 
-def _get_ai_config(db: Session) -> tuple[str, str]:
+def _get_ai_config(db: Session, user_id: int = DEFAULT_USER_ID) -> tuple[str, str]:
     """Return (provider, model) from DB, falling back to env defaults."""
-    provider_row = db.query(SyncStatus).filter(SyncStatus.key == "ai_provider").first()
-    model_row = db.query(SyncStatus).filter(SyncStatus.key == "ai_model").first()
+    provider_row = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == "ai_provider")
+        .first()
+    )
+    model_row = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == "ai_model")
+        .first()
+    )
     provider = provider_row.value if provider_row else "claude"
     model = model_row.value if model_row else settings.ai_model
     return provider, model
 
 
-def _call_ai(db: Session, context: str, trigger_type: str) -> tuple[str, str, str]:
+def _call_ai(
+    db: Session, context: str, trigger_type: str, user_id: int = DEFAULT_USER_ID
+) -> tuple[str, str, str]:
     """Dispatch to the configured AI provider with exponential backoff on transient errors."""
-    provider, model = _get_ai_config(db)
+    provider, model = _get_ai_config(db, user_id)
     call_fn = _call_gemini if provider == "gemini" else _call_claude
 
     last_exc: Exception = RuntimeError("no attempts made")
@@ -636,7 +664,19 @@ def _call_ai(db: Session, context: str, trigger_type: str) -> tuple[str, str, st
     raise last_exc
 
 
-def _save_error_insight(activity_id: int, exc: Exception) -> None:
+def _activity_user_id(activity_id: int) -> int:
+    """Best-effort lookup of an activity's owner (for error-path insight writes)."""
+    try:
+        with db_session() as db:
+            row = db.query(Activity.user_id).filter(Activity.id == activity_id).first()
+            return (row[0] if row and row[0] else DEFAULT_USER_ID)
+    except Exception:
+        return DEFAULT_USER_ID
+
+
+def _save_error_insight(
+    activity_id: int, exc: Exception, user_id: int = DEFAULT_USER_ID
+) -> None:
     """Persist a failure insight so the UI can show an error and allow retry."""
     if isinstance(exc, AITransientError):
         content = (
@@ -662,10 +702,12 @@ def _save_error_insight(activity_id: int, exc: Exception) -> None:
     try:
         with db_session() as db:
             db.query(Insight).filter(
+                Insight.user_id == user_id,
                 Insight.trigger_type == "activity",
                 Insight.trigger_id == activity_id,
             ).delete()
             db.add(Insight(
+                user_id=user_id,
                 created_at=datetime.now(timezone.utc),
                 trigger_type="activity",
                 trigger_id=activity_id,
@@ -686,10 +728,15 @@ def _load_zones(db: Session) -> dict[str, list[MetricZone]]:
     return zones_by_metric
 
 
-def _load_zone_configs(db: Session) -> dict:
+def _load_zone_configs(db: Session, user_id: int = DEFAULT_USER_ID) -> dict:
     """Load custom threshold-anchored zone configs and profile thresholds."""
-    profile = db.query(AthleteProfile).first()
-    all_zones = db.query(ZoneConfig).order_by(ZoneConfig.zone_type, ZoneConfig.zone_number).all()
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == user_id).first()
+    all_zones = (
+        db.query(ZoneConfig)
+        .filter(ZoneConfig.user_id == user_id)
+        .order_by(ZoneConfig.zone_type, ZoneConfig.zone_number)
+        .all()
+    )
     return {
         "hr": [z for z in all_zones if z.zone_type == "hr"],
         "pace": [z for z in all_zones if z.zone_type == "pace"],
@@ -700,11 +747,12 @@ def _load_zone_configs(db: Session) -> dict:
 
 def analyze_activity(activity: Activity):
     """Generate AI insight for a new activity."""
+    user_id = activity.user_id or DEFAULT_USER_ID
     with db_session() as db:
         try:
             activity_date = activity.started_at.date() if isinstance(activity.started_at, datetime) else activity.started_at
             zones_by_metric = _load_zones(db)
-            zc = _load_zone_configs(db)
+            zc = _load_zone_configs(db, user_id)
             activity_context = _format_activity_context(
                 activity, zones_by_metric,
                 hr_zone_configs=zc["hr"], pace_zone_configs=zc["pace"],
@@ -715,6 +763,7 @@ def analyze_activity(activity: Activity):
             workout_event = (
                 db.query(GarminCalendarEvent)
                 .filter(
+                    GarminCalendarEvent.user_id == user_id,
                     GarminCalendarEvent.date == activity_date,
                     GarminCalendarEvent.event_type == "workout",
                 )
@@ -726,10 +775,13 @@ def analyze_activity(activity: Activity):
                 if adherence_result:
                     activity_context += "\n\n" + adherence_mod.format_adherence_context(adherence_result)
 
-            full_context = _build_context(db, "activity", activity_context, reference_date=activity_date)
-            content, summary, category = _call_ai(db, full_context, "activity")
+            full_context = _build_context(
+                db, "activity", activity_context, reference_date=activity_date, user_id=user_id
+            )
+            content, summary, category = _call_ai(db, full_context, "activity", user_id)
 
             insight = Insight(
+                user_id=user_id,
                 created_at=datetime.now(timezone.utc),
                 trigger_type="activity",
                 trigger_id=activity.id,
@@ -751,13 +803,17 @@ def analyze_activity(activity: Activity):
 
 def analyze_daily_summary(daily: DailySummary):
     """Generate AI insight for a daily summary."""
+    user_id = daily.user_id or DEFAULT_USER_ID
     with db_session() as db:
         try:
             daily_context = _format_daily_context(daily)
-            full_context = _build_context(db, "daily_summary", daily_context, reference_date=daily.date)
-            content, summary, category = _call_ai(db, full_context, "daily_summary")
+            full_context = _build_context(
+                db, "daily_summary", daily_context, reference_date=daily.date, user_id=user_id
+            )
+            content, summary, category = _call_ai(db, full_context, "daily_summary", user_id)
 
             insight = Insight(
+                user_id=user_id,
                 created_at=datetime.now(timezone.utc),
                 trigger_type="daily_summary",
                 trigger_id=daily.id,
@@ -785,25 +841,30 @@ def analyze_activity_force(activity_id: int):
             if not activity:
                 logger.warning("Activity %s not found for re-analysis", activity_id)
                 return
+            user_id = activity.user_id or DEFAULT_USER_ID
 
             # Delete existing insight for this activity
             db.query(Insight).filter(
+                Insight.user_id == user_id,
                 Insight.trigger_type == "activity",
                 Insight.trigger_id == activity.id,
             ).delete()
 
             activity_date = activity.started_at.date() if isinstance(activity.started_at, datetime) else activity.started_at
             zones_by_metric = _load_zones(db)
-            zc = _load_zone_configs(db)
+            zc = _load_zone_configs(db, user_id)
             activity_context = _format_activity_context(
                 activity, zones_by_metric,
                 hr_zone_configs=zc["hr"], pace_zone_configs=zc["pace"],
                 threshold_hr=zc["threshold_hr"], threshold_pace=zc["threshold_pace"],
             )
-            full_context = _build_context(db, "activity", activity_context, reference_date=activity_date)
-            content, summary, category = _call_ai(db, full_context, "activity")
+            full_context = _build_context(
+                db, "activity", activity_context, reference_date=activity_date, user_id=user_id
+            )
+            content, summary, category = _call_ai(db, full_context, "activity", user_id)
 
             insight = Insight(
+                user_id=user_id,
                 created_at=datetime.now(timezone.utc),
                 trigger_type="activity",
                 trigger_id=activity.id,
@@ -817,7 +878,7 @@ def analyze_activity_force(activity_id: int):
             logger.info("AI re-analysis complete for activity %s: %s", activity.id, summary[:80])
         except Exception as exc:
             logger.exception("AI re-analysis failed for activity %s", activity_id)
-            _save_error_insight(activity_id, exc)
+            _save_error_insight(activity_id, exc, _activity_user_id(activity_id))
 
 
 def analyze_activity_with_feedback(activity_id: int):
@@ -828,15 +889,17 @@ def analyze_activity_with_feedback(activity_id: int):
             if not activity:
                 logger.warning("Activity %s not found for feedback analysis", activity_id)
                 return
+            user_id = activity.user_id or DEFAULT_USER_ID
 
             # Delete existing insight for this activity
             db.query(Insight).filter(
+                Insight.user_id == user_id,
                 Insight.trigger_type == "activity",
                 Insight.trigger_id == activity.id,
             ).delete()
 
             zones_by_metric = _load_zones(db)
-            zc = _load_zone_configs(db)
+            zc = _load_zone_configs(db, user_id)
             activity_context = _format_activity_context(
                 activity, zones_by_metric,
                 hr_zone_configs=zc["hr"], pace_zone_configs=zc["pace"],
@@ -863,10 +926,13 @@ def analyze_activity_with_feedback(activity_id: int):
                 activity_context += "\n\n## User Feedback\n" + "\n".join(feedback_parts)
 
             activity_date = activity.started_at.date() if isinstance(activity.started_at, datetime) else activity.started_at
-            full_context = _build_context(db, "activity", activity_context, reference_date=activity_date)
-            content, summary, category = _call_ai(db, full_context, "activity")
+            full_context = _build_context(
+                db, "activity", activity_context, reference_date=activity_date, user_id=user_id
+            )
+            content, summary, category = _call_ai(db, full_context, "activity", user_id)
 
             insight = Insight(
+                user_id=user_id,
                 created_at=datetime.now(timezone.utc),
                 trigger_type="activity",
                 trigger_id=activity.id,
@@ -880,10 +946,10 @@ def analyze_activity_with_feedback(activity_id: int):
             logger.info("AI feedback analysis complete for activity %s: %s", activity.id, summary[:80])
         except Exception as exc:
             logger.exception("AI feedback analysis failed for activity %s", activity_id)
-            _save_error_insight(activity_id, exc)
+            _save_error_insight(activity_id, exc, _activity_user_id(activity_id))
 
 
-def backfill_missing_insights():
+def backfill_missing_insights(user_id: int = DEFAULT_USER_ID):
     """Analyze past 7 days of activities and daily summaries that lack insights."""
     with db_session() as db:
         cutoff = datetime.now(timezone.utc) - timedelta(days=7)
@@ -892,6 +958,7 @@ def backfill_missing_insights():
         activities = (
             db.query(Activity)
             .filter(
+                Activity.user_id == user_id,
                 Activity.started_at >= cutoff,
                 Activity.ai_analyzed == False,
             )
@@ -910,6 +977,7 @@ def backfill_missing_insights():
         summaries = (
             db.query(DailySummary)
             .filter(
+                DailySummary.user_id == user_id,
                 DailySummary.date >= cutoff_date,
                 DailySummary.ai_analyzed == False,
             )
@@ -975,7 +1043,9 @@ Rules:
 """
 
 
-def _build_plan_adherence_context(db: Session, reference_date: date) -> str | None:
+def _build_plan_adherence_context(
+    db: Session, reference_date: date, user_id: int = DEFAULT_USER_ID
+) -> str | None:
     """Build adherence summary for the most recent training plan.
 
     For each non-rest day in the current plan that has already passed, checks
@@ -984,6 +1054,7 @@ def _build_plan_adherence_context(db: Session, reference_date: date) -> str | No
     """
     plan = (
         db.query(TrainingPlan)
+        .filter(TrainingPlan.user_id == user_id)
         .order_by(TrainingPlan.generated_at.desc())
         .first()
     )
@@ -1013,6 +1084,7 @@ def _build_plan_adherence_context(db: Session, reference_date: date) -> str | No
         activity = (
             db.query(Activity)
             .filter(
+                Activity.user_id == user_id,
                 Activity.started_at >= day_start,
                 Activity.started_at < day_end,
             )
@@ -1050,34 +1122,41 @@ def _build_plan_adherence_context(db: Session, reference_date: date) -> str | No
     return "\n".join(lines)
 
 
-def _build_plan_context(db: Session, reference_date: date) -> str:
+def _build_plan_context(
+    db: Session, reference_date: date, user_id: int = DEFAULT_USER_ID
+) -> str:
     """Build context string for plan generation (profile + load + recent history)."""
     sections: list[str] = [f"Today's date: {reference_date}"]
 
-    profile = db.query(AthleteProfile).first()
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == user_id).first()
     if profile:
         ctx = _format_athlete_profile_context(profile, reference_date)
         if ctx:
             sections.append(ctx)
 
     try:
-        estimate = threshold_mod.estimate_thresholds(db)
+        estimate = threshold_mod.estimate_thresholds(db, user_id=user_id)
         est_ctx = threshold_mod.format_threshold_estimate_context(estimate, profile)
         if est_ctx:
             sections.append(est_ctx)
     except Exception:
         pass
 
-    load_point = training_load.current_load(db, as_of=reference_date)
+    load_point = training_load.current_load(db, as_of=reference_date, user_id=user_id)
     load_ctx = training_load.format_training_load_context(load_point)
     if load_ctx:
         sections.append(load_ctx)
 
-    today_summary = db.query(DailySummary).filter(DailySummary.date == reference_date).first()
+    today_summary = (
+        db.query(DailySummary)
+        .filter(DailySummary.user_id == user_id, DailySummary.date == reference_date)
+        .first()
+    )
     rhr_cutoff = reference_date - timedelta(days=7)
     recent_rhr_rows = (
         db.query(DailySummary.resting_hr)
         .filter(
+            DailySummary.user_id == user_id,
             DailySummary.date >= rhr_cutoff,
             DailySummary.date < reference_date,
             DailySummary.resting_hr.isnot(None),
@@ -1098,6 +1177,7 @@ def _build_plan_context(db: Session, reference_date: date) -> str:
         result = (
             db.query(func.count(Activity.id), func.sum(Activity.distance_m))
             .filter(
+                Activity.user_id == user_id,
                 Activity.started_at >= datetime.combine(week_start, datetime.min.time()),
                 Activity.started_at < datetime.combine(week_end, datetime.min.time()),
             )
@@ -1110,7 +1190,7 @@ def _build_plan_context(db: Session, reference_date: date) -> str:
         sections.append("## Recent Weekly Volume\n" + "\n".join(weeks))
 
     # Adherence to the current plan
-    adherence_ctx = _build_plan_adherence_context(db, reference_date)
+    adherence_ctx = _build_plan_adherence_context(db, reference_date, user_id)
     if adherence_ctx:
         sections.append(adherence_ctx)
 
@@ -1118,6 +1198,7 @@ def _build_plan_context(db: Session, reference_date: date) -> str:
     upcoming = (
         db.query(GarminCalendarEvent)
         .filter(
+            GarminCalendarEvent.user_id == user_id,
             GarminCalendarEvent.event_type == "race",
             GarminCalendarEvent.date >= reference_date,
         )
@@ -1156,9 +1237,12 @@ def _parse_plan_json(raw: str) -> dict:
     return json.loads(text)
 
 
-def _store_training_plan(db: Session, plan_data: dict, week_start: date, raw_json: str) -> TrainingPlan:
+def _store_training_plan(
+    db: Session, plan_data: dict, week_start: date, raw_json: str, user_id: int = DEFAULT_USER_ID
+) -> TrainingPlan:
     """Persist the parsed plan dict as TrainingPlan + TrainingPlanDay rows."""
     plan = TrainingPlan(
+        user_id=user_id,
         generated_at=datetime.now(timezone.utc),
         week_start=week_start,
         plan_weeks=len(plan_data.get("weeks", [])) or 4,
@@ -1182,6 +1266,7 @@ def _store_training_plan(db: Session, plan_data: dict, week_start: date, raw_jso
             pace_display = day_data.get("target_pace_display")
             pace_num = _parse_pace_display(pace_display) if pace_display else None
             db.add(TrainingPlanDay(
+                user_id=user_id,
                 plan_id=plan.id,
                 day_date=day_date,
                 day_of_week=day_data.get("day_of_week", day_date.strftime("%A")),
@@ -1210,7 +1295,9 @@ def _parse_pace_display(pace_str: str) -> float | None:
 _REALIGNMENT_MISSED_THRESHOLD = 2  # Show banner when this many sessions are missed
 
 
-def detect_plan_realignment(db: Session, reference_date: date) -> dict:
+def detect_plan_realignment(
+    db: Session, reference_date: date, user_id: int = DEFAULT_USER_ID
+) -> dict:
     """Return realignment state for the current plan.
 
     Looks at all past non-rest TrainingPlanDay rows that lack a matching
@@ -1220,6 +1307,7 @@ def detect_plan_realignment(db: Session, reference_date: date) -> dict:
     """
     plan = (
         db.query(TrainingPlan)
+        .filter(TrainingPlan.user_id == user_id)
         .order_by(TrainingPlan.generated_at.desc())
         .first()
     )
@@ -1228,7 +1316,8 @@ def detect_plan_realignment(db: Session, reference_date: date) -> dict:
         return empty
 
     dismiss_row = db.query(SyncStatus).filter(
-        SyncStatus.key == "plan_realignment_dismissed_until"
+        SyncStatus.user_id == user_id,
+        SyncStatus.key == "plan_realignment_dismissed_until",
     ).first()
     dismissed = False
     if dismiss_row and dismiss_row.value:
@@ -1255,6 +1344,7 @@ def detect_plan_realignment(db: Session, reference_date: date) -> dict:
         activity = (
             db.query(Activity)
             .filter(
+                Activity.user_id == user_id,
                 Activity.started_at >= day_start,
                 Activity.started_at < day_end,
             )
@@ -1276,7 +1366,9 @@ def detect_plan_realignment(db: Session, reference_date: date) -> dict:
     }
 
 
-def generate_training_plan(reference_date: date | None = None) -> TrainingPlan | None:
+def generate_training_plan(
+    reference_date: date | None = None, user_id: int = DEFAULT_USER_ID
+) -> TrainingPlan | None:
     """Generate and persist a 4-week AI training plan.
 
     Can be called from the API (on demand) or from the scheduler (weekly).
@@ -1287,8 +1379,8 @@ def generate_training_plan(reference_date: date | None = None) -> TrainingPlan |
         week_start = _next_monday(ref)
 
         try:
-            context = _build_plan_context(db, ref)
-            provider, model = _get_ai_config(db)
+            context = _build_plan_context(db, ref, user_id)
+            provider, model = _get_ai_config(db, user_id)
 
             plan_prompt = (
                 f"Generate a 4-week running training plan starting Monday {week_start}.\n\n"
@@ -1356,7 +1448,7 @@ def generate_training_plan(reference_date: date | None = None) -> TrainingPlan |
                 raise last_exc
 
             plan_data = _parse_plan_json(raw)
-            plan = _store_training_plan(db, plan_data, week_start, raw)
+            plan = _store_training_plan(db, plan_data, week_start, raw, user_id)
             logger.info(
                 "Training plan generated: %d weeks, phase=%s, week_start=%s",
                 plan.plan_weeks, plan.phase, plan.week_start,
@@ -1367,14 +1459,17 @@ def generate_training_plan(reference_date: date | None = None) -> TrainingPlan |
             return None
 
 
-def weekly_review():
+def weekly_review(user_id: int = DEFAULT_USER_ID):
     """Generate a weekly training summary and recommendations."""
     with db_session() as db:
         try:
             week_start = date.today() - timedelta(days=7)
             week_activities = (
                 db.query(Activity)
-                .filter(Activity.started_at >= datetime.combine(week_start, datetime.min.time()))
+                .filter(
+                    Activity.user_id == user_id,
+                    Activity.started_at >= datetime.combine(week_start, datetime.min.time()),
+                )
                 .order_by(Activity.started_at.asc())
                 .all()
             )
@@ -1384,7 +1479,7 @@ def weekly_review():
                 return
 
             zones_by_metric = _load_zones(db)
-            zc = _load_zone_configs(db)
+            zc = _load_zone_configs(db, user_id)
             activity_summaries = "\n\n".join(
                 _format_activity_context(
                     a, zones_by_metric,
@@ -1394,10 +1489,11 @@ def weekly_review():
                 for a in week_activities
             )
             trigger_data = f"## Weekly Review ({week_start} to {date.today()})\n\n{activity_summaries}"
-            full_context = _build_context(db, "weekly_review", trigger_data)
-            content, summary, category = _call_ai(db, full_context, "weekly_review")
+            full_context = _build_context(db, "weekly_review", trigger_data, user_id=user_id)
+            content, summary, category = _call_ai(db, full_context, "weekly_review", user_id)
 
             insight = Insight(
+                user_id=user_id,
                 created_at=datetime.now(timezone.utc),
                 trigger_type="weekly_review",
                 trigger_id=None,

--- a/app/api.py
+++ b/app/api.py
@@ -110,7 +110,9 @@ AVAILABLE_MODELS: dict[str, list[str]] = {
 def api_today(
     date_str: str = Query(None, alias="date"),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
+    uid = current_user.id
     selected = _parse_date(date_str) if date_str else date.today()
 
     # Activities for the selected date
@@ -118,13 +120,21 @@ def api_today(
     day_end = datetime.combine(selected + timedelta(days=1), datetime.min.time())
     activities = (
         db.query(Activity)
-        .filter(Activity.started_at >= day_start, Activity.started_at < day_end)
+        .filter(
+            Activity.user_id == uid,
+            Activity.started_at >= day_start,
+            Activity.started_at < day_end,
+        )
         .order_by(Activity.started_at.desc())
         .all()
     )
 
     # Daily summary
-    daily_summary = db.query(DailySummary).filter(DailySummary.date == selected).first()
+    daily_summary = (
+        db.query(DailySummary)
+        .filter(DailySummary.user_id == uid, DailySummary.date == selected)
+        .first()
+    )
 
     # Weekly mileage (last 8 weeks) - split by activity type
     week_start_base = date.today() - timedelta(days=date.today().weekday())
@@ -132,6 +142,7 @@ def api_today(
     all_activities = (
         db.query(Activity.started_at, Activity.distance_m, Activity.activity_type)
         .filter(
+            Activity.user_id == uid,
             Activity.started_at >= datetime.combine(eight_weeks_ago, datetime.min.time()),
             Activity.distance_m.isnot(None),
         )
@@ -180,13 +191,18 @@ def api_today(
 
     # Latest insights
     latest_insights = (
-        db.query(Insight).order_by(Insight.created_at.desc()).limit(5).all()
+        db.query(Insight)
+        .filter(Insight.user_id == uid)
+        .order_by(Insight.created_at.desc())
+        .limit(5)
+        .all()
     )
 
     # Next 2 upcoming races
     next_race_rows = (
         db.query(GarminCalendarEvent)
         .filter(
+            GarminCalendarEvent.user_id == uid,
             GarminCalendarEvent.event_type == "race",
             GarminCalendarEvent.date >= date.today(),
         )
@@ -211,6 +227,7 @@ def api_today(
     scheduled_events_rows = (
         db.query(GarminCalendarEvent)
         .filter(
+            GarminCalendarEvent.user_id == uid,
             GarminCalendarEvent.date == selected,
             GarminCalendarEvent.event_type == "workout",
         )
@@ -220,13 +237,14 @@ def api_today(
     scheduled_events = [_enrich_event_with_steps(e) for e in scheduled_events_rows]
 
     # Current training load snapshot (Fitness/Fatigue/Form) as of the selected date
-    current_load = training_load.current_load(db, as_of=selected)
+    current_load = training_load.current_load(db, as_of=selected, user_id=uid)
 
     # Resting HR from the 7 days before the selected date (for trend comparison)
     rhr_cutoff = selected - timedelta(days=7)
     recent_rhr_rows = (
         db.query(DailySummary.resting_hr)
         .filter(
+            DailySummary.user_id == uid,
             DailySummary.date >= rhr_cutoff,
             DailySummary.date < selected,
             DailySummary.resting_hr.isnot(None),
@@ -256,9 +274,12 @@ def api_training_load(
     days: int = Query(90, ge=7, le=365),
     date_str: str = Query(None, alias="date"),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
     end_date = _parse_date(date_str) if date_str else date.today()
-    points = training_load.compute_load_series(db, end_date=end_date, days=days)
+    points = training_load.compute_load_series(
+        db, end_date=end_date, days=days, user_id=current_user.id
+    )
     return TrainingLoadResponse(points=points, current=points[-1] if points else None)
 
 
@@ -268,11 +289,12 @@ def api_training_load(
 def api_wellness_trends(
     days: int = Query(90, ge=7, le=365),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
     cutoff = date.today() - timedelta(days=days)
     summaries = (
         db.query(DailySummary)
-        .filter(DailySummary.date >= cutoff)
+        .filter(DailySummary.user_id == current_user.id, DailySummary.date >= cutoff)
         .order_by(DailySummary.date.asc())
         .all()
     )
@@ -286,10 +308,13 @@ def api_intensity_trends(
     days: int = Query(90, ge=7, le=365),
     zone_type: str = Query("hr"),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
     if zone_type not in ("hr", "power"):
         zone_type = "hr"
-    weeks_data = intensity_mod.aggregate_weekly_intensity(db, days=days, zone_type=zone_type)
+    weeks_data = intensity_mod.aggregate_weekly_intensity(
+        db, days=days, zone_type=zone_type, user_id=current_user.id
+    )
     weeks = [IntensityWeek(**w) for w in weeks_data]
     return IntensityTrendsResponse(weeks=weeks, zone_type=zone_type, days=days)
 
@@ -302,8 +327,13 @@ def api_activities(
     limit: int = Query(20, ge=1, le=100),
     type: str = Query(None),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
-    query = db.query(Activity).order_by(Activity.started_at.desc())
+    query = (
+        db.query(Activity)
+        .filter(Activity.user_id == current_user.id)
+        .order_by(Activity.started_at.desc())
+    )
     if type:
         query = query.filter(Activity.activity_type == type)
     offset = (page - 1) * limit
@@ -312,8 +342,16 @@ def api_activities(
 
 
 @api_router.get("/activities/{activity_id}", response_model=ActivityDetail)
-def api_activity_detail(activity_id: int, db: Session = Depends(get_db)):
-    activity = db.query(Activity).filter(Activity.id == activity_id).first()
+def api_activity_detail(
+    activity_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    activity = (
+        db.query(Activity)
+        .filter(Activity.id == activity_id, Activity.user_id == current_user.id)
+        .first()
+    )
     if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
@@ -326,7 +364,11 @@ def api_activity_detail(activity_id: int, db: Session = Depends(get_db)):
 
     insight = (
         db.query(Insight)
-        .filter(Insight.trigger_type == "activity", Insight.trigger_id == activity.id)
+        .filter(
+            Insight.user_id == current_user.id,
+            Insight.trigger_type == "activity",
+            Insight.trigger_id == activity.id,
+        )
         .first()
     )
 
@@ -345,6 +387,7 @@ def api_activity_detail(activity_id: int, db: Session = Depends(get_db)):
         workout_event = (
             db.query(GarminCalendarEvent)
             .filter(
+                GarminCalendarEvent.user_id == current_user.id,
                 GarminCalendarEvent.date == activity_date,
                 GarminCalendarEvent.event_type == "workout",
             )
@@ -377,10 +420,12 @@ def api_daily_summaries(
     page: int = Query(1, ge=1),
     limit: int = Query(30, ge=1, le=100),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
     offset = (page - 1) * limit
     summaries = (
         db.query(DailySummary)
+        .filter(DailySummary.user_id == current_user.id)
         .order_by(DailySummary.date.desc())
         .offset(offset)
         .limit(limit)
@@ -390,20 +435,33 @@ def api_daily_summaries(
 
 
 @api_router.get("/daily-summaries/{summary_id}", response_model=DailySummaryDetail)
-def api_daily_detail(summary_id: int, db: Session = Depends(get_db)):
-    summary = db.query(DailySummary).filter(DailySummary.id == summary_id).first()
+def api_daily_detail(
+    summary_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    summary = (
+        db.query(DailySummary)
+        .filter(DailySummary.id == summary_id, DailySummary.user_id == current_user.id)
+        .first()
+    )
     if not summary:
         raise HTTPException(status_code=404, detail="Daily summary not found")
 
     insight = (
         db.query(Insight)
-        .filter(Insight.trigger_type == "daily_summary", Insight.trigger_id == summary.id)
+        .filter(
+            Insight.user_id == current_user.id,
+            Insight.trigger_type == "daily_summary",
+            Insight.trigger_id == summary.id,
+        )
         .first()
     )
 
     day_activities = (
         db.query(Activity)
         .filter(
+            Activity.user_id == current_user.id,
             Activity.started_at >= datetime.combine(summary.date, datetime.min.time()),
             Activity.started_at < datetime.combine(summary.date + timedelta(days=1), datetime.min.time()),
         )
@@ -424,6 +482,7 @@ def api_daily_detail(summary_id: int, db: Session = Depends(get_db)):
 def api_calendar_month(
     month: str = Query(None),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
     if month:
         try:
@@ -441,6 +500,7 @@ def api_calendar_month(
     month_activities = (
         db.query(Activity)
         .filter(
+            Activity.user_id == current_user.id,
             Activity.started_at >= datetime.combine(view_date, datetime.min.time()),
             Activity.started_at < datetime.combine(next_month, datetime.min.time()),
         )
@@ -457,6 +517,7 @@ def api_calendar_month(
     month_events = (
         db.query(GarminCalendarEvent)
         .filter(
+            GarminCalendarEvent.user_id == current_user.id,
             GarminCalendarEvent.date >= view_date,
             GarminCalendarEvent.date < next_month,
         )
@@ -486,6 +547,7 @@ def api_calendar_month(
 def api_calendar_week(
     date_str: str = Query(None, alias="date"),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
     target = _parse_date(date_str) if date_str else date.today()
     # Monday of the week
@@ -495,6 +557,7 @@ def api_calendar_week(
     activities = (
         db.query(Activity)
         .filter(
+            Activity.user_id == current_user.id,
             Activity.started_at >= datetime.combine(week_start, datetime.min.time()),
             Activity.started_at < datetime.combine(week_end, datetime.min.time()),
         )
@@ -510,6 +573,7 @@ def api_calendar_week(
     events = (
         db.query(GarminCalendarEvent)
         .filter(
+            GarminCalendarEvent.user_id == current_user.id,
             GarminCalendarEvent.date >= week_start,
             GarminCalendarEvent.date < week_end,
         )
@@ -533,8 +597,16 @@ def api_calendar_week(
 # --- Calendar Event Detail ---
 
 @api_router.get("/calendar-events/{event_id}", response_model=CalendarEventResponse)
-def api_calendar_event_detail(event_id: int, db: Session = Depends(get_db)):
-    event = db.query(GarminCalendarEvent).filter(GarminCalendarEvent.id == event_id).first()
+def api_calendar_event_detail(
+    event_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    event = (
+        db.query(GarminCalendarEvent)
+        .filter(GarminCalendarEvent.id == event_id, GarminCalendarEvent.user_id == current_user.id)
+        .first()
+    )
     if not event:
         raise HTTPException(status_code=404, detail="Calendar event not found")
     return _enrich_event_with_steps(event)
@@ -547,8 +619,13 @@ def api_insights(
     category: str = Query(None),
     limit: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
-    query = db.query(Insight).order_by(Insight.created_at.desc())
+    query = (
+        db.query(Insight)
+        .filter(Insight.user_id == current_user.id)
+        .order_by(Insight.created_at.desc())
+    )
     if category:
         query = query.filter(Insight.category == category)
     return [InsightResponse.model_validate(i) for i in query.limit(limit).all()]
@@ -559,27 +636,42 @@ def api_insights(
 _INTERNAL_SYNC_KEYS = {"threshold_estimate", "training_load_series"}
 
 @api_router.get("/settings", response_model=SettingsResponse)
-def api_settings(db: Session = Depends(get_db)):
+def api_settings(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    uid = current_user.id
     sync_statuses = {}
-    for s in db.query(SyncStatus).all():
+    for s in db.query(SyncStatus).filter(SyncStatus.user_id == uid).all():
         if s.key in _INTERNAL_SYNC_KEYS:
             continue
         sync_statuses[s.key] = {"value": s.value, "updated_at": str(s.updated_at) if s.updated_at else None}
 
     counts = {
-        "activities": db.query(func.count(Activity.id)).scalar() or 0,
-        "daily_summaries": db.query(func.count(DailySummary.id)).scalar() or 0,
-        "insights": db.query(func.count(Insight.id)).scalar() or 0,
-        "calendar_events": db.query(func.count(GarminCalendarEvent.id)).scalar() or 0,
+        "activities": db.query(func.count(Activity.id)).filter(Activity.user_id == uid).scalar() or 0,
+        "daily_summaries": db.query(func.count(DailySummary.id)).filter(DailySummary.user_id == uid).scalar() or 0,
+        "insights": db.query(func.count(Insight.id)).filter(Insight.user_id == uid).scalar() or 0,
+        "calendar_events": db.query(func.count(GarminCalendarEvent.id)).filter(GarminCalendarEvent.user_id == uid).scalar() or 0,
     }
     return SettingsResponse(sync_statuses=sync_statuses, counts=counts)
 
 
 @api_router.get("/ai-config", response_model=AiConfigResponse)
-def api_get_ai_config(db: Session = Depends(get_db)):
+def api_get_ai_config(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     from app.config import settings as app_settings
-    provider_row = db.query(SyncStatus).filter(SyncStatus.key == "ai_provider").first()
-    model_row = db.query(SyncStatus).filter(SyncStatus.key == "ai_model").first()
+    provider_row = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == current_user.id, SyncStatus.key == "ai_provider")
+        .first()
+    )
+    model_row = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == current_user.id, SyncStatus.key == "ai_model")
+        .first()
+    )
     provider = provider_row.value if provider_row else "claude"
     model = model_row.value if model_row else app_settings.ai_model
     return AiConfigResponse(
@@ -591,18 +683,26 @@ def api_get_ai_config(db: Session = Depends(get_db)):
 
 
 @api_router.post("/ai-config", response_model=AiConfigResponse)
-def api_set_ai_config(config: AiConfigRequest, db: Session = Depends(get_db)):
+def api_set_ai_config(
+    config: AiConfigRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     if config.provider not in AVAILABLE_MODELS:
         raise HTTPException(status_code=400, detail=f"Unknown provider: {config.provider}")
     if config.model not in AVAILABLE_MODELS[config.provider]:
         raise HTTPException(status_code=400, detail=f"Model {config.model} not valid for {config.provider}")
 
     for key, value in [("ai_provider", config.provider), ("ai_model", config.model)]:
-        row = db.query(SyncStatus).filter(SyncStatus.key == key).first()
+        row = (
+            db.query(SyncStatus)
+            .filter(SyncStatus.user_id == current_user.id, SyncStatus.key == key)
+            .first()
+        )
         if row:
             row.value = value
         else:
-            db.add(SyncStatus(key=key, value=value))
+            db.add(SyncStatus(user_id=current_user.id, key=key, value=value))
     db.commit()
 
     return AiConfigResponse(
@@ -683,8 +783,11 @@ def _profile_response(profile: AthleteProfile) -> AthleteProfileResponse:
 
 
 @api_router.get("/athlete-profile", response_model=AthleteProfileResponse | None)
-def api_get_athlete_profile(db: Session = Depends(get_db)):
-    profile = db.query(AthleteProfile).first()
+def api_get_athlete_profile(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == current_user.id).first()
     return _profile_response(profile) if profile else None
 
 
@@ -694,15 +797,19 @@ GARMIN_MANAGED_PROFILE_FIELDS = {"name", "date_of_birth", "weight_kg"}
 
 
 @api_router.post("/athlete-profile", response_model=AthleteProfileResponse)
-def api_set_athlete_profile(profile_data: AthleteProfileRequest, db: Session = Depends(get_db)):
+def api_set_athlete_profile(
+    profile_data: AthleteProfileRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     updates = {
         key: value
         for key, value in profile_data.model_dump(exclude_unset=True).items()
         if key not in GARMIN_MANAGED_PROFILE_FIELDS
     }
-    profile = db.query(AthleteProfile).first()
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == current_user.id).first()
     if profile is None:
-        profile = AthleteProfile(**updates)
+        profile = AthleteProfile(user_id=current_user.id, **updates)
         db.add(profile)
     else:
         for key, value in updates.items():
@@ -728,13 +835,18 @@ def _compute_zone_bounds(zones: list, threshold: float | None) -> list[ZoneConfi
     return result
 
 
-def _build_zones_response(db: Session) -> ZoneConfigsResponse:
-    profile = db.query(AthleteProfile).first()
+def _build_zones_response(db: Session, user_id: int) -> ZoneConfigsResponse:
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == user_id).first()
     threshold_hr = profile.threshold_hr if profile else None
     threshold_pace = profile.threshold_pace_min_km if profile else None
     threshold_power = profile.threshold_power if profile else None
 
-    all_zones = db.query(ZoneConfig).order_by(ZoneConfig.zone_type, ZoneConfig.zone_number).all()
+    all_zones = (
+        db.query(ZoneConfig)
+        .filter(ZoneConfig.user_id == user_id)
+        .order_by(ZoneConfig.zone_type, ZoneConfig.zone_number)
+        .all()
+    )
 
     return ZoneConfigsResponse(
         hr=_compute_zone_bounds([z for z in all_zones if z.zone_type == "hr"], threshold_hr),
@@ -747,16 +859,27 @@ def _build_zones_response(db: Session) -> ZoneConfigsResponse:
 
 
 @api_router.get("/zones", response_model=ZoneConfigsResponse)
-def api_get_zones(db: Session = Depends(get_db)):
-    return _build_zones_response(db)
+def api_get_zones(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return _build_zones_response(db, current_user.id)
 
 
 @api_router.put("/zones", response_model=ZoneConfigsResponse)
-def api_update_zones(update: ZoneConfigBulkUpdate, db: Session = Depends(get_db)):
+def api_update_zones(
+    update: ZoneConfigBulkUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     for zu in update.zones:
         zone = (
             db.query(ZoneConfig)
-            .filter(ZoneConfig.zone_type == zu.zone_type, ZoneConfig.zone_number == zu.zone_number)
+            .filter(
+                ZoneConfig.user_id == current_user.id,
+                ZoneConfig.zone_type == zu.zone_type,
+                ZoneConfig.zone_number == zu.zone_number,
+            )
             .first()
         )
         if zone is None:
@@ -770,7 +893,7 @@ def api_update_zones(update: ZoneConfigBulkUpdate, db: Session = Depends(get_db)
         if "max_pct" in zu.model_fields_set:
             zone.max_pct = zu.max_pct
     db.commit()
-    return _build_zones_response(db)
+    return _build_zones_response(db, current_user.id)
 
 
 # --- Threshold / Critical Power estimation ---
@@ -805,20 +928,25 @@ def _build_threshold_response(
 
 
 @api_router.get("/threshold-estimate", response_model=ThresholdEstimateResponse)
-def api_get_threshold_estimate(db: Session = Depends(get_db)):
-    estimate = threshold_mod.estimate_thresholds(db)
-    profile = db.query(AthleteProfile).first()
+def api_get_threshold_estimate(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    estimate = threshold_mod.estimate_thresholds(db, user_id=current_user.id)
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == current_user.id).first()
     return _build_threshold_response(estimate, profile)
 
 
 @api_router.post("/threshold-estimate/apply", response_model=AthleteProfileResponse)
 def api_apply_threshold_estimate(
-    req: ThresholdApplyRequest, db: Session = Depends(get_db)
+    req: ThresholdApplyRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
-    estimate = threshold_mod.estimate_thresholds(db)
-    profile = db.query(AthleteProfile).first()
+    estimate = threshold_mod.estimate_thresholds(db, user_id=current_user.id)
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == current_user.id).first()
     if profile is None:
-        profile = AthleteProfile()
+        profile = AthleteProfile(user_id=current_user.id)
         db.add(profile)
     fields = req.fields if req.fields else None
     applied = threshold_mod.apply_estimate_to_profile(profile, estimate, fields)
@@ -835,9 +963,10 @@ def api_apply_threshold_estimate(
 def api_get_performance_curve(
     days: int = Query(90, ge=30, le=365),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
     """Power-duration and pace-duration curves with CP/CV model fit and race predictions."""
-    data = threshold_mod.get_performance_curve_data(db, lookback_days=days)
+    data = threshold_mod.get_performance_curve_data(db, lookback_days=days, user_id=current_user.id)
     return PerformanceCurveResponse(
         power_points=[
             PerformanceCurvePoint(
@@ -879,7 +1008,7 @@ def _build_plan_response(plan: TrainingPlan, db: Session) -> TrainingPlanRespons
     """Assemble a TrainingPlanResponse with nested week/day structure."""
     days = (
         db.query(TrainingPlanDay)
-        .filter(TrainingPlanDay.plan_id == plan.id)
+        .filter(TrainingPlanDay.plan_id == plan.id, TrainingPlanDay.user_id == plan.user_id)
         .order_by(TrainingPlanDay.day_date.asc())
         .all()
     )
@@ -916,16 +1045,24 @@ def _build_plan_response(plan: TrainingPlan, db: Session) -> TrainingPlanRespons
 
 
 @api_router.get("/training-plan", response_model=TrainingPlanResponse | None)
-def api_get_training_plan(db: Session = Depends(get_db)):
+def api_get_training_plan(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Return the most recently generated training plan, or null if none exists."""
-    plan = db.query(TrainingPlan).order_by(TrainingPlan.generated_at.desc()).first()
+    plan = (
+        db.query(TrainingPlan)
+        .filter(TrainingPlan.user_id == current_user.id)
+        .order_by(TrainingPlan.generated_at.desc())
+        .first()
+    )
     if not plan:
         return None
     return _build_plan_response(plan, db)
 
 
 @api_router.post("/training-plan/generate", response_model=TrainingPlanResponse | None)
-def api_generate_training_plan():
+def api_generate_training_plan(current_user: User = Depends(get_current_user)):
     """Trigger AI plan generation and return the new plan synchronously.
 
     Generation typically takes 5–15 seconds. The function opens its own DB
@@ -933,7 +1070,7 @@ def api_generate_training_plan():
     """
     from app.ai_coach import generate_training_plan
     from app.database import db_session as make_session
-    plan = generate_training_plan()
+    plan = generate_training_plan(user_id=current_user.id)
     if plan is None:
         raise HTTPException(status_code=500, detail="Plan generation failed — check AI config")
     with make_session() as fresh_db:
@@ -944,10 +1081,13 @@ def api_generate_training_plan():
 
 
 @api_router.get("/training-plan/realignment-status", response_model=PlanRealignmentStatus)
-def api_get_realignment_status(db: Session = Depends(get_db)):
+def api_get_realignment_status(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Return whether the current plan has enough missed sessions to warrant realignment."""
     from app.ai_coach import detect_plan_realignment
-    result = detect_plan_realignment(db, date.today())
+    result = detect_plan_realignment(db, date.today(), user_id=current_user.id)
     return PlanRealignmentStatus(
         should_prompt=result["should_prompt"],
         missed_count=result["missed_count"],
@@ -964,29 +1104,39 @@ def api_get_realignment_status(db: Session = Depends(get_db)):
 
 
 @api_router.post("/training-plan/realign")
-def api_realign_plan(body: PlanRealignmentRequest, db: Session = Depends(get_db)):
+def api_realign_plan(
+    body: PlanRealignmentRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     """Handle plan realignment: regenerate the plan or dismiss the banner for 7 days."""
     if body.action == "dismiss":
         dismiss_until = (date.today() + timedelta(days=7)).isoformat()
         row = db.query(SyncStatus).filter(
-            SyncStatus.key == "plan_realignment_dismissed_until"
+            SyncStatus.user_id == current_user.id,
+            SyncStatus.key == "plan_realignment_dismissed_until",
         ).first()
         if row:
             row.value = dismiss_until
         else:
-            db.add(SyncStatus(key="plan_realignment_dismissed_until", value=dismiss_until))
+            db.add(SyncStatus(
+                user_id=current_user.id,
+                key="plan_realignment_dismissed_until",
+                value=dismiss_until,
+            ))
         db.commit()
         return {"status": "dismissed", "until": dismiss_until}
 
     # action == "regenerate"
     from app.ai_coach import generate_training_plan
     from app.database import db_session as make_session
-    plan = generate_training_plan()
+    plan = generate_training_plan(user_id=current_user.id)
     if plan is None:
         raise HTTPException(status_code=500, detail="Plan generation failed — check AI config")
     # Clear dismiss snooze after generating a new plan
     row = db.query(SyncStatus).filter(
-        SyncStatus.key == "plan_realignment_dismissed_until"
+        SyncStatus.user_id == current_user.id,
+        SyncStatus.key == "plan_realignment_dismissed_until",
     ).first()
     if row:
         db.delete(row)
@@ -1001,8 +1151,16 @@ def api_realign_plan(body: PlanRealignmentRequest, db: Session = Depends(get_db)
 # --- Actions ---
 
 @api_router.post("/activities/{activity_id}/analyze")
-def api_trigger_analysis(activity_id: int, db: Session = Depends(get_db)):
-    activity = db.query(Activity).filter(Activity.id == activity_id).first()
+def api_trigger_analysis(
+    activity_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    activity = (
+        db.query(Activity)
+        .filter(Activity.id == activity_id, Activity.user_id == current_user.id)
+        .first()
+    )
     if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
     from app.ai_coach import analyze_activity_force
@@ -1011,8 +1169,17 @@ def api_trigger_analysis(activity_id: int, db: Session = Depends(get_db)):
 
 
 @api_router.post("/activities/{activity_id}/feedback")
-def api_submit_feedback(activity_id: int, feedback: FeedbackRequest, db: Session = Depends(get_db)):
-    activity = db.query(Activity).filter(Activity.id == activity_id).first()
+def api_submit_feedback(
+    activity_id: int,
+    feedback: FeedbackRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    activity = (
+        db.query(Activity)
+        .filter(Activity.id == activity_id, Activity.user_id == current_user.id)
+        .first()
+    )
     if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
@@ -1023,6 +1190,7 @@ def api_submit_feedback(activity_id: int, feedback: FeedbackRequest, db: Session
 
     # Delete existing insight
     db.query(Insight).filter(
+        Insight.user_id == current_user.id,
         Insight.trigger_type == "activity",
         Insight.trigger_id == activity.id,
     ).delete()
@@ -1034,19 +1202,31 @@ def api_submit_feedback(activity_id: int, feedback: FeedbackRequest, db: Session
 
 
 @api_router.post("/sync/{sync_type}")
-def api_trigger_sync(sync_type: str):
+def api_trigger_sync(sync_type: str, current_user: User = Depends(get_current_user)):
+    # Manual syncs are scoped to the calling user only (the scheduler is what
+    # fans a sync out across all connected users).
+    from app.main import run_activity_sync_for_user, run_daily_sync_for_user
+
+    uid = current_user.id
     if sync_type == "activities":
-        from app.main import _scheduled_activity_sync
-        threading.Thread(target=_scheduled_activity_sync, daemon=True).start()
+        threading.Thread(target=run_activity_sync_for_user, args=(uid,), daemon=True).start()
     elif sync_type == "daily":
-        from app.main import _scheduled_daily_sync
-        threading.Thread(target=_scheduled_daily_sync, daemon=True).start()
+        threading.Thread(target=run_daily_sync_for_user, args=(uid,), daemon=True).start()
     elif sync_type == "calendar":
-        from app.garmin_sync import sync_calendar
-        threading.Thread(target=sync_calendar, daemon=True).start()
+        threading.Thread(target=_sync_calendar_for_user, args=(uid,), daemon=True).start()
     else:
         raise HTTPException(status_code=400, detail=f"Unknown sync type: {sync_type}")
     return {"status": "accepted"}
+
+
+def _sync_calendar_for_user(user_id: int) -> None:
+    """Resolve a user by id and sync their Garmin calendar (background thread)."""
+    from app.database import db_session as make_session
+    from app.garmin_sync import sync_calendar
+    with make_session() as db:
+        user = db.query(User).filter(User.id == user_id).first()
+        if user is not None:
+            sync_calendar(user)
 
 
 # --- Data Export ---
@@ -1055,8 +1235,14 @@ def api_trigger_sync(sync_type: str):
 def api_export_activities(
     format: str = Query("csv", pattern="^(csv|json)$"),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
-    activities = db.query(Activity).order_by(Activity.started_at.desc()).all()
+    activities = (
+        db.query(Activity)
+        .filter(Activity.user_id == current_user.id)
+        .order_by(Activity.started_at.desc())
+        .all()
+    )
 
     if format == "json":
         data = [ActivitySummary.model_validate(a).model_dump() for a in activities]
@@ -1089,8 +1275,14 @@ def api_export_activities(
 def api_export_insights(
     format: str = Query("csv", pattern="^(csv|json)$"),
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
-    insights = db.query(Insight).order_by(Insight.created_at.desc()).all()
+    insights = (
+        db.query(Insight)
+        .filter(Insight.user_id == current_user.id)
+        .order_by(Insight.created_at.desc())
+        .all()
+    )
 
     if format == "json":
         data = [InsightResponse.model_validate(i).model_dump() for i in insights]

--- a/app/garmin_sync.py
+++ b/app/garmin_sync.py
@@ -12,7 +12,15 @@ from sqlalchemy.orm import Session
 from app import crypto, streams
 from app.config import settings
 from app.database import db_session
-from app.models import Activity, AthleteProfile, DailySummary, GarminCalendarEvent, SyncStatus, User
+from app.models import (
+    DEFAULT_USER_ID,
+    Activity,
+    AthleteProfile,
+    DailySummary,
+    GarminCalendarEvent,
+    SyncStatus,
+    User,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +91,18 @@ def _get_client_for(user_id: int, email: str, password: str, token_dir: str) -> 
 def _find_bootstrap_user(db: Session) -> User | None:
     """Locate user #1 — the account seeded from env GARMIN_EMAIL/PASSWORD."""
     return db.query(User).filter(User.email == _bootstrap_identity_email()).first()
+
+
+def _scope_uid(db: Session, user: User | None) -> int:
+    """Resolve the ``user_id`` to scope sync reads/writes to.
+
+    With an explicit user, that user's id. Otherwise the bootstrap user #1, or
+    ``DEFAULT_USER_ID`` when no User row exists yet (pre-seed / tests).
+    """
+    if user is not None:
+        return user.id
+    bootstrap = _find_bootstrap_user(db)
+    return bootstrap.id if bootstrap else DEFAULT_USER_ID
 
 
 def _get_bootstrap_client() -> Garmin:
@@ -174,6 +194,9 @@ def _finalize_connect(db: Session, user: User, garmin: Garmin, email: str, passw
     token_client = getattr(garmin, "client", None) or getattr(garmin, "garth", None)
     token_client.dump(token_dir)
     _store_credentials(db, user, email, password)
+    # A successful interactive (re)connect clears any pending re-auth flag.
+    user.garmin_needs_reauth = False
+    db.commit()
     # Drop any stale cached client so the next call rebuilds from new tokens.
     with _garmin_lock:
         _garmin_clients.pop(user.id, None)
@@ -184,6 +207,7 @@ def disconnect_garmin(db: Session, user: User) -> None:
     """Clear a user's Garmin credentials, cached client, and token dir."""
     user.garmin_email = None
     user.garmin_password_encrypted = None
+    user.garmin_needs_reauth = False
     db.commit()
     with _mfa_lock:
         _mfa_sessions.pop(user.id, None)
@@ -201,7 +225,21 @@ def garmin_connection_status(user: User) -> dict:
         "connected": bool(user.garmin_email),
         "garmin_email": user.garmin_email,
         "mfa_pending": mfa_pending,
+        "needs_reauth": bool(user.garmin_needs_reauth),
     }
+
+
+def mark_garmin_needs_reauth(user_id: int, value: bool = True) -> None:
+    """Flag/unflag a user's Garmin connection as needing an interactive reconnect.
+
+    Called by background syncs when a user's tokens are gone/expired and Garmin
+    wants an MFA code a cron can't supply.
+    """
+    with db_session() as db:
+        user = db.query(User).filter(User.id == user_id).first()
+        if user is not None and bool(user.garmin_needs_reauth) != value:
+            user.garmin_needs_reauth = value
+            db.commit()
 
 
 # --- Bootstrap (env account → user #1) + token-dir migration ---------------
@@ -256,18 +294,28 @@ def seed_bootstrap_user() -> None:
     _migrate_flat_token_dir(user_id)
 
 
-def _get_sync_status(db: Session, key: str) -> str | None:
-    row = db.query(SyncStatus).filter(SyncStatus.key == key).first()
+def _get_sync_status(db: Session, key: str, user_id: int = DEFAULT_USER_ID) -> str | None:
+    row = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == key)
+        .first()
+    )
     return row.value if row else None
 
 
-def _set_sync_status(db: Session, key: str, value: str):
-    row = db.query(SyncStatus).filter(SyncStatus.key == key).first()
+def _set_sync_status(db: Session, key: str, value: str, user_id: int = DEFAULT_USER_ID):
+    row = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == key)
+        .first()
+    )
     if row:
         row.value = value
         row.updated_at = datetime.now(timezone.utc)
     else:
-        row = SyncStatus(key=key, value=value, updated_at=datetime.now(timezone.utc))
+        row = SyncStatus(
+            user_id=user_id, key=key, value=value, updated_at=datetime.now(timezone.utc)
+        )
         db.add(row)
     db.commit()
 
@@ -374,13 +422,24 @@ def _fetch_activity_details(client: Garmin, activity_id) -> dict:
     return details
 
 
-def _store_activity(db: Session, summary: dict, details: dict, skip_ai: bool = False) -> Activity | None:
+def _store_activity(
+    db: Session,
+    summary: dict,
+    details: dict,
+    skip_ai: bool = False,
+    user_id: int = DEFAULT_USER_ID,
+    client: Garmin | None = None,
+) -> Activity | None:
     """Store an activity in the database. Returns the Activity if newly created."""
     garmin_id = summary.get("activityId")
     if not garmin_id:
         return None
 
-    existing = db.query(Activity).filter(Activity.garmin_id == garmin_id).first()
+    existing = (
+        db.query(Activity)
+        .filter(Activity.user_id == user_id, Activity.garmin_id == garmin_id)
+        .first()
+    )
     if existing:
         return None
 
@@ -415,8 +474,8 @@ def _store_activity(db: Session, summary: dict, details: dict, skip_ai: bool = F
     # we don't use.
     laps = None
     try:
-        client = get_garmin_client()
-        laps = client.get_activity_details(garmin_id, maxchart=10000, maxpoly=0)
+        detail_client = client or get_garmin_client()
+        laps = detail_client.get_activity_details(garmin_id, maxchart=10000, maxpoly=0)
     except Exception as e:
         logger.debug("No detailed data for %s: %s", garmin_id, e)
 
@@ -432,6 +491,7 @@ def _store_activity(db: Session, summary: dict, details: dict, skip_ai: bool = F
 
     activity = Activity(
         **fields,
+        user_id=user_id,
         run_time_sec=run_time_sec,
         walk_time_sec=walk_time_sec,
         laps_json=json.dumps(laps) if laps else None,
@@ -452,13 +512,14 @@ def _store_activity(db: Session, summary: dict, details: dict, skip_ai: bool = F
     return activity
 
 
-def sync_activities() -> list[Activity]:
+def sync_activities(user: User | None = None) -> list[Activity]:
     """Poll for recent activities. Returns list of newly added activities."""
     logger.info("Syncing recent activities...")
-    client = get_garmin_client()
+    client = get_garmin_client(user)
     new_activities = []
 
     with db_session() as db:
+        uid = _scope_uid(db, user)
         try:
             activities = client.get_activities(0, 20)
             for summary in activities:
@@ -466,17 +527,25 @@ def sync_activities() -> list[Activity]:
                 if not garmin_id:
                     continue
 
-                existing = db.query(Activity).filter(Activity.garmin_id == garmin_id).first()
+                existing = (
+                    db.query(Activity)
+                    .filter(Activity.user_id == uid, Activity.garmin_id == garmin_id)
+                    .first()
+                )
                 if existing:
                     continue
 
                 time.sleep(0.3)
                 details = _fetch_activity_details(client, garmin_id)
-                activity = _store_activity(db, summary, details, skip_ai=False)
+                activity = _store_activity(
+                    db, summary, details, skip_ai=False, user_id=uid, client=client
+                )
                 if activity:
                     new_activities.append(activity)
 
-            _set_sync_status(db, "last_activity_sync", datetime.now(timezone.utc).isoformat())
+            _set_sync_status(
+                db, "last_activity_sync", datetime.now(timezone.utc).isoformat(), user_id=uid
+            )
             logger.info("Activity sync complete. %d new activities.", len(new_activities))
         except Exception:
             logger.exception("Activity sync failed")
@@ -520,16 +589,19 @@ def _daily_summary_fields(
     }
 
 
-def sync_daily_summary(target_date: date | None = None) -> DailySummary | None:
+def sync_daily_summary(
+    target_date: date | None = None, user: User | None = None
+) -> DailySummary | None:
     """Sync daily summary for a given date (defaults to yesterday)."""
     if target_date is None:
         target_date = date.today() - timedelta(days=1)
 
     date_str = target_date.strftime("%Y-%m-%d")
     logger.info("Syncing daily summary for %s", date_str)
-    client = get_garmin_client()
+    client = get_garmin_client(user)
 
     with db_session() as db:
+        uid = _scope_uid(db, user)
         try:
             stats = client.get_stats(date_str)
             user_summary = client.get_user_summary(date_str)
@@ -586,7 +658,11 @@ def sync_daily_summary(target_date: date | None = None) -> DailySummary | None:
                 hrv_status=hrv_status,
             )
 
-            existing = db.query(DailySummary).filter(DailySummary.date == target_date).first()
+            existing = (
+                db.query(DailySummary)
+                .filter(DailySummary.user_id == uid, DailySummary.date == target_date)
+                .first()
+            )
             if existing:
                 for key, value in fields.items():
                     setattr(existing, key, value)
@@ -594,7 +670,7 @@ def sync_daily_summary(target_date: date | None = None) -> DailySummary | None:
                 db.refresh(existing)
                 summary = existing
             else:
-                summary = DailySummary(date=target_date, **fields)
+                summary = DailySummary(user_id=uid, date=target_date, **fields)
                 db.add(summary)
                 db.commit()
                 db.refresh(summary)
@@ -605,7 +681,9 @@ def sync_daily_summary(target_date: date | None = None) -> DailySummary | None:
             # object unreadable (DetachedInstanceError on first attribute
             # access). Expunging first preserves its loaded state for the caller.
             db.expunge(summary)
-            _set_sync_status(db, "last_daily_sync", datetime.now(timezone.utc).isoformat())
+            _set_sync_status(
+                db, "last_daily_sync", datetime.now(timezone.utc).isoformat(), user_id=uid
+            )
             logger.info("Daily summary synced for %s", date_str)
             return summary
 
@@ -676,25 +754,26 @@ def _fetch_garmin_profile_fields(client: Garmin) -> dict:
     return fields
 
 
-def sync_athlete_profile() -> AthleteProfile | None:
+def sync_athlete_profile(user: User | None = None) -> AthleteProfile | None:
     """Sync name, date of birth, weight, and resting HR from Garmin into the athlete profile.
 
     These fields are Garmin-managed (read-only in the UI), so the local
     values are always overwritten to stay in sync with Garmin.
     """
     logger.info("Syncing athlete profile from Garmin...")
-    client = get_garmin_client()
+    client = get_garmin_client(user)
 
     with db_session() as db:
+        uid = _scope_uid(db, user)
         try:
             fields = _fetch_garmin_profile_fields(client)
             if not fields:
                 logger.info("No Garmin profile fields available to sync")
                 return None
 
-            profile = db.query(AthleteProfile).first()
+            profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == uid).first()
             if profile is None:
-                profile = AthleteProfile(**fields)
+                profile = AthleteProfile(user_id=uid, **fields)
                 db.add(profile)
             else:
                 for key, value in fields.items():
@@ -702,7 +781,9 @@ def sync_athlete_profile() -> AthleteProfile | None:
 
             db.commit()
             db.refresh(profile)
-            _set_sync_status(db, "last_profile_sync", datetime.now(timezone.utc).isoformat())
+            _set_sync_status(
+                db, "last_profile_sync", datetime.now(timezone.utc).isoformat(), user_id=uid
+            )
             logger.info("Athlete profile synced from Garmin: %s", ", ".join(fields))
             return profile
         except Exception:
@@ -713,8 +794,9 @@ def sync_athlete_profile() -> AthleteProfile | None:
 def backfill_activities():
     """Backfill all historical activities on first start."""
     with db_session() as db:
+        uid = _scope_uid(db, None)
         try:
-            status = _get_sync_status(db, "backfill_activities")
+            status = _get_sync_status(db, "backfill_activities", user_id=uid)
             if status == "complete":
                 logger.info("Activity backfill already complete")
                 return
@@ -741,24 +823,30 @@ def backfill_activities():
                     if not garmin_id:
                         continue
 
-                    existing = db.query(Activity).filter(Activity.garmin_id == garmin_id).first()
+                    existing = (
+                        db.query(Activity)
+                        .filter(Activity.user_id == uid, Activity.garmin_id == garmin_id)
+                        .first()
+                    )
                     if existing:
                         continue
 
                     time.sleep(0.5)
                     try:
                         details = _fetch_activity_details(client, garmin_id)
-                        _store_activity(db, summary, details, skip_ai=True)
+                        _store_activity(
+                            db, summary, details, skip_ai=True, user_id=uid, client=client
+                        )
                     except Exception:
                         logger.exception("Failed to backfill activity %s", garmin_id)
 
                 page += 1
-                _set_sync_status(db, "backfill_activities", str(page))
+                _set_sync_status(db, "backfill_activities", str(page), user_id=uid)
 
                 if len(activities) < page_size:
                     break
 
-            _set_sync_status(db, "backfill_activities", "complete")
+            _set_sync_status(db, "backfill_activities", "complete", user_id=uid)
             logger.info("Activity backfill complete")
 
         except Exception:
@@ -768,8 +856,9 @@ def backfill_activities():
 def backfill_daily_summaries():
     """Backfill last 365 days of daily summaries on first start."""
     with db_session() as db:
+        uid = _scope_uid(db, None)
         try:
-            status = _get_sync_status(db, "backfill_daily")
+            status = _get_sync_status(db, "backfill_daily", user_id=uid)
             if status == "complete":
                 logger.info("Daily summary backfill already complete")
                 return
@@ -787,7 +876,11 @@ def backfill_daily_summaries():
             for days_ago in range(start_days_ago, 366):
                 target = today - timedelta(days=days_ago)
 
-                existing = db.query(DailySummary).filter(DailySummary.date == target).first()
+                existing = (
+                    db.query(DailySummary)
+                    .filter(DailySummary.user_id == uid, DailySummary.date == target)
+                    .first()
+                )
                 if existing:
                     continue
 
@@ -802,10 +895,10 @@ def backfill_daily_summaries():
                     logger.debug("No daily summary for %s", target)
 
                 if days_ago % 30 == 0:
-                    _set_sync_status(db, "backfill_daily", str(days_ago))
+                    _set_sync_status(db, "backfill_daily", str(days_ago), user_id=uid)
                     logger.info("Daily backfill progress: %d/365 days", days_ago)
 
-            _set_sync_status(db, "backfill_daily", "complete")
+            _set_sync_status(db, "backfill_daily", "complete", user_id=uid)
             logger.info("Daily summary backfill complete")
 
         except Exception:
@@ -1045,10 +1138,10 @@ def _extract_goal_time_from_details(detail: dict) -> int | None:
     return None
 
 
-def sync_calendar() -> int:
+def sync_calendar(user: User | None = None) -> int:
     """Sync Garmin calendar events (races + workouts). Returns count of upserted events."""
     logger.info("Syncing Garmin calendar...")
-    client = get_garmin_client()
+    client = get_garmin_client(user)
     today = date.today()
 
     # Fetch current month + next 2 months
@@ -1138,13 +1231,15 @@ def sync_calendar() -> int:
         evt["raw_json"] = json.dumps(raw, default=str)
 
     with db_session() as db:
+        uid = _scope_uid(db, user)
         try:
             seen_garmin_ids = set()
             for evt in all_events:
                 seen_garmin_ids.add(evt["garmin_id"])
                 # Upsert
                 existing = db.query(GarminCalendarEvent).filter(
-                    GarminCalendarEvent.garmin_id == evt["garmin_id"]
+                    GarminCalendarEvent.user_id == uid,
+                    GarminCalendarEvent.garmin_id == evt["garmin_id"],
                 ).first()
                 if existing:
                     for key, value in evt.items():
@@ -1152,10 +1247,11 @@ def sync_calendar() -> int:
                             setattr(existing, key, value)
                     existing.synced_at = datetime.now(timezone.utc)
                 else:
-                    db.add(GarminCalendarEvent(**evt, synced_at=datetime.now(timezone.utc)))
+                    db.add(GarminCalendarEvent(user_id=uid, **evt, synced_at=datetime.now(timezone.utc)))
 
             # Remove stale future events no longer in API response
             stale_query = db.query(GarminCalendarEvent).filter(
+                GarminCalendarEvent.user_id == uid,
                 GarminCalendarEvent.date >= today,
             )
             if seen_garmin_ids:
@@ -1167,7 +1263,9 @@ def sync_calendar() -> int:
                 logger.info("Removed %d stale calendar events", stale_count)
 
             db.commit()
-            _set_sync_status(db, "last_calendar_sync", datetime.now(timezone.utc).isoformat())
+            _set_sync_status(
+                db, "last_calendar_sync", datetime.now(timezone.utc).isoformat(), user_id=uid
+            )
             logger.info("Calendar sync complete. %d events.", len(seen_garmin_ids))
         except Exception:
             logger.exception("Calendar sync failed")

--- a/app/intensity.py
+++ b/app/intensity.py
@@ -17,7 +17,7 @@ from datetime import date, datetime, timedelta
 
 from sqlalchemy.orm import Session
 
-from app.models import Activity, ZoneConfig
+from app.models import DEFAULT_USER_ID, Activity, ZoneConfig
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +117,7 @@ def aggregate_weekly_intensity(
     days: int = 90,
     zone_type: str = "hr",
     as_of: date | None = None,
+    user_id: int = DEFAULT_USER_ID,
 ) -> list[dict]:
     """Aggregate per-activity zone data into weekly buckets.
 
@@ -134,6 +135,7 @@ def aggregate_weekly_intensity(
     rows = (
         db.query(Activity.started_at, json_col)
         .filter(
+            Activity.user_id == user_id,
             Activity.started_at >= cutoff,
             Activity.started_at < ref_dt,
             json_col.isnot(None),

--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,8 @@ from fastapi.staticfiles import StaticFiles
 import pytz
 
 from app.config import settings
-from app.database import init_db
+from app.database import db_session, init_db
+from app.models import User
 
 logging.basicConfig(
     level=logging.INFO,
@@ -50,41 +51,96 @@ def _trim_after_job(_event):
     _trim_memory()
 
 
-def _scheduled_activity_sync():
-    """Scheduled job: sync activities and calendar."""
-    from app.garmin_sync import sync_activities, sync_calendar
+def _iter_garmin_users() -> list[User]:
+    """Return all users with a Garmin connection, scoped for per-user sync.
 
-    sync_activities()
+    Excludes users flagged ``garmin_needs_reauth`` — a cron can't answer their
+    MFA prompt, so they're skipped until they reconnect from Settings. Returned
+    objects are detached but carry the id + credential fields the sync path
+    needs (no further DB access required).
+    """
+    with db_session() as db:
+        users = (
+            db.query(User)
+            .filter(
+                User.garmin_email.isnot(None),
+                User.garmin_needs_reauth == False,  # noqa: E712
+            )
+            .all()
+        )
+        for u in users:
+            db.expunge(u)
+        return users
+
+
+def _authenticate_or_flag(user: User) -> bool:
+    """Verify a user's Garmin client authenticates; flag for re-auth if not.
+
+    A cron can't satisfy an interactive MFA prompt, so when a user's tokens are
+    gone/expired and login fails we mark them ``needs_reauth`` and skip — the
+    Settings UI surfaces a Reconnect action. Returns True when authenticated.
+    """
+    from app.garmin_sync import get_garmin_client, mark_garmin_needs_reauth
 
     try:
-        sync_calendar()
+        get_garmin_client(user)
+        return True
     except Exception:
-        logger.exception("Calendar sync failed")
+        logger.exception("Garmin auth failed for user %s; flagging needs_reauth", user.id)
+        mark_garmin_needs_reauth(user.id, True)
+        return False
 
 
-def _scheduled_daily_sync():
-    """Scheduled job: sync a rolling window of daily summaries and trigger AI.
+def run_activity_sync_for_user(user_id: int) -> None:
+    """Sync one user's activities + calendar (used by the API manual trigger)."""
+    from app.garmin_sync import sync_activities, sync_calendar
+
+    with db_session() as db:
+        user = db.query(User).filter(User.id == user_id).first()
+        if user is None:
+            return
+        db.expunge(user)
+
+    if not _authenticate_or_flag(user):
+        return
+    sync_activities(user)
+    try:
+        sync_calendar(user)
+    except Exception:
+        logger.exception("Calendar sync failed for user %s", user_id)
+
+
+def run_daily_sync_for_user(user_id: int) -> None:
+    """Sync one user's rolling window of daily summaries and analyze today.
 
     Garmin attributes overnight metrics (sleep, HRV, resting HR) to the wake-up
     day, so we sync *today* to capture last night's data on the correct date, and
     re-sync the prior days in the window so their full-day totals finalize. AI
-    analysis runs only on today's (newest) summary to avoid re-analyzing days that
-    were already covered on previous runs.
+    analysis runs only on today's (newest) summary.
     """
     from app.garmin_sync import sync_athlete_profile, sync_daily_summary
     from app.ai_coach import analyze_daily_summary
 
+    with db_session() as db:
+        user = db.query(User).filter(User.id == user_id).first()
+        if user is None:
+            return
+        db.expunge(user)
+
+    if not _authenticate_or_flag(user):
+        return
+
     try:
-        sync_athlete_profile()
+        sync_athlete_profile(user)
     except Exception:
-        logger.exception("Athlete profile sync failed")
+        logger.exception("Athlete profile sync failed for user %s", user_id)
 
     window = max(1, settings.daily_sync_window_days)
     today = date.today()
     today_summary = None
     for offset in range(window):
         target = today - timedelta(days=offset)
-        summary = sync_daily_summary(target)
+        summary = sync_daily_summary(target, user)
         if offset == 0:
             today_summary = summary
 
@@ -95,18 +151,44 @@ def _scheduled_daily_sync():
             logger.exception("AI analysis failed for daily summary %s", today_summary.id)
 
 
+def _scheduled_activity_sync():
+    """Scheduled job: sync activities + calendar for every connected user."""
+    for user in _iter_garmin_users():
+        try:
+            run_activity_sync_for_user(user.id)
+        except Exception:
+            logger.exception("Activity sync failed for user %s", user.id)
+
+
+def _scheduled_daily_sync():
+    """Scheduled job: per-user rolling daily-summary sync + AI analysis."""
+    for user in _iter_garmin_users():
+        try:
+            run_daily_sync_for_user(user.id)
+        except Exception:
+            logger.exception("Daily sync failed for user %s", user.id)
+
+
 def _scheduled_weekly_review():
-    """Scheduled job: weekly training review."""
+    """Scheduled job: weekly training review for every connected user."""
     from app.ai_coach import weekly_review
 
-    weekly_review()
+    for user in _iter_garmin_users():
+        try:
+            weekly_review(user_id=user.id)
+        except Exception:
+            logger.exception("Weekly review failed for user %s", user.id)
 
 
 def _scheduled_plan_generation():
-    """Scheduled job: regenerate the training plan each week."""
+    """Scheduled job: regenerate the training plan for every connected user."""
     from app.ai_coach import generate_training_plan
 
-    generate_training_plan()
+    for user in _iter_garmin_users():
+        try:
+            generate_training_plan(user_id=user.id)
+        except Exception:
+            logger.exception("Plan generation failed for user %s", user.id)
 
 
 def _run_backfill():

--- a/app/models.py
+++ b/app/models.py
@@ -20,6 +20,24 @@ def _utcnow():
     return datetime.now(timezone.utc)
 
 
+# The primary/bootstrap user. The app began life single-tenant; Phase 3 keys
+# every data row on a user, defaulting unscoped writes to this id and
+# backfilling all pre-existing rows to it. Production read/write paths (API,
+# scheduler) always pass an explicit user, so this default only ever applies to
+# the single-tenant bootstrap account and the test suite.
+DEFAULT_USER_ID = 1
+
+
+def _user_id_column():
+    """A per-user scoping column shared by every data table.
+
+    Following the codebase convention (e.g. ``TrainingPlanDay.plan_id``), this is
+    a plain indexed integer rather than a DB-level ``ForeignKey`` — SQLite can't
+    add FKs via ``ALTER TABLE`` and the app enforces the relationship in code.
+    """
+    return Column(Integer, nullable=False, default=DEFAULT_USER_ID, index=True)
+
+
 class User(Base):
     __tablename__ = "users"
 
@@ -34,12 +52,21 @@ class User(Base):
     garmin_email = Column(String(255), nullable=True)
     garmin_password_encrypted = Column(Text, nullable=True)
 
+    # Set when a background sync can't authenticate (tokens gone/expired and the
+    # account needs an interactive MFA code a cron can't supply). The Settings UI
+    # surfaces a "Reconnect" action; reconnecting clears the flag. (Phase 3)
+    garmin_needs_reauth = Column(Boolean, default=False, nullable=False)
+
 
 class Activity(Base):
     __tablename__ = "activities"
+    __table_args__ = (
+        UniqueConstraint("user_id", "garmin_id", name="uq_activities_user_garmin"),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    garmin_id = Column(BigInteger, unique=True, nullable=False, index=True)
+    user_id = _user_id_column()
+    garmin_id = Column(BigInteger, nullable=False, index=True)
     activity_type = Column(Text)
     name = Column(Text)
     started_at = Column(DateTime, index=True)
@@ -111,9 +138,13 @@ class Activity(Base):
 
 class DailySummary(Base):
     __tablename__ = "daily_summaries"
+    __table_args__ = (
+        UniqueConstraint("user_id", "date", name="uq_daily_summaries_user_date"),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    date = Column(Date, unique=True, nullable=False, index=True)
+    user_id = _user_id_column()
+    date = Column(Date, nullable=False, index=True)
     steps = Column(Integer)
     total_calories = Column(Integer)
     active_calories = Column(Integer)
@@ -139,6 +170,7 @@ class Insight(Base):
     __tablename__ = "insights"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
     created_at = Column(DateTime, default=_utcnow, index=True)
     trigger_type = Column(Text)  # activity, daily_summary, weekly_review
     trigger_id = Column(Integer, nullable=True)
@@ -151,6 +183,7 @@ class Race(Base):
     __tablename__ = "races"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
     name = Column(Text, nullable=False)
     date = Column(Date, nullable=False, index=True)
     distance_m = Column(Float)
@@ -162,9 +195,13 @@ class Race(Base):
 
 class GarminCalendarEvent(Base):
     __tablename__ = "garmin_calendar_events"
+    __table_args__ = (
+        UniqueConstraint("user_id", "garmin_id", name="uq_garmin_calendar_user_garmin"),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    garmin_id = Column(String(100), unique=True, nullable=False, index=True)
+    user_id = _user_id_column()
+    garmin_id = Column(String(100), nullable=False, index=True)
     event_type = Column(String(50), nullable=False, index=True)  # "race", "workout"
     date = Column(Date, nullable=False, index=True)
     title = Column(Text)
@@ -194,9 +231,13 @@ class MetricZone(Base):
 
 class SyncStatus(Base):
     __tablename__ = "sync_status"
+    __table_args__ = (
+        UniqueConstraint("user_id", "key", name="uq_sync_status_user_key"),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    key = Column(String(100), unique=True, nullable=False)
+    user_id = _user_id_column()
+    key = Column(String(100), nullable=False)
     value = Column(Text)
     updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
 
@@ -204,13 +245,16 @@ class SyncStatus(Base):
 class AthleteProfile(Base):
     """Single-athlete profile feeding personalization and the AI context.
 
-    The app is single-user, so this table holds at most one row (accessed
-    via ``.first()``).
+    One row per user (Phase 3), looked up by ``user_id``.
     """
 
     __tablename__ = "athlete_profiles"
+    __table_args__ = (
+        UniqueConstraint("user_id", name="uq_athlete_profiles_user"),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
     name = Column(Text, nullable=True)
     date_of_birth = Column(Date, nullable=True)
     weight_kg = Column(Float, nullable=True)
@@ -240,6 +284,7 @@ class ZoneConfig(Base):
     __tablename__ = "zone_configs"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
     zone_type = Column(String(20), nullable=False, index=True)  # "hr", "pace", "power"
     zone_number = Column(Integer, nullable=False)               # 1–5
     zone_name = Column(String(50), nullable=False)
@@ -247,7 +292,9 @@ class ZoneConfig(Base):
     min_pct = Column(Float, nullable=True)   # lower % of threshold (null = no lower bound)
     max_pct = Column(Float, nullable=True)   # upper % of threshold (null = no upper bound)
 
-    __table_args__ = (UniqueConstraint("zone_type", "zone_number", name="uq_zone_type_number"),)
+    __table_args__ = (
+        UniqueConstraint("user_id", "zone_type", "zone_number", name="uq_zone_type_number"),
+    )
 
 
 class TrainingPlan(Base):
@@ -260,6 +307,7 @@ class TrainingPlan(Base):
     __tablename__ = "training_plans"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
     generated_at = Column(DateTime, default=_utcnow, index=True)
     week_start = Column(Date, nullable=False)   # Monday of week 1
     plan_weeks = Column(Integer, default=4)
@@ -274,6 +322,7 @@ class TrainingPlanDay(Base):
     __tablename__ = "training_plan_days"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
     plan_id = Column(Integer, nullable=False, index=True)   # → TrainingPlan.id
     day_date = Column(Date, nullable=False, index=True)
     day_of_week = Column(Text, nullable=False)               # "Monday" … "Sunday"

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -82,6 +82,7 @@ class GarminConnectionStatus(BaseModel):
     connected: bool
     garmin_email: str | None = None
     mfa_pending: bool = False
+    needs_reauth: bool = False
 
 
 class IntervalAdherence(BaseModel):

--- a/app/streams.py
+++ b/app/streams.py
@@ -292,19 +292,23 @@ def compute_curves_from_details(
     return result
 
 
-def backfill_missing_curves(db: Session, limit: int = 500) -> int:
+def backfill_missing_curves(db: Session, limit: int = 500, user_id: int | None = None) -> int:
     """Compute ``mean_max_json`` for synced activities that lack it.
 
     Self-heals databases populated before curve computation existed. Bounded by
     ``limit`` per call so it spreads cost across invocations; returns the number
-    of activities updated.
+    of activities updated. When ``user_id`` is given, only that user's activities
+    are processed.
     """
     from app.models import Activity
 
+    query = db.query(Activity).filter(
+        Activity.mean_max_json.is_(None), Activity.laps_json.isnot(None)
+    )
+    if user_id is not None:
+        query = query.filter(Activity.user_id == user_id)
     rows = (
-        db.query(Activity)
-        .filter(Activity.mean_max_json.is_(None), Activity.laps_json.isnot(None))
-        .order_by(Activity.started_at.desc())
+        query.order_by(Activity.started_at.desc())
         .limit(limit)
         .all()
     )

--- a/app/threshold.py
+++ b/app/threshold.py
@@ -42,7 +42,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app import streams
-from app.models import Activity, AthleteProfile, SyncStatus
+from app.models import DEFAULT_USER_ID, Activity, AthleteProfile, SyncStatus
 
 logger = logging.getLogger(__name__)
 
@@ -466,17 +466,20 @@ def _estimate_threshold_hr(
 # Result cache (SyncStatus-backed memoization)
 # ---------------------------------------------------------------------------
 
-def _threshold_fingerprint(db: Session, lookback_days: int, cutoff: datetime) -> str:
+def _threshold_fingerprint(db: Session, lookback_days: int, cutoff: datetime, user_id: int) -> str:
     """Cache key: run count + curves-available count + max synced_at in window."""
     run_count = db.query(func.count(Activity.id)).filter(
-        Activity.started_at >= cutoff
+        Activity.user_id == user_id,
+        Activity.started_at >= cutoff,
     ).scalar() or 0
     curve_count = db.query(func.count(Activity.id)).filter(
+        Activity.user_id == user_id,
         Activity.started_at >= cutoff,
         Activity.mean_max_json.isnot(None),
     ).scalar() or 0
     max_sync = db.query(func.max(Activity.synced_at)).filter(
-        Activity.started_at >= cutoff
+        Activity.user_id == user_id,
+        Activity.started_at >= cutoff,
     ).scalar()
     return "|".join([
         str(lookback_days),
@@ -500,17 +503,21 @@ def _deserialize_estimate(d: dict) -> ThresholdEstimate:
 
 
 def _load_cached_threshold(
-    db: Session, lookback_days: int, cutoff: datetime
+    db: Session, lookback_days: int, cutoff: datetime, user_id: int
 ) -> ThresholdEstimate | None:
     """Return the cached estimate when the fingerprint matches, else None."""
-    row = db.query(SyncStatus).filter(SyncStatus.key == _THRESHOLD_CACHE_KEY).first()
+    row = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == _THRESHOLD_CACHE_KEY)
+        .first()
+    )
     if not row or not row.value:
         return None
     try:
         data = json.loads(row.value)
     except (json.JSONDecodeError, TypeError):
         return None
-    if data.get("fp") != _threshold_fingerprint(db, lookback_days, cutoff):
+    if data.get("fp") != _threshold_fingerprint(db, lookback_days, cutoff, user_id):
         return None
     try:
         return _deserialize_estimate(data["estimate"])
@@ -519,19 +526,23 @@ def _load_cached_threshold(
 
 
 def _save_cached_threshold(
-    db: Session, estimate: ThresholdEstimate, lookback_days: int, cutoff: datetime
+    db: Session, estimate: ThresholdEstimate, lookback_days: int, cutoff: datetime, user_id: int
 ) -> None:
     """Persist the estimate alongside the current fingerprint."""
     payload = json.dumps({
-        "fp": _threshold_fingerprint(db, lookback_days, cutoff),
+        "fp": _threshold_fingerprint(db, lookback_days, cutoff, user_id),
         "estimate": dataclasses.asdict(estimate),
     })
-    row = db.query(SyncStatus).filter(SyncStatus.key == _THRESHOLD_CACHE_KEY).first()
+    row = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == _THRESHOLD_CACHE_KEY)
+        .first()
+    )
     if row:
         row.value = payload
         row.updated_at = datetime.now(timezone.utc)
     else:
-        db.add(SyncStatus(key=_THRESHOLD_CACHE_KEY, value=payload,
+        db.add(SyncStatus(user_id=user_id, key=_THRESHOLD_CACHE_KEY, value=payload,
                           updated_at=datetime.now(timezone.utc)))
     db.commit()
 
@@ -548,7 +559,7 @@ def _is_run(activity_type: str | None) -> bool:
 
 
 def estimate_thresholds(
-    db: Session, lookback_days: int = DEFAULT_LOOKBACK_DAYS
+    db: Session, lookback_days: int = DEFAULT_LOOKBACK_DAYS, user_id: int = DEFAULT_USER_ID
 ) -> ThresholdEstimate:
     """Compute threshold estimates from the last ``lookback_days`` of activities.
 
@@ -559,19 +570,23 @@ def estimate_thresholds(
     now = datetime.utcnow()
     cutoff = now - timedelta(days=lookback_days)
 
-    cached = _load_cached_threshold(db, lookback_days, cutoff)
+    cached = _load_cached_threshold(db, lookback_days, cutoff, user_id)
     if cached is not None:
         return cached
 
     # Self-heal: compute curves for any older activities that predate this feature.
     try:
-        streams.backfill_missing_curves(db)
+        streams.backfill_missing_curves(db, user_id=user_id)
     except Exception:
         pass
 
     activities = (
         db.query(Activity)
-        .filter(Activity.started_at.isnot(None), Activity.started_at >= cutoff)
+        .filter(
+            Activity.user_id == user_id,
+            Activity.started_at.isnot(None),
+            Activity.started_at >= cutoff,
+        )
         .all()
     )
     runs = [a for a in activities if _is_run(a.activity_type)]
@@ -615,7 +630,7 @@ def estimate_thresholds(
     )
 
     try:
-        _save_cached_threshold(db, estimate, lookback_days, cutoff)
+        _save_cached_threshold(db, estimate, lookback_days, cutoff, user_id)
     except Exception:
         logger.debug("Threshold estimate cache write failed", exc_info=True)
 
@@ -682,7 +697,7 @@ def _predict_race_times(cv: float, d_prime: float) -> list[RacePrediction]:
 
 
 def get_performance_curve_data(
-    db: Session, lookback_days: int = DEFAULT_LOOKBACK_DAYS
+    db: Session, lookback_days: int = DEFAULT_LOOKBACK_DAYS, user_id: int = DEFAULT_USER_ID
 ) -> PerformanceCurveData:
     """Aggregate mean-max frontiers + CP/CV model fit for the performance curve UI.
 
@@ -695,7 +710,11 @@ def get_performance_curve_data(
 
     activities = (
         db.query(Activity)
-        .filter(Activity.started_at.isnot(None), Activity.started_at >= cutoff)
+        .filter(
+            Activity.user_id == user_id,
+            Activity.started_at.isnot(None),
+            Activity.started_at >= cutoff,
+        )
         .all()
     )
     runs = [a for a in activities if _is_run(a.activity_type)]

--- a/app/training_load.py
+++ b/app/training_load.py
@@ -19,7 +19,7 @@ from datetime import date, datetime, timedelta, timezone
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from app.models import Activity, AthleteProfile, DailySummary, SyncStatus
+from app.models import DEFAULT_USER_ID, Activity, AthleteProfile, DailySummary, SyncStatus
 from app.schemas import TrainingLoadPoint, TrainingReadiness
 
 logger = logging.getLogger(__name__)
@@ -79,11 +79,11 @@ def estimate_tss(activity: Activity, profile: AthleteProfile | None) -> tuple[fl
     return _intensity_to_tss(duration_hr, _DEFAULT_IF), "duration"
 
 
-def _series_fingerprint(db: Session) -> str:
+def _series_fingerprint(db: Session, user_id: int) -> str:
     """Cheap cache key: activity count + newest sync timestamp + profile update time."""
-    count = db.query(func.count(Activity.id)).scalar() or 0
-    max_sync = db.query(func.max(Activity.synced_at)).scalar()
-    profile = db.query(AthleteProfile).first()
+    count = db.query(func.count(Activity.id)).filter(Activity.user_id == user_id).scalar() or 0
+    max_sync = db.query(func.max(Activity.synced_at)).filter(Activity.user_id == user_id).scalar()
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == user_id).first()
     return "|".join([
         str(count),
         max_sync.isoformat() if max_sync else "",
@@ -91,16 +91,20 @@ def _series_fingerprint(db: Session) -> str:
     ])
 
 
-def _load_cached_series(db: Session) -> list[TrainingLoadPoint] | None:
+def _load_cached_series(db: Session, user_id: int) -> list[TrainingLoadPoint] | None:
     """Return the cached full series when the fingerprint matches, else None."""
-    row = db.query(SyncStatus).filter(SyncStatus.key == _SERIES_CACHE_KEY).first()
+    row = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == _SERIES_CACHE_KEY)
+        .first()
+    )
     if not row or not row.value:
         return None
     try:
         data = json.loads(row.value)
     except (json.JSONDecodeError, TypeError):
         return None
-    if data.get("fp") != _series_fingerprint(db):
+    if data.get("fp") != _series_fingerprint(db, user_id):
         return None
     try:
         return [TrainingLoadPoint(**p) for p in data["series"]]
@@ -108,28 +112,38 @@ def _load_cached_series(db: Session) -> list[TrainingLoadPoint] | None:
         return None
 
 
-def _save_cached_series(db: Session, series: list[TrainingLoadPoint]) -> None:
+def _save_cached_series(db: Session, series: list[TrainingLoadPoint], user_id: int) -> None:
     """Persist the full series alongside the current fingerprint."""
     payload = json.dumps({
-        "fp": _series_fingerprint(db),
+        "fp": _series_fingerprint(db, user_id),
         "series": [p.model_dump(mode="json") for p in series],
     })
-    row = db.query(SyncStatus).filter(SyncStatus.key == _SERIES_CACHE_KEY).first()
+    row = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == _SERIES_CACHE_KEY)
+        .first()
+    )
     if row:
         row.value = payload
         row.updated_at = datetime.now(timezone.utc)
     else:
-        db.add(SyncStatus(key=_SERIES_CACHE_KEY, value=payload,
+        db.add(SyncStatus(user_id=user_id, key=_SERIES_CACHE_KEY, value=payload,
                           updated_at=datetime.now(timezone.utc)))
     db.commit()
 
 
-def _daily_tss(db: Session, end_date: date, profile: AthleteProfile | None) -> dict[date, float]:
+def _daily_tss(
+    db: Session, end_date: date, profile: AthleteProfile | None, user_id: int
+) -> dict[date, float]:
     """Sum estimated TSS per calendar day up to and including ``end_date``."""
     end_dt = datetime.combine(end_date + timedelta(days=1), datetime.min.time())
     activities = (
         db.query(Activity)
-        .filter(Activity.started_at.isnot(None), Activity.started_at < end_dt)
+        .filter(
+            Activity.user_id == user_id,
+            Activity.started_at.isnot(None),
+            Activity.started_at < end_dt,
+        )
         .all()
     )
     totals: dict[date, float] = defaultdict(float)
@@ -154,7 +168,9 @@ def _injury_risk(acwr: float | None, ramp_7d: float | None) -> str:
     return "low"
 
 
-def _compute_full_series(db: Session, end_date: date) -> list[TrainingLoadPoint]:
+def _compute_full_series(
+    db: Session, end_date: date, user_id: int = DEFAULT_USER_ID
+) -> list[TrainingLoadPoint]:
     """Build the daily CTL/ATL/TSB/ACWR series from the first activity to ``end_date``.
 
     Results are memoized in ``SyncStatus`` when ``end_date`` is today; the cache
@@ -162,19 +178,21 @@ def _compute_full_series(db: Session, end_date: date) -> list[TrainingLoadPoint]
     """
     today = date.today()
     if end_date == today:
-        cached = _load_cached_series(db)
+        cached = _load_cached_series(db, user_id)
         if cached is not None:
             return cached
 
-    first_started = db.query(func.min(Activity.started_at)).scalar()
+    first_started = (
+        db.query(func.min(Activity.started_at)).filter(Activity.user_id == user_id).scalar()
+    )
     if first_started is None:
         return []
     start_date = first_started.date() if isinstance(first_started, datetime) else first_started
     if start_date > end_date:
         return []
 
-    profile = db.query(AthleteProfile).first()
-    daily = _daily_tss(db, end_date, profile)
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == user_id).first()
+    daily = _daily_tss(db, end_date, profile, user_id)
 
     series: list[TrainingLoadPoint] = []
     ctl = 0.0
@@ -214,25 +232,29 @@ def _compute_full_series(db: Session, end_date: date) -> list[TrainingLoadPoint]
 
     if end_date == today and series:
         try:
-            _save_cached_series(db, series)
+            _save_cached_series(db, series, user_id)
         except Exception:
             logger.debug("Training load series cache write failed", exc_info=True)
 
     return series
 
 
-def compute_load_series(db: Session, end_date: date | None = None, days: int = 90) -> list[TrainingLoadPoint]:
+def compute_load_series(
+    db: Session, end_date: date | None = None, days: int = 90, user_id: int = DEFAULT_USER_ID
+) -> list[TrainingLoadPoint]:
     """Return the last ``days`` of the CTL/ATL/TSB series ending at ``end_date``."""
     end_date = end_date or date.today()
-    full = _compute_full_series(db, end_date)
+    full = _compute_full_series(db, end_date, user_id)
     if days and days > 0:
         return full[-days:]
     return full
 
 
-def current_load(db: Session, as_of: date | None = None) -> TrainingLoadPoint | None:
+def current_load(
+    db: Session, as_of: date | None = None, user_id: int = DEFAULT_USER_ID
+) -> TrainingLoadPoint | None:
     """Return the most recent CTL/ATL/TSB snapshot as of ``as_of``."""
-    full = _compute_full_series(db, as_of or date.today())
+    full = _compute_full_series(db, as_of or date.today(), user_id)
     return full[-1] if full else None
 
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -187,9 +187,21 @@ the plan surface never prescribes supporting work.
 - **P3-3 · Adopt Alembic** — replace the hand-rolled column-add helper in
   `app/database.py` for safe schema evolution. **M.** Files: `app/database.py`, new
   `alembic/`.
-- **P3-4 · Deployment hardening (optional auth)** — the app is single-user with no
-  auth; add a simple access guard before any non-private exposure. **S–M.** Files:
-  `app/main.py`, `app/api.py`.
+- **P3-4 · Auth & multi-user** *(shipped — see `docs/multi_user_plan.md`)* — turns the
+  single-tenant app into a real multi-user one in three phases. **Identity:** a
+  Cloudflare Access JWT is verified against the team JWKS (`app/auth.py`); the `email`
+  claim keys an auto-provisioned `User`. A dev/CI bypass (`auth_enabled=false`) resolves
+  to a single `DEV_USER_EMAIL` user so local runs and tests need no Cloudflare.
+  **Per-user Garmin:** each user supplies their own credentials in Settings (password
+  Fernet-encrypted via `ENCRYPTION_KEY`, tokens under `{garmin_token_dir}/{user_id}/`,
+  MFA-aware connect flow); the env account becomes bootstrap user #1.
+  **Data isolation:** every data table carries a `user_id` (composite uniques like
+  `(user_id, date)`); all queries, compute paths, and the four cron jobs are scoped to
+  one user, with the scheduler iterating Garmin-connected users in isolation and flagging
+  `needs_reauth` when a cron can't answer an MFA prompt. **M–L.** Files: `app/auth.py`,
+  `app/crypto.py`, `app/models.py`, `app/garmin_sync.py`, `app/ai_coach.py`,
+  `app/training_load.py`, `app/threshold.py`, `app/intensity.py`, `app/api.py`,
+  `app/main.py`, `alembic/`.
 
 ---
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -47,6 +47,7 @@ export interface GarminConnectionStatus {
   connected: boolean
   garmin_email: string | null
   mfa_pending: boolean
+  needs_reauth: boolean
 }
 
 export interface IntervalAdherence {

--- a/frontend/src/components/settings/SettingsView.css
+++ b/frontend/src/components/settings/SettingsView.css
@@ -182,6 +182,24 @@
   color: var(--text);
 }
 
+.garmin-reauth {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(243, 156, 18, 0.12);
+  border: 1px solid rgba(243, 156, 18, 0.35);
+}
+
+.garmin-reauth-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.82rem;
+  color: var(--text);
+}
+
 .garmin-disconnect {
   color: #e74c3c;
 }

--- a/frontend/src/components/settings/SettingsView.tsx
+++ b/frontend/src/components/settings/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Download, RefreshCw, Watch } from 'lucide-react'
+import { AlertTriangle, Download, RefreshCw, Watch } from 'lucide-react'
 import {
   useSettings,
   useTriggerSync,
@@ -120,6 +120,7 @@ function GarminConnectionSection() {
   const [password, setPassword] = useState('')
   const [mfaCode, setMfaCode] = useState('')
   const [needsMfa, setNeedsMfa] = useState(false)
+  const [reconnecting, setReconnecting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const handleConnect = async (e: React.FormEvent) => {
@@ -132,6 +133,7 @@ function GarminConnectionSection() {
       } else {
         setEmail('')
         setPassword('')
+        setReconnecting(false)
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Connection failed')
@@ -147,6 +149,7 @@ function GarminConnectionSection() {
       setMfaCode('')
       setEmail('')
       setPassword('')
+      setReconnecting(false)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'MFA verification failed')
     }
@@ -166,11 +169,22 @@ function GarminConnectionSection() {
     <section className="settings-section">
       <h2 className="section-title">Garmin Connection</h2>
       <div className="card garmin-connect">
-        {status?.connected ? (
+        {status?.connected && !reconnecting ? (
           <div className="garmin-connected">
             <span className="garmin-status-line">
               <Watch size={16} /> Connected as {status.garmin_email}
             </span>
+            {status.needs_reauth && (
+              <div className="garmin-reauth">
+                <span className="garmin-reauth-line">
+                  <AlertTriangle size={16} /> Your Garmin session expired. Background
+                  syncs are paused until you reconnect with a one-time code.
+                </span>
+                <button className="sync-btn" onClick={() => { setError(null); setReconnecting(true) }}>
+                  Reconnect
+                </button>
+              </div>
+            )}
             <button
               className="sync-btn garmin-disconnect"
               onClick={handleDisconnect}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,45 +1,61 @@
-# Phase 2 — Per-user Garmin credentials
+# Phase 3 — Data Isolation (multi-user)
 
-Implement Phase 2 of docs/multi_user_plan.md. Note: DB migrations now use Alembic
-(not the old hand-rolled `_migrate_db`), so schema changes ship as an Alembic revision.
+Goal: every row, query, computation, and sync job is scoped to one user.
+Migration ships as a new Alembic revision (P3-3 retired the hand-rolled helper).
+
+Convention: `DEFAULT_USER_ID = 1` is the primary/bootstrap user. Data columns
+default to it; the migration backfills existing rows to it; compute/sync
+functions default their `user_id` scope to it. API and scheduler always pass an
+explicit user, so the default is only the single-tenant/test fallback.
 
 ## Tasks
-- [x] `app/models.py`: add `garmin_email`, `garmin_password_encrypted` to `User`.
-- [x] Alembic revision `b2c3d4e5f6a7`: add the two columns to `users` (batch ALTER).
-- [x] `app/crypto.py`: Fernet encrypt/decrypt using `settings.encryption_key`.
-- [x] `app/garmin_sync.py`: per-user client cache (`dict[user_id -> Garmin]`),
-      `get_garmin_client(user=None)` (bootstrap fallback for global jobs),
-      MFA-aware connect/resume/disconnect/status helpers, bootstrap seeding +
-      flat-token-dir migration.
-- [x] `app/api.py` + `app/schemas.py`: `POST /garmin-credentials`,
-      `POST /garmin-credentials/mfa`, `GET /garmin-credentials/status`,
-      `DELETE /garmin-credentials`.
-- [x] `app/main.py`: seed user #1 from env + migrate token dir on startup.
-- [x] requirements.txt: pin `cryptography`. docker-compose.yml: pass auth/encryption env.
-- [x] Frontend: types, hooks, apiDelete, Connect-Garmin section in Settings.
-- [x] Tests: crypto, connect flow, bootstrap/migration; updated the two
-      `get_garmin_client` tests for the new per-user cache.
-- [x] Regenerated `perf/perf.db` (new users columns) — perf suite 34 passed.
-- [x] Full backend (coverage 84.8% ≥ 80%) + frontend (build + 50 vitest) green.
+- [x] models.py: `user_id` on Activity, DailySummary, Insight, Race,
+      GarminCalendarEvent, AthleteProfile, ZoneConfig, TrainingPlan,
+      TrainingPlanDay, SyncStatus. Composite uniques. `User.garmin_needs_reauth`.
+- [x] alembic revision `c3d4e5f6a7b8`: add `user_id` (server_default="1" backfill),
+      rework single-tenant uniques into per-user (batch mode for SQLite).
+- [x] garmin_sync.py: per-user sync (`user` arg), write `user_id`, scope queries,
+      per-user SyncStatus helpers, `mark_garmin_needs_reauth` + status field.
+- [x] compute paths: `user_id` scope in training_load, threshold, intensity, streams
+      (incl. per-user SyncStatus caches).
+- [x] ai_coach.py: thread `user_id` through context build, analyze_*, plan, review;
+      derive user from the trigger row where possible.
+- [x] api.py: inject `current_user`, filter every query, pass user scope to compute;
+      manual `/sync` scoped to the caller.
+- [x] main.py scheduler: iterate Garmin-connected users, isolate failures, flag
+      `needs_reauth` when a cron can't authenticate.
+- [x] frontend: `needs_reauth` type + Reconnect banner in Settings.
+- [x] docs/IMPROVEMENT_PLAN.md: rewrote P3-4 bullet.
+- [x] perf/perf.db: regenerated at new head (user_id=1).
+- [x] tests: suite green (440) + new test_data_isolation.py; updated garmin_sync/main
+      tests for the new signatures/scheduler. Coverage 84.8% ≥ 80%. Frontend build +
+      50 vitest green. Perf 34 passed.
 
 ## Review
-**Migration approach (Alembic, not the old `_migrate_db`).** The plan predated
-Alembic adoption; schema changes now ship as Alembic revision `b2c3d4e5f6a7`
-(batch `ALTER TABLE users` for SQLite). `perf/perf.db` was regenerated via
-`python -m perf.seed_perf_db` so its `users` table carries the new columns and is
-stamped at the new head — required because every endpoint upserts a `User`.
 
-**garminconnect 0.3.2 (not 0.2.25/garth).** The codebase upgraded to garminconnect
-0.3.2, which dropped garth and keeps MFA state *on the client instance* rather than
-returning a `client_state` dict. So `connect_garmin_start` stashes the whole
-`Garmin` object in an in-memory dict (5-min TTL) and `connect_garmin_mfa` calls
-`resume_login(None, code)` on it. Tokens are dumped via `client.dump()`.
+**Convention `DEFAULT_USER_ID = 1`.** The app was single-tenant, so every data
+column defaults to user 1, the migration backfills existing rows to user 1, and
+compute/sync helpers default their `user_id` scope to 1. Production read/write
+paths (API → `current_user.id`, scheduler → iterated user) always pass an explicit
+id, so the default only ever covers the bootstrap account and the test suite. This
+kept ~100 existing test data-instantiations and compute call-sites green untouched.
 
-**Non-breaking for the existing single-user homelab.** `get_garmin_client()` with
-no args resolves the bootstrap user #1 (seeded from env on startup) and the global
-sync jobs keep working. Users without a stored encrypted password fall back to the
-env `GARMIN_PASSWORD`, so a deployment without `ENCRYPTION_KEY` still runs; the key
-is only required to *connect* a new account in-app.
+**Migration (Alembic `c3d4e5f6a7b8`).** Adds `user_id` to ten tables with
+`server_default="1"` (the backfill), plus `users.garmin_needs_reauth`. The initial
+schema had declared single-column uniqueness as *both* a unique index and an
+unnamed UNIQUE constraint, so for `activities`/`daily_summaries`/
+`garmin_calendar_events` the index is demoted to a plain lookup index and the
+constraint is replaced (batch mode + naming convention) with a composite
+`(user_id, …)`. `zone_configs` and `sync_status` get composite uniques the same
+way. Verified end-to-end: backfill → per-user duplicates allowed, same-user
+duplicates rejected.
 
-Data isolation (per-user `user_id` on every row, per-user sync jobs) is Phase 3.
-</content>
+**Scheduler.** The four cron jobs now iterate `_iter_garmin_users()` (Garmin
+connected, not flagged `needs_reauth`) and run each user in isolation — one
+failure can't abort the rest. `_authenticate_or_flag` validates the user's Garmin
+client up front; a cron can't answer an MFA prompt, so on auth failure it sets
+`needs_reauth` and skips, and Settings surfaces a Reconnect action that clears the
+flag. The manual `/sync` endpoint is scoped to the calling user.
+
+**Models, not FKs.** Following the existing convention (`TrainingPlanDay.plan_id`
+is a plain indexed int, not a `ForeignKey`), `user_id` is a plain indexed integer.

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -258,7 +258,7 @@ def test_call_gemini_uses_genai(monkeypatch):
 def stub_ai(monkeypatch):
     monkeypatch.setattr(
         ai_coach, "_call_ai",
-        lambda db, ctx, trigger: ("**Summary:** mocked\nDetailed analysis", "mocked", "workout_analysis"),
+        lambda db, ctx, trigger, user_id=1: ("**Summary:** mocked\nDetailed analysis", "mocked", "workout_analysis"),
     )
 
 
@@ -305,7 +305,7 @@ def test_analyze_activity_force_missing_activity_noop(db, patch_db_session, stub
 def test_analyze_activity_with_feedback_appends_feedback(db, patch_db_session, monkeypatch):
     captured = {}
 
-    def fake_call(db_, ctx, trigger):
+    def fake_call(db_, ctx, trigger, user_id=1):
         captured["ctx"] = ctx
         return ("**Summary:** fb\nbody", "fb", "workout_analysis")
 
@@ -417,7 +417,7 @@ def test_weekly_review_generates_insight(db, patch_db_session, monkeypatch):
     patch_db_session(ai_coach)
     monkeypatch.setattr(
         ai_coach, "_call_ai",
-        lambda d, c, t: ("**Summary:** week done\nbody", "week done", "training_plan"),
+        lambda d, c, t, user_id=1: ("**Summary:** week done\nbody", "week done", "training_plan"),
     )
     # An activity within the last 7 days of today() so weekly_review picks it up.
     from datetime import timedelta

--- a/tests/test_data_isolation.py
+++ b/tests/test_data_isolation.py
@@ -1,0 +1,164 @@
+"""Phase 3: every API read is scoped to the authenticated user.
+
+Seeds two users with their own activities / summaries / insights / profile /
+plan and asserts each caller sees only their own rows.
+"""
+from datetime import date, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app import models  # noqa: F401
+from app.api import api_router
+from app.auth import get_current_user
+from app.database import Base, get_db
+from app.models import (
+    Activity,
+    AthleteProfile,
+    DailySummary,
+    GarminCalendarEvent,
+    Insight,
+    TrainingPlan,
+    TrainingPlanDay,
+    User,
+)
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    yield sessionmaker(bind=engine)
+    engine.dispose()
+
+
+def _seed(session_factory):
+    """Create two users, each with one activity / summary / insight / profile."""
+    db = session_factory()
+    u1 = User(id=1, email="u1@example.com")
+    u2 = User(id=2, email="u2@example.com")
+    db.add_all([u1, u2])
+    db.flush()
+
+    base = datetime(2026, 6, 1, 7, 0)
+    for uid in (1, 2):
+        db.add(Activity(
+            user_id=uid, garmin_id=1000 + uid, activity_type="running",
+            name=f"Run U{uid}", started_at=base, duration_sec=3600, distance_m=10000,
+        ))
+        db.add(DailySummary(user_id=uid, date=date(2026, 6, 1), steps=1000 * uid))
+        db.add(Insight(
+            user_id=uid, created_at=base, trigger_type="weekly_review",
+            content="c", summary=f"insight U{uid}", category="training_plan",
+        ))
+        db.add(AthleteProfile(user_id=uid, name=f"Athlete U{uid}", weekly_availability=str(uid)))
+        plan = TrainingPlan(user_id=uid, generated_at=base, week_start=date(2026, 6, 1), plan_weeks=1)
+        db.add(plan)
+        db.flush()
+        db.add(TrainingPlanDay(
+            user_id=uid, plan_id=plan.id, day_date=date(2026, 6, 1),
+            day_of_week="Monday", week_number=1, workout_type="easy",
+        ))
+        db.add(GarminCalendarEvent(
+            user_id=uid, garmin_id=f"race_{uid}", event_type="race",
+            date=date(2026, 9, 1), title=f"Race U{uid}", distance_label="10K",
+        ))
+    db.commit()
+    db.close()
+
+
+def _client_for(session_factory, user_id: int) -> TestClient:
+    app = FastAPI()
+    app.include_router(api_router)
+
+    def override_get_db():
+        s = session_factory()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    def override_user():
+        s = session_factory()
+        try:
+            return s.query(User).filter(User.id == user_id).first()
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_user
+    return TestClient(app)
+
+
+def test_activities_scoped_to_user(session_factory):
+    _seed(session_factory)
+    c1, c2 = _client_for(session_factory, 1), _client_for(session_factory, 2)
+
+    a1 = c1.get("/api/v1/activities").json()
+    a2 = c2.get("/api/v1/activities").json()
+    assert len(a1) == 1 and a1[0]["name"] == "Run U1"
+    assert len(a2) == 1 and a2[0]["name"] == "Run U2"
+
+
+def test_cross_user_activity_detail_is_404(session_factory):
+    _seed(session_factory)
+    c1 = _client_for(session_factory, 1)
+    # user1's own activity is visible
+    own = c1.get("/api/v1/activities").json()[0]["id"]
+    assert c1.get(f"/api/v1/activities/{own}").status_code == 200
+    # user2's activity id must not be reachable by user1
+    c2 = _client_for(session_factory, 2)
+    other = c2.get("/api/v1/activities").json()[0]["id"]
+    if other != own:
+        assert c1.get(f"/api/v1/activities/{other}").status_code == 404
+
+
+def test_insights_scoped_to_user(session_factory):
+    _seed(session_factory)
+    i1 = _client_for(session_factory, 1).get("/api/v1/insights").json()
+    i2 = _client_for(session_factory, 2).get("/api/v1/insights").json()
+    assert [i["summary"] for i in i1] == ["insight U1"]
+    assert [i["summary"] for i in i2] == ["insight U2"]
+
+
+def test_profile_scoped_to_user(session_factory):
+    _seed(session_factory)
+    p1 = _client_for(session_factory, 1).get("/api/v1/athlete-profile").json()
+    p2 = _client_for(session_factory, 2).get("/api/v1/athlete-profile").json()
+    assert p1["name"] == "Athlete U1"
+    assert p2["name"] == "Athlete U2"
+
+
+def test_training_plan_scoped_to_user(session_factory):
+    _seed(session_factory)
+    plan1 = _client_for(session_factory, 1).get("/api/v1/training-plan").json()
+    plan2 = _client_for(session_factory, 2).get("/api/v1/training-plan").json()
+    assert plan1 is not None and plan2 is not None
+    assert plan1["id"] != plan2["id"]
+
+
+def test_settings_counts_scoped_to_user(session_factory):
+    _seed(session_factory)
+    s1 = _client_for(session_factory, 1).get("/api/v1/settings").json()
+    # Exactly one of each per user, never the other user's rows.
+    assert s1["counts"]["activities"] == 1
+    assert s1["counts"]["daily_summaries"] == 1
+    assert s1["counts"]["insights"] == 1
+    assert s1["counts"]["calendar_events"] == 1
+
+
+def test_today_scoped_to_user(session_factory):
+    _seed(session_factory)
+    body = _client_for(session_factory, 1).get("/api/v1/today?date=2026-06-01").json()
+    assert len(body["activities"]) == 1
+    assert body["activities"][0]["name"] == "Run U1"
+    assert body["daily_summary"]["steps"] == 1000
+    assert [r["title"] for r in body["next_races"]] == ["Race U1"]

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -213,7 +213,7 @@ def test_get_set_sync_status_roundtrip(db):
 def test_store_activity_creates_row(db, monkeypatch):
     fake_client = MagicMock()
     fake_client.get_activity_details.return_value = {"metricDescriptors": []}
-    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: fake_client)
 
     summary = {
         "activityId": 555,
@@ -240,7 +240,7 @@ def test_store_activity_creates_row(db, monkeypatch):
 
 
 def test_store_activity_skips_duplicate(db, monkeypatch):
-    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: MagicMock())
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: MagicMock())
     db.add(Activity(garmin_id=777, name="Existing", activity_type="running"))
     db.commit()
     result = garmin_sync._store_activity(db, {"activityId": 777}, {}, skip_ai=True)
@@ -322,7 +322,7 @@ def test_sync_activities_stores_new(db, patch_db_session, monkeypatch):
          "duration": 1800, "distance": 5000},
     ]
     fake_client.get_activity_details.return_value = {"metricDescriptors": []}
-    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: fake_client)
     monkeypatch.setattr(garmin_sync, "_fetch_activity_details", lambda c, gid: {})
 
     new = garmin_sync.sync_activities()
@@ -340,7 +340,7 @@ def test_sync_activities_skips_existing(db, patch_db_session, monkeypatch):
 
     fake_client = MagicMock()
     fake_client.get_activities.return_value = [{"activityId": 2002}]
-    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: fake_client)
 
     new = garmin_sync.sync_activities()
     assert new == []
@@ -363,7 +363,7 @@ def test_sync_daily_summary_creates_row(db, patch_db_session, monkeypatch):
     fake_client.get_hrv_data.return_value = {
         "hrvSummary": {"lastNightAvg": 46, "weeklyAvg": 42, "status": "BALANCED"}
     }
-    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: fake_client)
 
     summary = garmin_sync.sync_daily_summary(date(2026, 6, 10))
     assert summary is not None
@@ -395,7 +395,7 @@ def test_sync_daily_summary_updates_existing(db, patch_db_session, monkeypatch):
     fake_client.get_heart_rates.return_value = {}
     fake_client.get_all_day_stress.return_value = {}
     fake_client.get_hrv_data.return_value = {}
-    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: fake_client)
 
     garmin_sync.sync_daily_summary(date(2026, 6, 10))
     db.expire_all()
@@ -445,7 +445,7 @@ def test_fetch_garmin_profile_fields_tolerates_missing_data():
 
 def test_sync_athlete_profile_creates_row(db, patch_db_session, monkeypatch):
     patch_db_session(garmin_sync)
-    monkeypatch.setattr(garmin_sync, "get_garmin_client", _profile_client)
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: _profile_client())
 
     profile = garmin_sync.sync_athlete_profile()
     assert profile is not None
@@ -460,7 +460,7 @@ def test_sync_athlete_profile_overwrites_garmin_fields_but_keeps_others(db, patc
     db.add(AthleteProfile(name="Old Name", weight_kg=80.0, goal_race="Berlin Marathon"))
     db.commit()
 
-    monkeypatch.setattr(garmin_sync, "get_garmin_client", _profile_client)
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: _profile_client())
     garmin_sync.sync_athlete_profile()
     db.expire_all()
 
@@ -484,7 +484,7 @@ def test_backfill_activities_walks_pages(db, patch_db_session, monkeypatch):
           "duration": 1800, "distance": 5000}],
     ]
     fake_client.get_activity_details.return_value = {"metricDescriptors": []}
-    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: fake_client)
 
     garmin_sync.backfill_activities()
     assert db.query(Activity).filter(Activity.garmin_id == 3001).count() == 1
@@ -495,7 +495,7 @@ def test_backfill_activities_skips_when_complete(db, patch_db_session, monkeypat
     patch_db_session(garmin_sync)
     garmin_sync._set_sync_status(db, "backfill_activities", "complete")
     monkeypatch.setattr(garmin_sync, "get_garmin_client",
-                        lambda: pytest.fail("client should not be created"))
+                        lambda *a, **k: pytest.fail("client should not be created"))
     garmin_sync.backfill_activities()  # returns immediately
 
 
@@ -547,10 +547,56 @@ def test_sync_calendar_upserts_events(db, patch_db_session, monkeypatch):
         return {}
 
     fake_client.connectapi.side_effect = fake_connectapi
-    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda: fake_client)
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: fake_client)
     monkeypatch.setattr(garmin_sync.time, "sleep", lambda *a, **k: None)
 
     count = garmin_sync.sync_calendar()
     assert count >= 1
     races = db.query(GarminCalendarEvent).filter(GarminCalendarEvent.event_type == "race").all()
     assert any(r.title == "Future Race" for r in races)
+
+
+# --- Phase 3: per-user scoping + needs_reauth ------------------------------
+
+def test_sync_activities_tags_rows_with_user_id(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    monkeypatch.setattr(garmin_sync.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(garmin_sync, "_fetch_activity_details", lambda c, gid: {})
+
+    fake_client = MagicMock()
+    fake_client.get_activities.return_value = [
+        {"activityId": 4242, "activityType": {"typeKey": "running"},
+         "activityName": "Run", "startTimeLocal": "2026-06-10 07:00:00",
+         "duration": 1800, "distance": 5000},
+    ]
+    fake_client.get_activity_details.return_value = {"metricDescriptors": []}
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: fake_client)
+
+    user = User(id=9, email="nine@example.com", garmin_email="nine@garmin.com")
+    garmin_sync.sync_activities(user)
+
+    row = db.query(Activity).filter(Activity.garmin_id == 4242).first()
+    assert row is not None
+    assert row.user_id == 9
+
+
+def test_garmin_connection_status_reports_needs_reauth():
+    user = User(id=3, email="x@example.com", garmin_email="x@garmin.com",
+                garmin_needs_reauth=True)
+    status = garmin_sync.garmin_connection_status(user)
+    assert status["connected"] is True
+    assert status["needs_reauth"] is True
+
+
+def test_mark_garmin_needs_reauth_sets_and_clears(db, patch_db_session):
+    patch_db_session(garmin_sync)
+    db.add(User(id=4, email="r@example.com", garmin_email="r@garmin.com"))
+    db.commit()
+
+    garmin_sync.mark_garmin_needs_reauth(4, True)
+    db.expire_all()
+    assert db.query(User).filter(User.id == 4).first().garmin_needs_reauth is True
+
+    garmin_sync.mark_garmin_needs_reauth(4, False)
+    db.expire_all()
+    assert db.query(User).filter(User.id == 4).first().garmin_needs_reauth is False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,43 +1,101 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import app.main as main
 
 
-def test_scheduled_activity_sync_runs_both(monkeypatch):
+def _user(uid=1):
+    return SimpleNamespace(id=uid, garmin_email="g@x.com", garmin_needs_reauth=False)
+
+
+def _fake_db_session_returning(user):
+    """A db_session() replacement whose query(...).first() yields ``user``."""
+    @contextmanager
+    def _cm():
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+        yield db
+    return _cm
+
+
+# --- scheduled jobs fan out across connected users -------------------------
+
+def test_scheduled_activity_sync_delegates_per_user(monkeypatch):
+    users = [_user(1), _user(2)]
+    monkeypatch.setattr(main, "_iter_garmin_users", lambda: users)
+    run = MagicMock()
+    monkeypatch.setattr(main, "run_activity_sync_for_user", run)
+
+    main._scheduled_activity_sync()
+
+    assert run.call_count == 2
+    assert {c.args[0] for c in run.call_args_list} == {1, 2}
+
+
+def test_scheduled_activity_sync_survives_one_user_error(monkeypatch):
+    users = [_user(1), _user(2)]
+    monkeypatch.setattr(main, "_iter_garmin_users", lambda: users)
+
+    def run(uid):
+        if uid == 1:
+            raise RuntimeError("boom")
+
+    run_mock = MagicMock(side_effect=run)
+    monkeypatch.setattr(main, "run_activity_sync_for_user", run_mock)
+    # Should not raise; the second user is still processed.
+    main._scheduled_activity_sync()
+    assert run_mock.call_count == 2
+
+
+# --- per-user activity sync ------------------------------------------------
+
+def test_run_activity_sync_for_user_syncs_activities_and_calendar(monkeypatch):
+    import app.garmin_sync as garmin_sync
+    user = _user(7)
+    monkeypatch.setattr(main, "db_session", _fake_db_session_returning(user))
+    monkeypatch.setattr(main, "_authenticate_or_flag", lambda u: True)
     sync_activities = MagicMock()
     sync_calendar = MagicMock()
-    import app.garmin_sync as garmin_sync
     monkeypatch.setattr(garmin_sync, "sync_activities", sync_activities)
     monkeypatch.setattr(garmin_sync, "sync_calendar", sync_calendar)
 
-    main._scheduled_activity_sync()
+    main.run_activity_sync_for_user(7)
 
-    sync_activities.assert_called_once()
-    sync_calendar.assert_called_once()
+    sync_activities.assert_called_once_with(user)
+    sync_calendar.assert_called_once_with(user)
 
 
-def test_scheduled_activity_sync_survives_calendar_error(monkeypatch):
+def test_run_activity_sync_skips_when_auth_fails(monkeypatch):
     import app.garmin_sync as garmin_sync
-    monkeypatch.setattr(garmin_sync, "sync_activities", MagicMock())
-    monkeypatch.setattr(garmin_sync, "sync_calendar", MagicMock(side_effect=RuntimeError("boom")))
-    # Should swallow the calendar failure, not raise.
-    main._scheduled_activity_sync()
+    user = _user(7)
+    monkeypatch.setattr(main, "db_session", _fake_db_session_returning(user))
+    monkeypatch.setattr(main, "_authenticate_or_flag", lambda u: False)
+    sync_activities = MagicMock()
+    monkeypatch.setattr(garmin_sync, "sync_activities", sync_activities)
+
+    main.run_activity_sync_for_user(7)
+
+    sync_activities.assert_not_called()
 
 
-def test_scheduled_daily_sync_syncs_window_and_analyzes_today(monkeypatch):
+# --- per-user daily sync ---------------------------------------------------
+
+def test_run_daily_sync_for_user_window_and_analyzes_today(monkeypatch):
     from datetime import date
 
     import app.garmin_sync as garmin_sync
     import app.ai_coach as ai_coach
 
+    user = _user(3)
+    monkeypatch.setattr(main, "db_session", _fake_db_session_returning(user))
+    monkeypatch.setattr(main, "_authenticate_or_flag", lambda u: True)
     monkeypatch.setattr(main.settings, "daily_sync_window_days", 3)
     monkeypatch.setattr(garmin_sync, "sync_athlete_profile", MagicMock())
 
-    # Return a distinct summary per requested date so we can verify which one
-    # is handed to the AI (the newest — today).
     summaries = {}
 
-    def fake_sync(target):
+    def fake_sync(target, user=None):
         s = MagicMock(id=target.toordinal(), date=target)
         summaries[target] = s
         return s
@@ -47,35 +105,49 @@ def test_scheduled_daily_sync_syncs_window_and_analyzes_today(monkeypatch):
     analyze = MagicMock()
     monkeypatch.setattr(ai_coach, "analyze_daily_summary", analyze)
 
-    main._scheduled_daily_sync()
+    main.run_daily_sync_for_user(3)
 
-    # Rolling window: today + the prior 2 days.
     assert sync.call_count == 3
     synced_dates = {c.args[0] for c in sync.call_args_list}
     assert date.today() in synced_dates
-    # AI runs only on today's (newest) summary.
     analyze.assert_called_once_with(summaries[date.today()])
 
 
-def test_scheduled_daily_sync_no_summary_skips_ai(monkeypatch):
+def test_run_daily_sync_no_summary_skips_ai(monkeypatch):
     import app.garmin_sync as garmin_sync
     import app.ai_coach as ai_coach
+
+    user = _user(3)
+    monkeypatch.setattr(main, "db_session", _fake_db_session_returning(user))
+    monkeypatch.setattr(main, "_authenticate_or_flag", lambda u: True)
     monkeypatch.setattr(garmin_sync, "sync_athlete_profile", MagicMock())
     monkeypatch.setattr(garmin_sync, "sync_daily_summary", MagicMock(return_value=None))
     analyze = MagicMock()
     monkeypatch.setattr(ai_coach, "analyze_daily_summary", analyze)
 
-    main._scheduled_daily_sync()
+    main.run_daily_sync_for_user(3)
 
     analyze.assert_not_called()
 
 
-def test_scheduled_weekly_review_delegates(monkeypatch):
+# --- weekly review / plan generation fan out -------------------------------
+
+def test_scheduled_weekly_review_delegates_per_user(monkeypatch):
     import app.ai_coach as ai_coach
+    monkeypatch.setattr(main, "_iter_garmin_users", lambda: [_user(5)])
     review = MagicMock()
     monkeypatch.setattr(ai_coach, "weekly_review", review)
     main._scheduled_weekly_review()
-    review.assert_called_once()
+    review.assert_called_once_with(user_id=5)
+
+
+def test_scheduled_plan_generation_delegates_per_user(monkeypatch):
+    import app.ai_coach as ai_coach
+    monkeypatch.setattr(main, "_iter_garmin_users", lambda: [_user(5)])
+    gen = MagicMock()
+    monkeypatch.setattr(ai_coach, "generate_training_plan", gen)
+    main._scheduled_plan_generation()
+    gen.assert_called_once_with(user_id=5)
 
 
 def test_run_backfill_runs_all_steps(monkeypatch):
@@ -86,6 +158,7 @@ def test_run_backfill_runs_all_steps(monkeypatch):
     weekly = MagicMock()
     monkeypatch.setattr(garmin_sync, "backfill_activities", backfill_activities)
     monkeypatch.setattr(garmin_sync, "backfill_daily_summaries", backfill_daily)
+    monkeypatch.setattr(garmin_sync, "sync_athlete_profile", MagicMock())
     monkeypatch.setattr(ai_coach, "weekly_review", weekly)
 
     main._run_backfill()


### PR DESCRIPTION
Completes the multi-user plan (`docs/multi_user_plan.md`): **every row, query, computation, and sync job is now scoped to one user.** Phases 1 (identity) and 2 (per-user Garmin credentials) already shipped; this is the data-isolation heavy lift.

Adjusted from the original plan for changes since it was written: schema changes ship as an **Alembic** revision (P3-3 retired the hand-rolled `_migrate_db`), and the scheduler builds on the per-user Garmin client cache from Phase 2.

## Design
`DEFAULT_USER_ID = 1` is the primary/bootstrap user. Every data column defaults to it, the migration backfills existing rows to it, and compute/sync helpers default their `user_id` scope to it. Production read/write paths always pass an explicit id (API → `current_user.id`, scheduler → the iterated user), so the default only ever covers the single-tenant bootstrap account and the test suite — which is why the existing suite stayed green with no churn to data fixtures.

Following the codebase convention (`TrainingPlanDay.plan_id` is a plain indexed int, not a `ForeignKey`), `user_id` is a plain indexed integer.

## Changes
- **models**: `user_id` on Activity, DailySummary, Insight, Race, GarminCalendarEvent, AthleteProfile, ZoneConfig, TrainingPlan, TrainingPlanDay, SyncStatus. Single-tenant uniques → composite `(user_id, …)` (e.g. `DailySummary` `(user_id, date)`, one `AthleteProfile`/user). New `User.garmin_needs_reauth`.
- **alembic `c3d4e5f6a7b8`**: adds `user_id` with `server_default="1"` (the backfill). The initial schema declared single-column uniqueness as *both* a unique index and an unnamed UNIQUE constraint, so the index is demoted to a plain lookup index and the constraint replaced with a composite (SQLite batch mode + naming convention). Verified end-to-end: backfill → per-user duplicates allowed, same-user duplicates rejected, downgrade round-trips.
- **garmin_sync / ai_coach / training_load / threshold / intensity / streams**: thread a `user_id` scope through every query, compute path, and per-user `SyncStatus` cache (training-load / threshold caches are now per-user, so they never serve one user's data to another).
- **api**: inject `current_user` and filter every query; cross-user detail lookups 404; manual `/sync` is scoped to the caller.
- **scheduler** (`main.py`): the four cron jobs iterate `_iter_garmin_users()` and run each user in isolation — one failure can't abort the rest. `_authenticate_or_flag` validates a user's Garmin client up front; a cron can't answer an MFA prompt, so on auth failure it sets `needs_reauth` and skips. The Settings UI surfaces a **Reconnect** action that clears the flag.
- **frontend**: `needs_reauth` type + Reconnect banner in Settings.
- **docs**: rewrote the P3-4 bullet in `IMPROVEMENT_PLAN.md`.

## Verification
- Backend: **440 passed**, coverage **84.8%** (gate 80%). New `tests/test_data_isolation.py` seeds two users and asserts `/today`, activities, insights, profile, plan, and settings counts return only the caller's data.
- Frontend: build + **50 vitest** green.
- Perf: `perf/perf.db` regenerated at the new head (user_id=1); **34 perf tests passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XC1cAB7Ccu1T1Rp7ob69iA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1cAB7Ccu1T1Rp7ob69iA)_