### PR TITLE
P3-2: Move AI model catalog to config

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -14,7 +14,7 @@ from app import training_load
 from app import threshold as threshold_mod
 from app import adherence as adherence_mod
 from app import intensity as intensity_mod
-from app.config import settings
+from app.config import settings, AVAILABLE_MODELS
 from app.database import db_session
 from app.models import (
     DEFAULT_USER_ID,
@@ -689,7 +689,16 @@ def _get_ai_config(db: Session, user_id: int = DEFAULT_USER_ID) -> tuple[str, st
         .first()
     )
     provider = provider_row.value if provider_row else "claude"
-    model = model_row.value if model_row else settings.ai_model
+    if provider not in AVAILABLE_MODELS:
+        logger.warning("Stored AI provider %r is not in AVAILABLE_MODELS; falling back to 'claude'", provider)
+        provider = "claude"
+    stored_model = model_row.value if model_row else None
+    if stored_model and stored_model in AVAILABLE_MODELS.get(provider, []):
+        model = stored_model
+    else:
+        if stored_model:
+            logger.warning("Stored AI model %r is not allowed for provider %r; falling back to default", stored_model, provider)
+        model = settings.ai_model
     return provider, model
 
 

--- a/app/api.py
+++ b/app/api.py
@@ -75,6 +75,7 @@ from app import training_load
 from app import threshold as threshold_mod
 from app import adherence as adherence_mod
 from app import intensity as intensity_mod
+from app.config import AVAILABLE_MODELS
 from app.utils import safe_json_loads, parse_activity_charts, parse_activity_route, calculate_age
 
 logger = logging.getLogger(__name__)
@@ -88,20 +89,6 @@ api_router = APIRouter(
 @api_router.get("/me", response_model=UserResponse)
 def api_me(current_user: User = Depends(get_current_user)):
     return current_user
-
-
-AVAILABLE_MODELS: dict[str, list[str]] = {
-    "claude": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
-    "gemini": [
-        "gemini-2.5-flash",
-        "gemini-2.5-flash-lite",
-        "gemini-3-flash",
-        "gemini-3.1-flash-lite",
-        "gemma-2-2b-it",
-        "gemma-4-26b-it",
-        "gemma-4-31b-it",
-    ],
-}
 
 
 # --- Today ---

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,18 @@
 from pydantic_settings import BaseSettings
 
+AVAILABLE_MODELS: dict[str, list[str]] = {
+    "claude": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
+    "gemini": [
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "gemini-3-flash",
+        "gemini-3.1-flash-lite",
+        "gemma-2-2b-it",
+        "gemma-4-26b-it",
+        "gemma-4-31b-it",
+    ],
+}
+
 
 class Settings(BaseSettings):
     garmin_email: str = ""


### PR DESCRIPTION
## Summary

- Moves `AVAILABLE_MODELS` dict from `app/api.py` into `app/config.py` so it's a single source of truth shared by both `api.py` and `ai_coach.py`
- Imports `AVAILABLE_MODELS` in `app/api.py` from config instead of defining it inline
- Adds validation in `app/ai_coach.py`'s `_get_ai_config`: if the DB-stored provider or model is no longer in the allowed catalog, logs a warning and falls back to the config default rather than silently using a disallowed value

## Test plan

- [ ] All 444 existing tests pass (`444 passed in 7.89s`)
- [ ] `test_ai_config_defaults`, `test_ai_config_set_valid`, `test_ai_config_unknown_provider`, `test_ai_config_invalid_model` all green
- [ ] `test_get_ai_config_defaults`, `test_get_ai_config_from_db` all green

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8KUM5iwuRgWcmK9oY5WV4)_