### PR TITLE
Add help icons and explainer pages for training stats

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import OnboardingView from './components/onboarding/OnboardingView'
 import TrendsView from './components/trends/TrendsView'
 import PlanView from './components/plan/PlanView'
 import PlanSetupView from './components/plan-setup/PlanSetupView'
+import StatInfoView from './components/info/StatInfoView'
 import { useAthleteProfile } from './api/hooks'
 
 interface DateContextType {
@@ -69,7 +70,7 @@ export default function App() {
   }, [profileLoading, profile, location.pathname, navigate])
 
   const isOnboarding = location.pathname === '/onboarding'
-  const isDetailPage = isOnboarding || location.pathname === '/plan/setup' || location.pathname.startsWith('/activities/') || location.pathname.startsWith('/daily/') || location.pathname.startsWith('/workouts/')
+  const isDetailPage = isOnboarding || location.pathname === '/plan/setup' || location.pathname.startsWith('/activities/') || location.pathname.startsWith('/daily/') || location.pathname.startsWith('/workouts/') || location.pathname.startsWith('/info/')
   const showCalendar = !isDetailPage
 
   return (
@@ -105,6 +106,7 @@ export default function App() {
             <Route path="/plan" element={<PlanView />} />
             <Route path="/plan/setup" element={<PlanSetupView />} />
             <Route path="/settings" element={<SettingsView />} />
+            <Route path="/info/:topic" element={<StatInfoView />} />
             <Route path="/onboarding" element={<OnboardingView />} />
           </Routes>
         </main>

--- a/frontend/src/components/info/StatHelpButton.css
+++ b/frontend/src/components/info/StatHelpButton.css
@@ -1,0 +1,19 @@
+.stat-help-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 50%;
+  line-height: 0;
+  transition: color 0.15s ease;
+}
+
+.stat-help-btn:hover,
+.stat-help-btn:focus-visible {
+  color: var(--accent);
+  outline: none;
+}

--- a/frontend/src/components/info/StatHelpButton.tsx
+++ b/frontend/src/components/info/StatHelpButton.tsx
@@ -1,0 +1,24 @@
+import { HelpCircle } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import './StatHelpButton.css'
+
+interface Props {
+  topic: string
+  label: string
+}
+
+/** Small question-mark icon that opens the explainer page for a stats section. */
+export default function StatHelpButton({ topic, label }: Props) {
+  const navigate = useNavigate()
+  return (
+    <button
+      type="button"
+      className="stat-help-btn"
+      aria-label={`About ${label}`}
+      title={`About ${label}`}
+      onClick={() => navigate(`/info/${topic}`)}
+    >
+      <HelpCircle size={16} />
+    </button>
+  )
+}

--- a/frontend/src/components/info/StatInfoView.css
+++ b/frontend/src/components/info/StatInfoView.css
@@ -1,0 +1,137 @@
+.stat-info {
+  min-height: 100dvh;
+  background: var(--bg);
+}
+
+.stat-info-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px 16px;
+  background: var(--bg-card);
+  border-bottom: 3px solid var(--accent);
+}
+
+.stat-info-back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.stat-info-back:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.stat-info-header-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.stat-info-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 6px 0 4px;
+}
+
+.stat-info-subtitle {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.stat-info-body {
+  padding: 16px;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.stat-info-intro {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  margin: 0 0 16px;
+}
+
+.stat-info-empty {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 32px 0;
+}
+
+.stat-info-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  margin-bottom: 14px;
+}
+
+.stat-info-card-name {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 8px;
+}
+
+.stat-info-acronym {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.01em;
+}
+
+.stat-info-desc {
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--text);
+  margin: 0 0 14px;
+}
+
+.stat-info-field {
+  margin-top: 12px;
+}
+
+.stat-info-field-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.stat-info-formula {
+  display: block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--text);
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.stat-info-limits {
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  margin: 0;
+}

--- a/frontend/src/components/info/StatInfoView.tsx
+++ b/frontend/src/components/info/StatInfoView.tsx
@@ -1,0 +1,53 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { ArrowLeft } from 'lucide-react'
+import { STAT_INFO } from './statInfo'
+import './StatInfoView.css'
+
+export default function StatInfoView() {
+  const { topic } = useParams<{ topic: string }>()
+  const navigate = useNavigate()
+  const info = topic ? STAT_INFO[topic] : undefined
+
+  return (
+    <div className="stat-info">
+      <header className="stat-info-header">
+        <button className="stat-info-back" onClick={() => navigate(-1)} aria-label="Go back">
+          <ArrowLeft size={20} />
+        </button>
+        <div className="stat-info-header-info">
+          <h1 className="stat-info-title">{info ? info.title : 'Not found'}</h1>
+          <span className="stat-info-subtitle">How each stat is calculated</span>
+        </div>
+      </header>
+
+      <div className="stat-info-body">
+        {!info ? (
+          <div className="stat-info-empty">No explanation available for this section.</div>
+        ) : (
+          <>
+            {info.intro && <p className="stat-info-intro">{info.intro}</p>}
+            {info.stats.map(stat => (
+              <section className="stat-info-card" key={stat.name}>
+                <h2 className="stat-info-card-name">
+                  {stat.name}
+                  {stat.acronym && <span className="stat-info-acronym">{stat.acronym}</span>}
+                </h2>
+                <p className="stat-info-desc">{stat.description}</p>
+
+                <div className="stat-info-field">
+                  <span className="stat-info-field-label">Formula</span>
+                  <code className="stat-info-formula">{stat.formula}</code>
+                </div>
+
+                <div className="stat-info-field">
+                  <span className="stat-info-field-label">Limits &amp; interpretation</span>
+                  <p className="stat-info-limits">{stat.limits}</p>
+                </div>
+              </section>
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/info/statInfo.ts
+++ b/frontend/src/components/info/statInfo.ts
@@ -1,0 +1,177 @@
+/**
+ * Explainer content for the Training Load and Training Readiness stats.
+ *
+ * This is a plain data module (no backend call). The descriptions, formulas and
+ * limits restate the calculations implemented in `app/training_load.py` so the
+ * user can understand what each number means. Every acronym is given both its
+ * full expansion and a plain-language description of what it measures.
+ */
+
+export interface StatDetail {
+  /** Full, human-readable name of the stat. */
+  name: string
+  /** Short form spelled out, e.g. "CTL (Chronic Training Load)". */
+  acronym?: string
+  /** What it is, in plain language — spelling out any acronyms it relies on. */
+  description: string
+  /** How it's calculated. */
+  formula: string
+  /** Sane ranges, interpretation bands, and caveats. */
+  limits: string
+}
+
+export interface InfoTopic {
+  title: string
+  /** Optional lead-in shown under the page title. */
+  intro?: string
+  stats: StatDetail[]
+}
+
+export const STAT_INFO: Record<string, InfoTopic> = {
+  'training-load': {
+    title: 'Training Load',
+    intro:
+      'Training load tracks how much work you’ve done and how it’s balancing out over time. ' +
+      'Every stat below is built from TSS (Training Stress Score) — a single number summarising ' +
+      'how hard one session was, derived from its duration and intensity. When a run has no power ' +
+      'data, TSS is estimated from pace, then heart rate, then duration, with the intensity factor ' +
+      'capped at 1.50 so one fluky data point can’t blow up the load.',
+    stats: [
+      {
+        name: 'Fitness',
+        acronym: 'CTL (Chronic Training Load)',
+        description:
+          'Your long-term training load — roughly how much fitness you’ve built up over the past ' +
+          '~6 weeks. It’s a 42-day EWMA (Exponentially-Weighted Moving Average: a rolling average ' +
+          'that weights recent days more heavily than older ones) of your daily TSS (Training Stress ' +
+          'Score). Higher means fitter.',
+        formula:
+          'CTL_today = CTL_yesterday + (TSS_today − CTL_yesterday) × α,  where α = 1 − e^(−1/42) ≈ 0.0235',
+        limits:
+          'Builds and decays slowly, so it needs several weeks of consistent data to be meaningful. ' +
+          'Typical recreational range ~30–80; well-trained endurance athletes often exceed 100.',
+      },
+      {
+        name: 'Fatigue',
+        acronym: 'ATL (Acute Training Load)',
+        description:
+          'Your short-term training load — how much fatigue you’re carrying right now from recent ' +
+          'sessions. It’s a 7-day EWMA (Exponentially-Weighted Moving Average) of your daily TSS ' +
+          '(Training Stress Score), so it reacts quickly to hard days and rest days alike.',
+        formula:
+          'ATL_today = ATL_yesterday + (TSS_today − ATL_yesterday) × α,  where α = 1 − e^(−1/7) ≈ 0.1331',
+        limits:
+          'Rises and falls fast (days, not weeks). On its own it just tells you how loaded the last ' +
+          'week was — it’s most useful compared against Fitness (see Form and ACWR).',
+      },
+      {
+        name: 'Form',
+        acronym: 'TSB (Training Stress Balance)',
+        description:
+          'Your freshness — the gap between long-term fitness and short-term fatigue. Positive Form ' +
+          'means you’re rested and ready; negative Form means fatigue is outweighing fitness because ' +
+          'you’re in a training block.',
+        formula: 'TSB = CTL (Fitness) − ATL (Fatigue)',
+        limits:
+          'Interpretation bands: above +15 = very fresh / detraining risk; +5 to +15 = fresh, tapered; ' +
+          '−10 to +5 = neutral, race-ready; −30 to −10 = productive training fatigue; below −30 = high ' +
+          'fatigue / overreaching risk.',
+      },
+      {
+        name: 'Workload Ratio',
+        acronym: 'ACWR (Acute:Chronic Workload Ratio)',
+        description:
+          'A relative injury-risk gauge: how big your recent load (Fatigue) is compared with the load ' +
+          'your body is accustomed to (Fitness). It flags when you’re ramping up too fast. Only shown ' +
+          'once you have enough history for Fitness to be established.',
+        formula: 'ACWR = ATL (Fatigue) ÷ CTL (Fitness),  shown only when CTL > 1',
+        limits:
+          'Risk bands: 0.8–1.3 = the “sweet spot” / optimal training zone; above 1.3 = moderate risk, ' +
+          'monitor fatigue; above 1.5 = high risk / significant overreaching. Below 0.8 suggests ' +
+          'detraining. A rapid 7-day rise in Fitness also bumps the risk rating.',
+      },
+    ],
+  },
+
+  'training-readiness': {
+    title: 'Training Readiness',
+    intro:
+      'Readiness is a single 0–100 score estimating how prepared your body is to train hard today. ' +
+      'It’s a weighted average of up to five wellness components (each scored 0–100). Any component ' +
+      'with no data for the day is dropped and the remaining weights are rebalanced, so a partial ' +
+      'data day still gives a meaningful score.',
+    stats: [
+      {
+        name: 'Overall Readiness Score',
+        description:
+          'The headline 0–100 number. It’s the weighted average of the available components below: ' +
+          'Sleep 25%, Recovery 25%, Freshness 20%, Resting HR 10%, HRV 20%.',
+        formula:
+          'score = Σ(component × weight) ÷ Σ(weights of available components)',
+        limits:
+          'Labels: 86–100 = Excellent; 71–85 = Very Good; 51–70 = Good; 31–50 = Fair; 0–30 = Low. ' +
+          'It’s a guide, not a verdict — context (illness, life stress, race day) still matters.',
+      },
+      {
+        name: 'Sleep',
+        description:
+          'How well you slept last night, combining sleep quality and quantity. Uses your device’s ' +
+          'sleep score plus a score based purely on hours slept.',
+        formula:
+          'avg(device sleep score, duration score) — where duration score maps 5 h → 0 and 8 h → 100 linearly',
+        limits:
+          'Scored 0–100. Needs sleep tracking data; if neither a sleep score nor a duration is ' +
+          'recorded, this component is omitted.',
+      },
+      {
+        name: 'Recovery',
+        description:
+          'How recovered your nervous system looks, from all-day stress and Body Battery (your ' +
+          'device’s energy-reserve estimate). Lower stress and higher Body Battery mean better recovery.',
+        formula:
+          'avg(100 − average stress, Body Battery high) — each clamped to 0–100',
+        limits:
+          'Scored 0–100. Requires stress and/or Body Battery data; omitted if neither is available.',
+      },
+      {
+        name: 'Freshness',
+        description:
+          'How little training fatigue you’re carrying — the inverse of your short-term load. It’s ' +
+          'derived directly from Fatigue (ATL, Acute Training Load, the 7-day load average used in ' +
+          'Training Load). Higher means less fatigued.',
+        formula: 'Freshness = 100 − ATL (Fatigue),  clamped to 0–100',
+        limits:
+          'Scored 0–100. Because it’s based on Fatigue, very heavy recent training pushes it toward 0.',
+      },
+      {
+        name: 'Resting HR',
+        acronym: 'RHR (Resting Heart Rate)',
+        description:
+          'Your lowest heart rate at rest, compared against your recent norm. An elevated resting ' +
+          'heart rate often signals incomplete recovery, illness, or stress, so a lower-than-usual ' +
+          'value scores higher.',
+        formula:
+          'score = 75 − delta × 7.5,  where delta = today’s RHR − 7-day average RHR (clamped 0–100). ' +
+          'So −5 bpm → 100, 0 → 75, +10 bpm → 0.',
+        limits:
+          'Scored 0–100. Needs today’s resting HR plus a recent baseline to compare against; omitted ' +
+          'otherwise. Lowest weight (10%) since RHR is noisy day to day.',
+      },
+      {
+        name: 'HRV',
+        acronym: 'HRV (Heart-Rate Variability)',
+        description:
+          'The beat-to-beat variation in your heart rate overnight — a well-established marker of ' +
+          'recovery and autonomic balance. Measured against your own personal baseline rather than ' +
+          'an absolute target, because healthy HRV varies a lot between people.',
+        formula:
+          'score = 75 + (ratio − 1) × 250,  where ratio = last-night HRV ÷ 7-day baseline HRV ' +
+          '(clamped 0–100). Falls back to your device’s HRV status (Balanced/Unbalanced/Low/Poor) ' +
+          'when no baseline exists.',
+        limits:
+          'Scored 0–100. At baseline → 75 (“good”); roughly +20% → 100, −20% → 25. Needs overnight ' +
+          'HRV data; omitted if unavailable.',
+      },
+    ],
+  },
+}

--- a/frontend/src/components/today/ReadinessCard.css
+++ b/frontend/src/components/today/ReadinessCard.css
@@ -9,6 +9,11 @@
   margin-bottom: 16px;
 }
 
+.readiness-help {
+  margin-left: auto;
+  align-self: flex-start;
+}
+
 .readiness-score-ring {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/today/ReadinessCard.tsx
+++ b/frontend/src/components/today/ReadinessCard.tsx
@@ -1,4 +1,5 @@
 import type { TrainingReadiness } from '../../api/types'
+import StatHelpButton from '../info/StatHelpButton'
 import './ReadinessCard.css'
 
 interface Props {
@@ -44,6 +45,9 @@ export default function ReadinessCard({ readiness }: Props) {
         <div className="readiness-label-block">
           <span className="readiness-label" style={{ color }}>{readiness.label}</span>
           <span className="readiness-sub">Training Readiness</span>
+        </div>
+        <div className="readiness-help">
+          <StatHelpButton topic="training-readiness" label="Training Readiness" />
         </div>
       </div>
 

--- a/frontend/src/components/today/TodayView.tsx
+++ b/frontend/src/components/today/TodayView.tsx
@@ -8,6 +8,7 @@ import WeekOverview from './WeekOverview'
 import TrainingLoadChart from './TrainingLoadChart'
 import ReadinessCard from './ReadinessCard'
 import InsightsList from './InsightsList'
+import StatHelpButton from '../info/StatHelpButton'
 import { AlertTriangle, RefreshCw } from 'lucide-react'
 import './TodayView.css'
 
@@ -165,7 +166,10 @@ export default function TodayView() {
       {/* Training load (Fitness / Fatigue / Form) */}
       {data?.training_load && (
         <section className="today-section">
-          <h2 className="section-title">Training Load</h2>
+          <div className="section-title-row">
+            <h2 className="section-title">Training Load</h2>
+            <StatHelpButton topic="training-load" label="Training Load" />
+          </div>
           <TrainingLoadChart current={data.training_load} />
         </section>
       )}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -141,6 +141,17 @@ button {
   margin-bottom: 12px;
 }
 
+.section-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.section-title-row .section-title {
+  margin-bottom: 0;
+}
+
 .empty-state {
   text-align: center;
   padding: 32px 16px;


### PR DESCRIPTION
Add a question-mark help icon to the Training Load and Training
Readiness section headers. Tapping it opens a dedicated page that
describes each stat, the formula used to calculate it, and its
limits/interpretation ranges, spelling out and explaining every
acronym (CTL, ATL, TSB, ACWR, TSS, IF, EWMA, RHR, HRV).

- StatHelpButton: reusable HelpCircle button navigating to /info/:topic
- statInfo.ts: explainer content restating app/training_load.py formulas
- StatInfoView: parameterized info page reusing the detail-page pattern
- Route /info/:topic registered and treated as a full-screen detail page

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G6AC7TFbcXkJRB4Y7YnBKu