### PR TITLE
fix: HR zone chart shows non-zero time for zones runner never reached

### DIFF
--- a/frontend/src/components/activity-detail/HrZonesChart.tsx
+++ b/frontend/src/components/activity-detail/HrZonesChart.tsx
@@ -16,7 +16,7 @@ export default function HrZonesChart({ zones }: Props) {
   if (!zones || !Array.isArray(zones) || zones.length === 0) return null
 
   const data = zones.map((z: any, i: number) => {
-    const secs = z?.secsInZone || z?.zoneLowBoundary || 0
+    const secs = z?.secsInZone ?? 0
     const mins = Math.round(secs / 60)
     return {
       zone: ZONE_LABELS[i] || `Zone ${i + 1}`,


### PR DESCRIPTION
When secsInZone is 0 (no time spent in a zone), the || operator
treated it as falsy and fell through to zoneLowBoundary, which holds
the HR boundary in bpm (e.g. 172 for Zone 5). Math.round(172/60) = 3,
so Zone 5 displayed "3 min" even when max HR was well below the
Zone 5 threshold.

Using ?? (nullish coalescing) ensures 0 is preserved correctly and
zoneLowBoundary is never used as a time value.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ogjtHr1bJzSi2WnzcvL2K