### PR TITLE
fix: dark theme tooltip text color on workout page zone charts

### DIFF
--- a/frontend/src/components/activity-detail/ChartTabs.tsx
+++ b/frontend/src/components/activity-detail/ChartTabs.tsx
@@ -5,7 +5,7 @@ import {
 } from 'recharts'
 import type { ChartSeries, MetricZone } from '../../api/types'
 import { useTheme } from '../../App'
-import { getChartTooltipStyle } from '../../utils/theme'
+import { getChartTooltipStyle, getChartTooltipTextStyle } from '../../utils/theme'
 import './ChartTabs.css'
 
 const chartColors: Record<string, string> = {
@@ -63,6 +63,7 @@ export default function ChartTabs({ chartData, metricZones }: Props) {
   const reversed = activeKey === 'pace'
 
   const tooltipStyle = getChartTooltipStyle(theme)
+  const tooltipTextStyle = getChartTooltipTextStyle(theme)
 
   const formatValue = (value: any) => {
     if (value === null || value === undefined) return ['-', series.label]
@@ -104,6 +105,8 @@ export default function ChartTabs({ chartData, metricZones }: Props) {
               <YAxis dataKey="y" hide domain={['auto', 'auto']} />
               <Tooltip
                 contentStyle={tooltipStyle}
+                labelStyle={tooltipTextStyle}
+                itemStyle={tooltipTextStyle}
                 formatter={(value: any) => formatValue(value)}
                 labelFormatter={() => ''}
               />
@@ -163,6 +166,8 @@ export default function ChartTabs({ chartData, metricZones }: Props) {
             />
             <Tooltip
               contentStyle={tooltipStyle}
+              labelStyle={tooltipTextStyle}
+              itemStyle={tooltipTextStyle}
               formatter={formatValue}
               labelFormatter={() => ''}
             />

--- a/frontend/src/components/activity-detail/HrZonesChart.tsx
+++ b/frontend/src/components/activity-detail/HrZonesChart.tsx
@@ -1,6 +1,6 @@
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
 import { useTheme } from '../../App'
-import { getChartTooltipStyle, getChartTickColor } from '../../utils/theme'
+import { getChartTooltipStyle, getChartTickColor, getChartTooltipTextStyle } from '../../utils/theme'
 import './HrZonesChart.css'
 
 const ZONE_COLORS = ['#2ecc71', '#27ae60', '#f39c12', '#e67e22', '#e74c3c']
@@ -44,6 +44,8 @@ export default function HrZonesChart({ zones }: Props) {
             />
             <Tooltip
               contentStyle={getChartTooltipStyle(theme)}
+              labelStyle={getChartTooltipTextStyle(theme)}
+              itemStyle={getChartTooltipTextStyle(theme)}
               formatter={(value: number) => [`${value} min`, 'Time']}
             />
             <Bar dataKey="minutes" radius={[0, 4, 4, 0]} barSize={20}>

--- a/frontend/src/components/activity-detail/PaceZonesChart.tsx
+++ b/frontend/src/components/activity-detail/PaceZonesChart.tsx
@@ -2,7 +2,7 @@ import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 
 import { useZoneConfigs } from '../../api/hooks'
 import type { ChartSeries } from '../../api/types'
 import { useTheme } from '../../App'
-import { getChartTooltipStyle, getChartTickColor } from '../../utils/theme'
+import { getChartTooltipStyle, getChartTickColor, getChartTooltipTextStyle } from '../../utils/theme'
 import './PaceZonesChart.css'
 
 interface Props {
@@ -91,6 +91,8 @@ export default function PaceZonesChart({ paceSeries }: Props) {
             />
             <Tooltip
               contentStyle={getChartTooltipStyle(theme)}
+              labelStyle={getChartTooltipTextStyle(theme)}
+              itemStyle={getChartTooltipTextStyle(theme)}
               formatter={(value: number, _name: string, props: any) => [
                 `${value}% (${props.payload.rangeLabel})`,
                 'Time',

--- a/frontend/src/utils/theme.ts
+++ b/frontend/src/utils/theme.ts
@@ -11,3 +11,7 @@ export function getChartTooltipStyle(theme: Theme): CSSProperties {
 export function getChartTickColor(theme: Theme): string {
   return theme === 'light' ? '#6b7280' : '#888'
 }
+
+export function getChartTooltipTextStyle(theme: Theme): CSSProperties {
+  return { color: theme === 'light' ? '#1a1a2e' : '#e0e0e0' }
+}


### PR DESCRIPTION
Recharts sets inline styles on its tooltip label and item sub-elements
that don't inherit from contentStyle, causing black text on the dark
background. Add labelStyle and itemStyle props to all Tooltip components
using a new getChartTooltipTextStyle() helper in theme.ts.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018zxNd3hLjdX8tPW9BUx8Wz