### PR TITLE
fix: correct cadence doubling and stride unit conversion

### DIFF
--- a/app/garmin_sync.py
+++ b/app/garmin_sync.py
@@ -344,7 +344,7 @@ def _extract_activity_fields(summary: dict, details: dict | None = None) -> dict
         "elevation_gain": summary.get("elevationGain"),
         "elevation_loss": summary.get("elevationLoss"),
         "avg_cadence": summary.get("averageRunningCadenceInStepsPerMinute"),
-        "avg_stride": summary.get("avgStrideLength"),
+        "avg_stride": summary.get("avgStrideLength") / 100 if summary.get("avgStrideLength") is not None else None,
         "training_effect_aerobic": summary.get("aerobicTrainingEffect"),
         "training_effect_anaerobic": summary.get("anaerobicTrainingEffect"),
         "vo2max": summary.get("vO2MaxValue"),

--- a/frontend/src/components/activity-detail/ActivityDetailView.tsx
+++ b/frontend/src/components/activity-detail/ActivityDetailView.tsx
@@ -43,7 +43,7 @@ export default function ActivityDetailView() {
     activity.max_hr ? { label: 'Max HR', value: String(activity.max_hr), unit: 'bpm' } : null,
     activity.elevation_gain ? { label: 'Elev. Gain', value: `${Math.round(activity.elevation_gain)}`, unit: 'm' } : null,
     activity.calories ? { label: 'Calories', value: String(Math.round(activity.calories)), unit: 'kcal' } : null,
-    activity.avg_cadence ? { label: 'Cadence', value: String(Math.round(activity.avg_cadence * 2)), unit: 'spm' } : null,
+    activity.avg_cadence ? { label: 'Cadence', value: String(Math.round(activity.avg_cadence)), unit: 'spm' } : null,
     activity.avg_stride ? { label: 'Stride', value: activity.avg_stride.toFixed(2), unit: 'm' } : null,
   ].filter(Boolean) as { label: string; value: string; unit?: string }[]
 


### PR DESCRIPTION
- Remove erroneous *2 multiplier on avg_cadence in the stats display;
  Garmin's averageRunningCadenceInStepsPerMinute is already full spm
  (the *2 doubling only applies to raw stream chart data)
- Convert avgStrideLength from centimeters to meters on ingestion since
  Garmin returns this field in cm (e.g. 103.36 cm → 1.03 m)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D1GHCuj7NkXQRDdduL8nwP