### PR TITLE
Add GAP pace chart to activity detail view

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,8 @@
 import json
 from datetime import date
 
+from app.streams import grade_adjusted_speed
+
 
 def calculate_age(dob: date | None, reference: date | None = None) -> int | None:
     """Return age in whole years from a date of birth, or None if unset."""
@@ -83,6 +85,25 @@ def parse_activity_charts(laps_data) -> dict:
             round(v * 2) if v is not None else None
             for v in charts["cadence"]["data"]
         ]
+
+    # GAP (grade-adjusted pace): reuse speed/elevation/distance columns if available.
+    spd_idx = col_map.get("directSpeed")
+    elev_idx = col_map.get("directElevation")
+    dist_idx = col_map.get("sumDistance")
+    if spd_idx is not None and elev_idx is not None and dist_idx is not None:
+        spd_raw, elev_raw, dist_raw = [], [], []
+        for m in sampled:
+            arr = m.get("metrics", [])
+            spd_raw.append(arr[spd_idx] if spd_idx < len(arr) else None)
+            elev_raw.append(arr[elev_idx] if elev_idx < len(arr) else None)
+            dist_raw.append(arr[dist_idx] if dist_idx < len(arr) else None)
+        gap_speed = grade_adjusted_speed(spd_raw, elev_raw, dist_raw)
+        gap_pace = [
+            round(1000 / (60 * v), 2) if v and v > 0 else None
+            for v in gap_speed
+        ]
+        if any(v is not None for v in gap_pace):
+            charts["gap_pace"] = {"label": "GAP", "unit": "min/km", "data": gap_pace}
 
     return charts
 

--- a/frontend/src/components/activity-detail/ChartTabs.tsx
+++ b/frontend/src/components/activity-detail/ChartTabs.tsx
@@ -12,6 +12,7 @@ const chartColors: Record<string, string> = {
   heart_rate: '#e74c3c',
   elevation: '#2ecc71',
   pace: '#f39c12',
+  gap_pace: '#fd9644',
   cadence: '#0984e3',
   power: '#e84393',
   gct: '#6c5ce7',
@@ -59,8 +60,8 @@ export default function ChartTabs({ chartData, metricZones }: Props) {
   const isScatter = SCATTER_METRICS.has(activeKey)
   const zones = metricZones?.[activeKey]
 
-  // Reverse Y for pace (lower pace = faster = better)
-  const reversed = activeKey === 'pace'
+  // Reverse Y for pace metrics (lower value = faster = better)
+  const reversed = activeKey === 'pace' || activeKey === 'gap_pace'
 
   const tooltipStyle = getChartTooltipStyle(theme)
   const tooltipTextStyle = getChartTooltipTextStyle(theme)
@@ -68,7 +69,7 @@ export default function ChartTabs({ chartData, metricZones }: Props) {
   const formatValue = (value: any) => {
     if (value === null || value === undefined) return ['-', series.label]
     const num = Number(value)
-    if (activeKey === 'pace') {
+    if (activeKey === 'pace' || activeKey === 'gap_pace') {
       const m = Math.floor(num)
       const s = Math.round((num - m) * 60)
       return [`${m}:${s.toString().padStart(2, '0')}`, series.label]


### PR DESCRIPTION
Computes grade-adjusted pace on-the-fly from the directSpeed/directElevation/
sumDistance streams already stored in laps_json, using the existing
grade_adjusted_speed() (Minetti model) from app/streams.py. Emits a gap_pace
series from parse_activity_charts() so it appears as a new tab alongside HR,
elevation, pace, etc. without any schema or sync changes.

Frontend renders it identically to regular pace (reversed Y axis, mm:ss tooltip).