### PR TITLE
P1-3: Harden AI plan generation with structured output

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -44,6 +44,7 @@ class AIFatalError(Exception):
 
 _MAX_RETRIES = 3
 _BACKOFF_BASE = 2  # seconds; delays are 1s, 2s before the 3rd attempt
+_PLAN_MAX_TOKENS = 16000
 
 
 SYSTEM_PROMPT = """You are an experienced, data-driven running coach. You analyze training data from Garmin Connect and provide actionable insights.
@@ -1163,6 +1164,97 @@ Rules:
     rebuild week (easy/moderate volume) before resuming normal load.
 """
 
+# Anthropic tool-use schema — forces a schema-valid plan object instead of free text.
+_PLAN_TOOL_SCHEMA = {
+    "name": "generate_plan",
+    "description": "Return the 4-week running training plan as a structured object.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "phase": {
+                "type": "string",
+                "enum": ["base", "build", "peak", "taper"],
+            },
+            "overview": {"type": "string"},
+            "weeks": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "week_number": {"type": "integer"},
+                        "theme": {"type": "string"},
+                        "notes": {"type": "string"},
+                        "days": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "date": {"type": "string"},
+                                    "day_of_week": {
+                                        "type": "string",
+                                        "enum": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+                                    },
+                                    "workout_type": {
+                                        "type": "string",
+                                        "enum": ["easy", "tempo", "long", "interval", "rest", "cross", "strength"],
+                                    },
+                                    "target_distance_km": {"type": ["number", "null"]},
+                                    "target_pace_display": {"type": ["string", "null"]},
+                                    "description": {"type": "string"},
+                                    "notes": {"type": ["string", "null"]},
+                                },
+                                "required": ["date", "day_of_week", "workout_type", "description"],
+                            },
+                        },
+                    },
+                    "required": ["week_number", "days"],
+                },
+            },
+        },
+        "required": ["phase", "overview", "weeks"],
+    },
+}
+
+# Gemini response_schema — enforces structured JSON output at the API level.
+# Gemini's schema dialect doesn't support type unions, so nullable fields are
+# left optional (absent) rather than typed as ["string", "null"].
+_PLAN_GEMINI_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "phase": {"type": "string"},
+        "overview": {"type": "string"},
+        "weeks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "week_number": {"type": "integer"},
+                    "theme": {"type": "string"},
+                    "notes": {"type": "string"},
+                    "days": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "date": {"type": "string"},
+                                "day_of_week": {"type": "string"},
+                                "workout_type": {"type": "string"},
+                                "target_distance_km": {"type": "number"},
+                                "target_pace_display": {"type": "string"},
+                                "description": {"type": "string"},
+                                "notes": {"type": "string"},
+                            },
+                            "required": ["date", "day_of_week", "workout_type", "description"],
+                        },
+                    },
+                },
+                "required": ["week_number", "days"],
+            },
+        },
+    },
+    "required": ["phase", "overview", "weeks"],
+}
+
 
 def _build_plan_adherence_context(
     db: Session, reference_date: date, user_id: int = DEFAULT_USER_ID
@@ -1510,6 +1602,7 @@ def generate_training_plan(
 
             last_exc: Exception = RuntimeError("no attempts made")
             raw = None
+            plan_data: dict | None = None
             for attempt in range(_MAX_RETRIES):
                 try:
                     if provider == "gemini":
@@ -1520,6 +1613,8 @@ def generate_training_plan(
                                 contents=plan_prompt,
                                 config=_genai_types.GenerateContentConfig(
                                     system_instruction=_PLAN_SYSTEM_PROMPT,
+                                    response_mime_type="application/json",
+                                    response_schema=_PLAN_GEMINI_RESPONSE_SCHEMA,
                                 ),
                             )
                         except _genai_errors.ServerError as exc:
@@ -1534,8 +1629,10 @@ def generate_training_plan(
                         try:
                             response = client.messages.create(
                                 model=model,
-                                max_tokens=4096,
+                                max_tokens=_PLAN_MAX_TOKENS,
                                 system=_PLAN_SYSTEM_PROMPT,
+                                tools=[_PLAN_TOOL_SCHEMA],
+                                tool_choice={"type": "tool", "name": "generate_plan"},
                                 messages=[{"role": "user", "content": plan_prompt}],
                             )
                         except (
@@ -1552,7 +1649,18 @@ def generate_training_plan(
                             anthropic.NotFoundError,
                         ) as exc:
                             raise AIFatalError(str(exc)) from exc
-                        raw = response.content[0].text
+                        # Extract the structured dict from the guaranteed tool_use block.
+                        for block in response.content:
+                            if block.type == "tool_use" and block.name == "generate_plan":
+                                plan_data = block.input
+                                raw = json.dumps(plan_data)
+                                break
+                        # Fallback: model returned text instead of a tool call.
+                        if plan_data is None:
+                            for block in response.content:
+                                if hasattr(block, "text"):
+                                    raw = block.text
+                                    break
                     break  # success
                 except AIFatalError:
                     raise
@@ -1568,7 +1676,8 @@ def generate_training_plan(
             else:
                 raise last_exc
 
-            plan_data = _parse_plan_json(raw)
+            if plan_data is None:
+                plan_data = _parse_plan_json(raw)
             plan = _store_training_plan(db, plan_data, week_start, raw, user_id)
             logger.info(
                 "Training plan generated: %d weeks, phase=%s, week_start=%s",

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -164,7 +164,7 @@ machinery already computed and stored per activity.
 `app/api.py` (trend endpoint), `app/ai_coach.py` context,
 `frontend/src/components/trends/*` + hooks/types.
 
-#### P1-3 · Harden AI plan generation (structured output)
+#### ✅ P1-3 · Harden AI plan generation (structured output)
 **What:** Replace fragile free-text JSON parsing in `generate_training_plan` with
 provider **structured-output / tool-use** (Claude tool schema; Gemini
 `response_schema`) so the model returns schema-valid plan objects, and raise the

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -709,3 +709,136 @@ def test_detect_realignment_expired_dismiss_prompts(db):
     db.commit()
     result = ai_coach.detect_plan_realignment(db, ref)
     assert result["should_prompt"] is True
+
+
+# --- generate_training_plan – P1-3 structured output ---
+
+def _minimal_plan_dict(week_start: date) -> dict:
+    """Smallest valid plan dict: 4 rest weeks starting from week_start."""
+    from datetime import timedelta
+    weeks = []
+    for w in range(4):
+        days = []
+        for d in range(7):
+            day = week_start + timedelta(days=w * 7 + d)
+            days.append({
+                "date": day.isoformat(),
+                "day_of_week": day.strftime("%A"),
+                "workout_type": "rest",
+                "description": "Rest day",
+                "notes": None,
+                "target_distance_km": None,
+                "target_pace_display": None,
+            })
+        weeks.append({"week_number": w + 1, "theme": "Base", "notes": "Easy week", "days": days})
+    return {"phase": "base", "overview": "Test plan overview", "weeks": weeks}
+
+
+def test_generate_training_plan_claude_tool_use(db, patch_db_session, monkeypatch):
+    """Claude path: plan_data is extracted from the tool_use block; no JSON parsing needed."""
+    patch_db_session(ai_coach)
+
+    week_start = date(2026, 7, 7)  # next Monday after 2026-07-03
+    plan_dict = _minimal_plan_dict(week_start)
+
+    tool_block = MagicMock()
+    tool_block.type = "tool_use"
+    tool_block.name = "generate_plan"
+    tool_block.input = plan_dict
+
+    mock_response = MagicMock()
+    mock_response.content = [tool_block]
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+
+    monkeypatch.setattr(ai_coach, "_get_ai_config", lambda db, user_id=1: ("claude", "claude-sonnet-4-6"))
+    monkeypatch.setattr(ai_coach.anthropic, "Anthropic", lambda **kw: mock_client)
+
+    result = ai_coach.generate_training_plan(reference_date=date(2026, 7, 3))
+
+    assert result is not None
+    assert result.phase == "base"
+    assert result.plan_weeks == 4
+    # raw_json is the serialised tool input, not a free-text response
+    assert result.raw_json == json.dumps(plan_dict)
+
+    kwargs = mock_client.messages.create.call_args[1]
+    assert "tools" in kwargs
+    assert kwargs["tool_choice"] == {"type": "tool", "name": "generate_plan"}
+    assert kwargs["max_tokens"] == ai_coach._PLAN_MAX_TOKENS
+
+
+def test_generate_training_plan_gemini_structured_output(db, patch_db_session, monkeypatch):
+    """Gemini path: response_schema + response_mime_type enforce schema-valid JSON."""
+    patch_db_session(ai_coach)
+
+    week_start = date(2026, 7, 7)
+    plan_dict = _minimal_plan_dict(week_start)
+    plan_json = json.dumps(plan_dict)
+
+    mock_response = MagicMock()
+    mock_response.text = plan_json
+
+    mock_models = MagicMock()
+    mock_models.generate_content.return_value = mock_response
+
+    mock_gemini_client = MagicMock()
+    mock_gemini_client.models = mock_models
+
+    monkeypatch.setattr(ai_coach, "_get_ai_config", lambda db, user_id=1: ("gemini", "gemini-2.5-flash"))
+    monkeypatch.setattr(ai_coach.genai, "Client", lambda **kw: mock_gemini_client)
+
+    result = ai_coach.generate_training_plan(reference_date=date(2026, 7, 3))
+
+    assert result is not None
+    assert result.phase == "base"
+    assert result.plan_weeks == 4
+
+    kwargs = mock_models.generate_content.call_args[1]
+    config = kwargs["config"]
+    assert config.response_mime_type == "application/json"
+    assert config.response_schema is not None
+
+
+def test_generate_training_plan_claude_text_fallback(db, patch_db_session, monkeypatch):
+    """When Claude returns plain text (no tool call), _parse_plan_json is used as fallback."""
+    patch_db_session(ai_coach)
+
+    week_start = date(2026, 7, 7)
+    plan_dict = _minimal_plan_dict(week_start)
+    plan_json = json.dumps(plan_dict)
+
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = plan_json
+    # Ensure hasattr(block, "text") returns True (MagicMock does this by default)
+
+    mock_response = MagicMock()
+    mock_response.content = [text_block]
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+
+    monkeypatch.setattr(ai_coach, "_get_ai_config", lambda db, user_id=1: ("claude", "claude-sonnet-4-6"))
+    monkeypatch.setattr(ai_coach.anthropic, "Anthropic", lambda **kw: mock_client)
+
+    result = ai_coach.generate_training_plan(reference_date=date(2026, 7, 3))
+
+    assert result is not None
+    assert result.phase == "base"
+    assert result.plan_weeks == 4
+
+
+def test_generate_training_plan_exception_returns_none(db, patch_db_session, monkeypatch):
+    """Any unexpected exception during generation returns None without raising."""
+    patch_db_session(ai_coach)
+
+    def _raise(*a, **kw):
+        raise RuntimeError("unexpected boom")
+
+    monkeypatch.setattr(ai_coach, "_get_ai_config", _raise)
+
+    result = ai_coach.generate_training_plan(reference_date=date(2026, 7, 3))
+
+    assert result is None


### PR DESCRIPTION
Replace fragile free-text JSON parsing in generate_training_plan with
provider-native structured output:

- Claude: tool-use API (_PLAN_TOOL_SCHEMA) forces a schema-valid plan
  dict from the tool_use block, bypassing json.loads entirely; raises
  max_tokens from 4096 to 16000 (_PLAN_MAX_TOKENS) so 4-week plans
  cannot truncate mid-JSON
- Gemini: response_mime_type="application/json" + response_schema
  (_PLAN_GEMINI_RESPONSE_SCHEMA) enforce structured output at the API
  level
- _parse_plan_json retained as fence-stripping fallback for the Claude
  text path

Adds 4 tests covering the Claude tool-use path, Gemini structured path,
Claude text fallback, and graceful exception handling.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RTpSdaEzeVG2YYVRxNnDBe