### PR TITLE
feat(P2-1): durable AI task queue replacing daemon threads

### DIFF
--- a/alembic/versions/h1i2j3k4l5m6_add_ai_jobs.py
+++ b/alembic/versions/h1i2j3k4l5m6_add_ai_jobs.py
@@ -1,0 +1,47 @@
+"""add ai_jobs table for durable task queue
+
+Revision ID: h1i2j3k4l5m6
+Revises: f6a7b8c9d0e1
+Create Date: 2026-06-29
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision: str = "h1i2j3k4l5m6"
+down_revision: Union[str, None] = "g8h9i0j1k2l3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    insp = inspect(op.get_bind())
+    if "ai_jobs" not in insp.get_table_names():
+        op.create_table(
+            "ai_jobs",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("user_id", sa.Integer(), nullable=False, default=1),
+            sa.Column("task_type", sa.String(50), nullable=False),
+            sa.Column("payload_json", sa.Text(), nullable=True),
+            sa.Column("status", sa.String(20), nullable=False, default="pending"),
+            sa.Column("attempts", sa.Integer(), nullable=False, default=0),
+            sa.Column("max_attempts", sa.Integer(), nullable=False, default=3),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("started_at", sa.DateTime(), nullable=True),
+            sa.Column("completed_at", sa.DateTime(), nullable=True),
+        )
+        op.create_index("ix_ai_jobs_user_id", "ai_jobs", ["user_id"])
+        op.create_index("ix_ai_jobs_status", "ai_jobs", ["status"])
+        op.create_index("ix_ai_jobs_created_at", "ai_jobs", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ai_jobs_created_at", "ai_jobs")
+    op.drop_index("ix_ai_jobs_status", "ai_jobs")
+    op.drop_index("ix_ai_jobs_user_id", "ai_jobs")
+    op.drop_table("ai_jobs")

--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -812,6 +812,80 @@ def _save_error_insight(
         logger.exception("Failed to save error insight for activity %s", activity_id)
 
 
+def enqueue_job(task_type: str, payload: dict, user_id: int) -> int:
+    """Persist a pending AIJob and return its id.
+
+    Called from API request handlers to hand off AI work to the background
+    worker instead of blocking the request or spawning a daemon thread.
+    """
+    from app.models import AIJob
+
+    job = AIJob(
+        user_id=user_id,
+        task_type=task_type,
+        payload_json=json.dumps(payload),
+        status="pending",
+        attempts=0,
+        max_attempts=3,
+    )
+    with db_session() as db:
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        return job.id
+
+
+def execute_job(job_id: int) -> None:
+    """Claim and execute a single AIJob. Called by the APScheduler worker.
+
+    Atomically marks the job running, dispatches to the appropriate AI
+    function, then records done or schedules a retry (up to max_attempts).
+    """
+    from app.models import AIJob
+
+    with db_session() as db:
+        job = db.query(AIJob).filter(AIJob.id == job_id).first()
+        if job is None or job.status not in ("pending",):
+            return
+        job.status = "running"
+        job.started_at = datetime.now(timezone.utc)
+        job.attempts += 1
+        db.commit()
+        task_type = job.task_type
+        payload = json.loads(job.payload_json or "{}")
+        attempts = job.attempts
+        max_attempts = job.max_attempts
+        user_id = job.user_id
+
+    try:
+        if task_type == "analyze_activity":
+            analyze_activity_force(payload["activity_id"])
+        elif task_type == "analyze_feedback":
+            analyze_activity_with_feedback(payload["activity_id"])
+        elif task_type == "generate_plan":
+            generate_training_plan(user_id=user_id)
+        elif task_type == "weekly_review":
+            weekly_review(user_id=user_id)
+        else:
+            raise ValueError(f"Unknown task_type: {task_type!r}")
+
+        with db_session() as db:
+            job = db.query(AIJob).filter(AIJob.id == job_id).first()
+            if job:
+                job.status = "done"
+                job.completed_at = datetime.now(timezone.utc)
+                db.commit()
+    except Exception as exc:
+        logger.exception("Job %s (%s) failed on attempt %s/%s", job_id, task_type, attempts, max_attempts)
+        with db_session() as db:
+            job = db.query(AIJob).filter(AIJob.id == job_id).first()
+            if job:
+                job.error_message = str(exc)[:1000]
+                job.completed_at = datetime.now(timezone.utc)
+                job.status = "failed" if attempts >= max_attempts else "pending"
+                db.commit()
+
+
 def _load_zones(db: Session) -> dict[str, list[MetricZone]]:
     """Load metric zones from the database, grouped by metric_key."""
     zones_by_metric: dict[str, list[MetricZone]] = {}

--- a/app/api.py
+++ b/app/api.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 from app.auth import get_current_user
 from app.database import get_db
 from app.models import (
+    AIJob,
     Activity,
     AthleteProfile,
     ChatMessage,
@@ -79,6 +80,8 @@ from app.schemas import (
     PushWorkoutResponse,
     AerobicTrendPoint,
     AerobicTrendsResponse,
+    AIJobEnqueuedResponse,
+    AIJobResponse,
 )
 from app import training_load
 from app import threshold as threshold_mod
@@ -1153,23 +1156,16 @@ def api_get_training_plan(
     return _build_plan_response(plan, db)
 
 
-@api_router.post("/training-plan/generate", response_model=TrainingPlanResponse | None)
+@api_router.post("/training-plan/generate", response_model=AIJobEnqueuedResponse)
 def api_generate_training_plan(current_user: User = Depends(get_current_user)):
-    """Trigger AI plan generation and return the new plan synchronously.
+    """Enqueue AI plan generation and return the job id for polling.
 
-    Generation typically takes 5–15 seconds. The function opens its own DB
-    session internally, so we re-query via a fresh dependency after completion.
+    Clients poll GET /api/v1/jobs/{job_id} until status is 'done', then
+    refresh the training plan via GET /api/v1/training-plan.
     """
-    from app.ai_coach import generate_training_plan
-    from app.database import db_session as make_session
-    plan = generate_training_plan(user_id=current_user.id)
-    if plan is None:
-        raise HTTPException(status_code=500, detail="Plan generation failed — check AI config")
-    with make_session() as fresh_db:
-        db_plan = fresh_db.query(TrainingPlan).filter(TrainingPlan.id == plan.id).first()
-        if not db_plan:
-            raise HTTPException(status_code=500, detail="Plan not found after generation")
-        return _build_plan_response(db_plan, fresh_db)
+    from app.ai_coach import enqueue_job
+    job_id = enqueue_job("generate_plan", {}, current_user.id)
+    return AIJobEnqueuedResponse(status="queued", job_id=job_id)
 
 
 @api_router.get("/training-plan/realignment-status", response_model=PlanRealignmentStatus)
@@ -1219,13 +1215,9 @@ def api_realign_plan(
         db.commit()
         return {"status": "dismissed", "until": dismiss_until}
 
-    # action == "regenerate"
-    from app.ai_coach import generate_training_plan
-    from app.database import db_session as make_session
-    plan = generate_training_plan(user_id=current_user.id)
-    if plan is None:
-        raise HTTPException(status_code=500, detail="Plan generation failed — check AI config")
-    # Clear dismiss snooze after generating a new plan
+    # action == "regenerate" — enqueue and return job id for polling
+    from app.ai_coach import enqueue_job
+    # Clear any existing dismiss snooze when the user triggers regeneration
     row = db.query(SyncStatus).filter(
         SyncStatus.user_id == current_user.id,
         SyncStatus.key == "plan_realignment_dismissed_until",
@@ -1233,11 +1225,8 @@ def api_realign_plan(
     if row:
         db.delete(row)
         db.commit()
-    with make_session() as fresh_db:
-        db_plan = fresh_db.query(TrainingPlan).filter(TrainingPlan.id == plan.id).first()
-        if not db_plan:
-            raise HTTPException(status_code=500, detail="Plan not found after generation")
-        return _build_plan_response(db_plan, fresh_db)
+    job_id = enqueue_job("generate_plan", {}, current_user.id)
+    return AIJobEnqueuedResponse(status="queued", job_id=job_id)
 
 
 @api_router.post("/training-plan/days/{day_id}/push-to-garmin", response_model=PushWorkoutResponse)
@@ -1463,9 +1452,9 @@ def api_trigger_analysis(
     )
     if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
-    from app.ai_coach import analyze_activity_force
-    threading.Thread(target=analyze_activity_force, args=(activity_id,), daemon=True).start()
-    return {"status": "accepted"}
+    from app.ai_coach import enqueue_job
+    job_id = enqueue_job("analyze_activity", {"activity_id": activity_id}, current_user.id)
+    return AIJobEnqueuedResponse(status="queued", job_id=job_id)
 
 
 @api_router.post("/activities/{activity_id}/feedback")
@@ -1496,9 +1485,9 @@ def api_submit_feedback(
     ).delete()
     db.commit()
 
-    from app.ai_coach import analyze_activity_with_feedback
-    threading.Thread(target=analyze_activity_with_feedback, args=(activity_id,), daemon=True).start()
-    return {"status": "accepted"}
+    from app.ai_coach import enqueue_job
+    job_id = enqueue_job("analyze_feedback", {"activity_id": activity_id}, current_user.id)
+    return AIJobEnqueuedResponse(status="queued", job_id=job_id)
 
 
 @api_router.post("/sync/{sync_type}")
@@ -1517,6 +1506,19 @@ def api_trigger_sync(sync_type: str, current_user: User = Depends(get_current_us
     else:
         raise HTTPException(status_code=400, detail=f"Unknown sync type: {sync_type}")
     return {"status": "accepted"}
+
+
+@api_router.get("/jobs/{job_id}", response_model=AIJobResponse)
+def api_get_job(
+    job_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return the status of an AI background job owned by the current user."""
+    job = db.query(AIJob).filter(AIJob.id == job_id, AIJob.user_id == current_user.id).first()
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
 
 
 def _sync_calendar_for_user(user_id: int) -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -191,6 +191,36 @@ def _scheduled_plan_generation():
             logger.exception("Plan generation failed for user %s", user.id)
 
 
+def _worker_run_pending_jobs():
+    """APScheduler job: claim and execute pending AIJobs.
+
+    Picks up at most 5 pending jobs per poll cycle (oldest first) and runs
+    them synchronously in the scheduler thread. Each job atomically transitions
+    pending → running → done|failed, with retries up to max_attempts.
+    """
+    from app.ai_coach import execute_job
+    from app.models import AIJob
+
+    with db_session() as db:
+        pending = (
+            db.query(AIJob)
+            .filter(
+                AIJob.status == "pending",
+                AIJob.attempts < AIJob.max_attempts,
+            )
+            .order_by(AIJob.created_at)
+            .limit(5)
+            .all()
+        )
+        job_ids = [j.id for j in pending]
+
+    for job_id in job_ids:
+        try:
+            execute_job(job_id)
+        except Exception:
+            logger.exception("Worker: unexpected error executing job %s", job_id)
+
+
 def _run_backfill():
     """Run historical backfill in a background thread."""
     from app.garmin_sync import backfill_activities, backfill_daily_summaries, sync_athlete_profile
@@ -263,6 +293,15 @@ async def lifespan(app: FastAPI):
         CronTrigger(day_of_week="sun", hour=9, minute=0, timezone=tz),
         id="plan_generation",
         name="Training Plan Generation",
+        replace_existing=True,
+    )
+
+    # Poll the AI job ledger every 30 seconds and execute pending jobs
+    scheduler.add_job(
+        _worker_run_pending_jobs,
+        IntervalTrigger(seconds=30),
+        id="ai_job_worker",
+        name="AI Job Worker",
         replace_existing=True,
     )
 

--- a/app/models.py
+++ b/app/models.py
@@ -334,6 +334,30 @@ class TrainingPlan(Base):
     raw_json = Column(Text, nullable=True)        # full AI JSON output
 
 
+class AIJob(Base):
+    """Persisted job ledger for durable AI task execution.
+
+    Replaces ephemeral daemon threads and blocking inline calls. The APScheduler
+    worker polls for pending rows, marks them running, executes, and records the
+    outcome. Failed jobs are retried up to max_attempts before being marked failed.
+    """
+
+    __tablename__ = "ai_jobs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
+    task_type = Column(String(50), nullable=False)   # analyze_activity | analyze_feedback | generate_plan | weekly_review
+    payload_json = Column(Text, nullable=True)        # JSON task args (e.g. {"activity_id": 123})
+    status = Column(String(20), nullable=False, default="pending", index=True)  # pending | running | done | failed
+    attempts = Column(Integer, nullable=False, default=0)
+    max_attempts = Column(Integer, nullable=False, default=3)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=_utcnow, index=True)
+    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
+    started_at = Column(DateTime, nullable=True)
+    completed_at = Column(DateTime, nullable=True)
+
+
 class ChatMessage(Base):
     """Persisted multi-turn chat messages between the athlete and the AI coach."""
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -629,3 +629,23 @@ class PacingPushRequest(BaseModel):
     strategy: str = "even"
     split_unit: str = "km"
     target_time_sec: int | None = None
+
+
+class AIJobEnqueuedResponse(BaseModel):
+    status: str
+    job_id: int
+
+
+class AIJobResponse(BaseModel):
+    id: int
+    task_type: str
+    status: str          # pending | running | done | failed
+    attempts: int
+    max_attempts: int
+    error_message: str | None = None
+    created_at: datetime | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+    class Config:
+        from_attributes = True

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -181,7 +181,7 @@ provider call sites), possibly `app/config.py` (per-call token budgets).
 
 ### P2 — Reliability, breadth, and coaching depth
 
-#### P2-1 · Durable AI task queue
+#### ✅ P2-1 · Durable AI task queue
 **What:** Replace inline / short-lived-daemon-thread AI execution (on-demand
 re-analysis and plan generation) with a **persisted job ledger** + worker, so a
 slow/failed provider call neither blocks the request nor is lost on restart, and

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiGet, apiPost, apiPut, apiDelete } from './client'
 import type {
+  AIJobEnqueuedResponse,
   AIJobResponse,
   TodayResponse,
   ActivitySummary,
@@ -157,7 +158,7 @@ export function useJobStatus(jobId: number | null) {
 
 export function useTriggerAnalysis() {
   return useMutation({
-    mutationFn: (id: number) => apiPost<AIJobResponse>(`/activities/${id}/analyze`),
+    mutationFn: (id: number) => apiPost<AIJobEnqueuedResponse>(`/activities/${id}/analyze`),
   })
 }
 
@@ -165,7 +166,7 @@ export function useSubmitFeedback() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: ({ id, feedback }: { id: number; feedback: FeedbackRequest }) =>
-      apiPost<AIJobResponse>(`/activities/${id}/feedback`, feedback),
+      apiPost<AIJobEnqueuedResponse>(`/activities/${id}/feedback`, feedback),
     onSuccess: (_, { id }) => {
       // Immediately refresh so the card shows the pending state; job polling
       // in ActivityDetailView handles subsequent refreshes on completion.
@@ -297,7 +298,7 @@ export function useTrainingPlan() {
 
 export function useGenerateTrainingPlan() {
   return useMutation({
-    mutationFn: () => apiPost<AIJobResponse>('/training-plan/generate', {}),
+    mutationFn: () => apiPost<AIJobEnqueuedResponse>('/training-plan/generate', {}),
   })
 }
 
@@ -333,7 +334,7 @@ export function useRealignPlan() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (action: 'regenerate' | 'dismiss') =>
-      apiPost<AIJobResponse | { status: string; until: string }>('/training-plan/realign', { action }),
+      apiPost<AIJobEnqueuedResponse | { status: string; until: string }>('/training-plan/realign', { action }),
     onSuccess: (_data, action) => {
       if (action === 'dismiss') {
         qc.invalidateQueries({ queryKey: ['realignment-status'] })

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiGet, apiPost, apiPut, apiDelete } from './client'
 import type {
+  AIJobResponse,
   TodayResponse,
   ActivitySummary,
   ActivityDetail,
@@ -142,13 +143,21 @@ export function useTriggerSync() {
   })
 }
 
-export function useTriggerAnalysis() {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (id: number) => apiPost<{ status: string }>(`/activities/${id}/analyze`),
-    onSuccess: (_, id) => {
-      setTimeout(() => qc.invalidateQueries({ queryKey: ['activity', id] }), 5000)
+export function useJobStatus(jobId: number | null) {
+  return useQuery({
+    queryKey: ['job', jobId],
+    queryFn: () => apiGet<AIJobResponse>(`/jobs/${jobId}`),
+    enabled: jobId != null && jobId > 0,
+    refetchInterval: (query) => {
+      const s = query.state.data?.status
+      return s === 'pending' || s === 'running' ? 2000 : false
     },
+  })
+}
+
+export function useTriggerAnalysis() {
+  return useMutation({
+    mutationFn: (id: number) => apiPost<AIJobResponse>(`/activities/${id}/analyze`),
   })
 }
 
@@ -156,11 +165,11 @@ export function useSubmitFeedback() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: ({ id, feedback }: { id: number; feedback: FeedbackRequest }) =>
-      apiPost<{ status: string }>(`/activities/${id}/feedback`, feedback),
+      apiPost<AIJobResponse>(`/activities/${id}/feedback`, feedback),
     onSuccess: (_, { id }) => {
+      // Immediately refresh so the card shows the pending state; job polling
+      // in ActivityDetailView handles subsequent refreshes on completion.
       qc.invalidateQueries({ queryKey: ['activity', id] })
-      setTimeout(() => qc.invalidateQueries({ queryKey: ['activity', id] }), 5000)
-      setTimeout(() => qc.invalidateQueries({ queryKey: ['activity', id] }), 12000)
     },
   })
 }
@@ -287,12 +296,8 @@ export function useTrainingPlan() {
 }
 
 export function useGenerateTrainingPlan() {
-  const qc = useQueryClient()
   return useMutation({
-    mutationFn: () => apiPost<TrainingPlanResponse>('/training-plan/generate', {}),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['training-plan'] })
-    },
+    mutationFn: () => apiPost<AIJobResponse>('/training-plan/generate', {}),
   })
 }
 
@@ -328,10 +333,12 @@ export function useRealignPlan() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (action: 'regenerate' | 'dismiss') =>
-      apiPost<unknown>('/training-plan/realign', { action }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['training-plan'] })
-      qc.invalidateQueries({ queryKey: ['realignment-status'] })
+      apiPost<AIJobResponse | { status: string; until: string }>('/training-plan/realign', { action }),
+    onSuccess: (_data, action) => {
+      if (action === 'dismiss') {
+        qc.invalidateQueries({ queryKey: ['realignment-status'] })
+      }
+      // For 'regenerate', the caller polls via useJobStatus and invalidates on done
     },
   })
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -3,6 +3,18 @@ export interface UserResponse {
   full_name: string | null
 }
 
+export interface AIJobResponse {
+  id: number
+  task_type: string
+  status: 'pending' | 'running' | 'done' | 'failed'
+  attempts: number
+  max_attempts: number
+  error_message: string | null
+  created_at: string | null
+  started_at: string | null
+  completed_at: string | null
+}
+
 export interface ActivitySummary {
   id: number
   garmin_id: number | null

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -3,6 +3,11 @@ export interface UserResponse {
   full_name: string | null
 }
 
+export interface AIJobEnqueuedResponse {
+  status: string
+  job_id: number
+}
+
 export interface AIJobResponse {
   id: number
   task_type: string

--- a/frontend/src/components/activity-detail/ActivityDetailView.tsx
+++ b/frontend/src/components/activity-detail/ActivityDetailView.tsx
@@ -1,6 +1,8 @@
+import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, RotateCcw, Loader } from 'lucide-react'
-import { useActivity, useTriggerAnalysis } from '../../api/hooks'
+import { useActivity, useTriggerAnalysis, useJobStatus } from '../../api/hooks'
 import { getActivityColor, colorMap } from '../../utils/colors'
 import { formatDistance, formatDuration, formatPace } from '../../utils/formatting'
 import { format, parseISO } from '../../utils/date'
@@ -20,8 +22,28 @@ import './ActivityDetailView.css'
 export default function ActivityDetailView() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const qc = useQueryClient()
   const { data: activity, isLoading } = useActivity(Number(id) || 0)
   const triggerAnalysis = useTriggerAnalysis()
+  const [analysisJobId, setAnalysisJobId] = useState<number | null>(null)
+  const { data: analysisJob } = useJobStatus(analysisJobId)
+
+  const isAnalyzing =
+    triggerAnalysis.isPending ||
+    (analysisJobId != null && analysisJob?.status !== 'done' && analysisJob?.status !== 'failed')
+
+  useEffect(() => {
+    if (analysisJob?.status === 'done' || analysisJob?.status === 'failed') {
+      qc.invalidateQueries({ queryKey: ['activity', Number(id) || 0] })
+      setAnalysisJobId(null)
+    }
+  }, [analysisJob?.status, id, qc])
+
+  function handleReanalyze() {
+    triggerAnalysis.mutate(activity!.id, {
+      onSuccess: (data) => { if (data?.id) setAnalysisJobId(data.id) },
+    })
+  }
 
   if (isLoading) return <div className="spinner" />
   if (!activity) return <div className="empty-state">Activity not found</div>
@@ -164,8 +186,8 @@ export default function ActivityDetailView() {
         {activity.insight ? (
           <AiInsightCard
             insight={activity.insight}
-            onReanalyze={() => triggerAnalysis.mutate(activity.id)}
-            isAnalyzing={triggerAnalysis.isPending}
+            onReanalyze={handleReanalyze}
+            isAnalyzing={isAnalyzing}
           />
         ) : activity.feedback_rating ? (
           <section className="detail-section">

--- a/frontend/src/components/activity-detail/ActivityDetailView.tsx
+++ b/frontend/src/components/activity-detail/ActivityDetailView.tsx
@@ -41,7 +41,7 @@ export default function ActivityDetailView() {
 
   function handleReanalyze() {
     triggerAnalysis.mutate(activity!.id, {
-      onSuccess: (data) => { if (data?.id) setAnalysisJobId(data.id) },
+      onSuccess: (data) => { if (data?.job_id) setAnalysisJobId(data.job_id) },
     })
   }
 

--- a/frontend/src/components/plan/PlanView.tsx
+++ b/frontend/src/components/plan/PlanView.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import { ClipboardList, RefreshCw, ChevronLeft, ChevronRight, AlertTriangle, Settings2, Watch, CheckCircle } from 'lucide-react'
-import { useTrainingPlan, useGenerateTrainingPlan, useRealignmentStatus, useRealignPlan, usePushWorkoutToGarmin } from '../../api/hooks'
+import { useTrainingPlan, useGenerateTrainingPlan, useRealignmentStatus, useRealignPlan, usePushWorkoutToGarmin, useJobStatus } from '../../api/hooks'
 import type { TrainingPlanDay, TrainingPlanWeek } from '../../api/types'
 import './PlanView.css'
 
@@ -122,11 +123,19 @@ function DayCard({ day }: { day: TrainingPlanDay }) {
   )
 }
 
-function RealignmentBanner() {
+function RealignmentBanner({ onJobEnqueued }: { onJobEnqueued: (jobId: number) => void }) {
   const { data: status } = useRealignmentStatus()
   const { mutate: realign, isPending } = useRealignPlan()
 
   if (!status?.should_prompt) return null
+
+  function handleRegenerate() {
+    realign('regenerate', {
+      onSuccess: (data) => {
+        if (data && 'job_id' in data) onJobEnqueued(data.job_id)
+      },
+    })
+  }
 
   return (
     <div className="realignment-banner">
@@ -139,7 +148,7 @@ function RealignmentBanner() {
         <div className="realignment-actions">
           <button
             className="btn-primary realignment-btn"
-            onClick={() => realign('regenerate')}
+            onClick={handleRegenerate}
             disabled={isPending}
           >
             {isPending ? <RefreshCw size={13} className="spin" /> : null}
@@ -184,10 +193,29 @@ function WeekView({ week }: { week: TrainingPlanWeek }) {
 }
 
 export default function PlanView() {
+  const qc = useQueryClient()
   const { data: plan, isLoading } = useTrainingPlan()
-  const { mutate: generate, isPending: isGenerating } = useGenerateTrainingPlan()
+  const { mutate: generate } = useGenerateTrainingPlan()
   const [weekIndex, setWeekIndex] = useState(0)
+  const [planJobId, setPlanJobId] = useState<number | null>(null)
+  const { data: jobStatus } = useJobStatus(planJobId)
   const navigate = useNavigate()
+
+  const isGenerating = planJobId != null && jobStatus?.status !== 'done' && jobStatus?.status !== 'failed'
+
+  useEffect(() => {
+    if (jobStatus?.status === 'done' || jobStatus?.status === 'failed') {
+      qc.invalidateQueries({ queryKey: ['training-plan'] })
+      qc.invalidateQueries({ queryKey: ['realignment-status'] })
+      setPlanJobId(null)
+    }
+  }, [jobStatus?.status, qc])
+
+  function handleGenerate() {
+    generate(undefined, {
+      onSuccess: (data) => { if (data?.id) setPlanJobId(data.id) },
+    })
+  }
 
   if (isLoading) return <div className="spinner" />
 
@@ -200,7 +228,7 @@ export default function PlanView() {
           <p>Generate a personalised 4-week plan based on your fitness, readiness, and upcoming races.</p>
           <button
             className="btn-primary"
-            onClick={() => generate()}
+            onClick={handleGenerate}
             disabled={isGenerating}
           >
             {isGenerating ? (
@@ -222,7 +250,7 @@ export default function PlanView() {
 
   return (
     <div className="plan-view">
-      <RealignmentBanner />
+      <RealignmentBanner onJobEnqueued={setPlanJobId} />
 
       <div className="plan-header">
         <div className="plan-meta">
@@ -244,7 +272,7 @@ export default function PlanView() {
           </button>
           <button
             className="plan-regen-btn"
-            onClick={() => generate()}
+            onClick={handleGenerate}
             disabled={isGenerating}
             title="Regenerate plan"
           >

--- a/frontend/src/components/plan/PlanView.tsx
+++ b/frontend/src/components/plan/PlanView.tsx
@@ -213,7 +213,7 @@ export default function PlanView() {
 
   function handleGenerate() {
     generate(undefined, {
-      onSuccess: (data) => { if (data?.id) setPlanJobId(data.id) },
+      onSuccess: (data) => { if (data?.job_id) setPlanJobId(data.job_id) },
     })
   }
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -247,18 +247,24 @@ def no_threads(monkeypatch):
     monkeypatch.setattr(garmin_sync, "sync_calendar", MagicMock())
 
 
-def test_trigger_analysis_accepted(client, db, no_threads):
+def test_trigger_analysis_accepted(client, db, patch_db_session):
+    import app.ai_coach as ai_coach
+    patch_db_session(ai_coach)
     act = _add_activity(db, datetime(2026, 6, 1, 7, 0))
     resp = client.post(f"/api/v1/activities/{act.id}/analyze")
     assert resp.status_code == 200
-    assert resp.json()["status"] == "accepted"
+    body = resp.json()
+    assert body["status"] == "queued"
+    assert isinstance(body["job_id"], int)
 
 
 def test_trigger_analysis_404(client, no_threads):
     assert client.post("/api/v1/activities/999/analyze").status_code == 404
 
 
-def test_submit_feedback(client, db, no_threads):
+def test_submit_feedback(client, db, patch_db_session):
+    import app.ai_coach as ai_coach
+    patch_db_session(ai_coach)
     act = _add_activity(db, datetime(2026, 6, 1, 7, 0))
     db.add(Insight(trigger_type="activity", trigger_id=act.id, content="old", summary="old"))
     db.commit()
@@ -267,6 +273,9 @@ def test_submit_feedback(client, db, no_threads):
         json={"rating": "bad", "tags": ["tough_pace"], "text": "legs heavy"},
     )
     assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "queued"
+    assert isinstance(body["job_id"], int)
     db.expire_all()
     refreshed = db.get(Activity, act.id)
     assert refreshed.feedback_rating == "bad"
@@ -402,30 +411,23 @@ def test_realign_dismiss_idempotent(client, db):
     assert second == first  # same date since both calls happen on the same day
 
 
-def test_realign_regenerate(client, db, monkeypatch, patch_db_session):
-    import app.database as _app_db
-    plan = _seed_plan_and_days(db, [])
-    # Stub the AI generation to return the existing plan's id
-    class _FakePlan:
-        id = plan.id
-    monkeypatch.setattr("app.ai_coach.generate_training_plan", lambda *a, **kw: _FakePlan())
-    # Redirect db_session (used by the endpoint's make_session) to the test DB
-    patch_db_session(_app_db)
+def test_realign_regenerate(client, db, patch_db_session):
+    import app.ai_coach as ai_coach
+    _seed_plan_and_days(db, [])
+    patch_db_session(ai_coach)
     resp = client.post("/api/v1/training-plan/realign", json={"action": "regenerate"})
     assert resp.status_code == 200
     body = resp.json()
-    assert "id" in body
+    assert body["status"] == "queued"
+    assert isinstance(body["job_id"], int)
 
 
-def test_realign_regenerate_clears_dismiss(client, db, monkeypatch, patch_db_session):
-    import app.database as _app_db
-    plan = _seed_plan_and_days(db, [])
+def test_realign_regenerate_clears_dismiss(client, db, patch_db_session):
+    import app.ai_coach as ai_coach
+    _seed_plan_and_days(db, [])
     db.add(SyncStatus(key="plan_realignment_dismissed_until", value="2099-01-01"))
     db.commit()
-    class _FakePlan:
-        id = plan.id
-    monkeypatch.setattr("app.ai_coach.generate_training_plan", lambda *a, **kw: _FakePlan())
-    patch_db_session(_app_db)
+    patch_db_session(ai_coach)
     client.post("/api/v1/training-plan/realign", json={"action": "regenerate"})
     db.expire_all()
     row = db.query(SyncStatus).filter(

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -1,0 +1,270 @@
+"""Tests for the durable AI job queue (P2-1)."""
+import json
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.models import AIJob, Activity
+from app.ai_coach import enqueue_job, execute_job
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_activity(db, user_id=1):
+    act = Activity(
+        user_id=user_id,
+        garmin_id=123456,
+        activity_type="running",
+        name="Test Run",
+        started_at=datetime(2026, 6, 1, 7, 0),
+        duration_sec=3600,
+        distance_m=10000,
+    )
+    db.add(act)
+    db.commit()
+    db.refresh(act)
+    return act
+
+
+# ---------------------------------------------------------------------------
+# enqueue_job
+# ---------------------------------------------------------------------------
+
+def test_enqueue_job_creates_pending_row(db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("analyze_activity", {"activity_id": 99}, user_id=1)
+
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job is not None
+    assert job.status == "pending"
+    assert job.task_type == "analyze_activity"
+    assert json.loads(job.payload_json) == {"activity_id": 99}
+    assert job.attempts == 0
+    assert job.max_attempts == 3
+    assert job.user_id == 1
+
+
+def test_enqueue_job_returns_integer_id(db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("generate_plan", {}, user_id=2)
+    assert isinstance(job_id, int)
+    assert job_id > 0
+
+
+# ---------------------------------------------------------------------------
+# execute_job — dispatch routing
+# ---------------------------------------------------------------------------
+
+def test_execute_job_dispatches_analyze_activity(db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    act = _make_activity(db)
+    job_id = enqueue_job("analyze_activity", {"activity_id": act.id}, user_id=1)
+
+    with patch.object(ai_mod, "analyze_activity_force") as mock_fn:
+        execute_job(job_id)
+
+    mock_fn.assert_called_once_with(act.id)
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "done"
+    assert job.attempts == 1
+    assert job.completed_at is not None
+
+
+def test_execute_job_dispatches_analyze_feedback(db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    act = _make_activity(db)
+    job_id = enqueue_job("analyze_feedback", {"activity_id": act.id}, user_id=1)
+
+    with patch.object(ai_mod, "analyze_activity_with_feedback") as mock_fn:
+        execute_job(job_id)
+
+    mock_fn.assert_called_once_with(act.id)
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "done"
+
+
+def test_execute_job_dispatches_generate_plan(db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("generate_plan", {}, user_id=1)
+
+    with patch.object(ai_mod, "generate_training_plan") as mock_fn:
+        execute_job(job_id)
+
+    mock_fn.assert_called_once_with(user_id=1)
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "done"
+
+
+def test_execute_job_dispatches_weekly_review(db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("weekly_review", {}, user_id=5)
+
+    with patch.object(ai_mod, "weekly_review") as mock_fn:
+        execute_job(job_id)
+
+    mock_fn.assert_called_once_with(user_id=5)
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "done"
+
+
+# ---------------------------------------------------------------------------
+# execute_job — retry and failure logic
+# ---------------------------------------------------------------------------
+
+def test_execute_job_marks_pending_on_first_failure(db, patch_db_session):
+    """A job that fails before max_attempts should become pending for retry."""
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("generate_plan", {}, user_id=1)
+
+    with patch.object(ai_mod, "generate_training_plan", side_effect=RuntimeError("timeout")):
+        execute_job(job_id)
+
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "pending"   # retry eligible
+    assert job.attempts == 1
+    assert "timeout" in job.error_message
+
+
+def test_execute_job_marks_failed_when_max_attempts_reached(db, patch_db_session):
+    """A job that exhausts all retries should be permanently failed."""
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("generate_plan", {}, user_id=1)
+
+    # Exhaust all 3 attempts
+    for _ in range(3):
+        with patch.object(ai_mod, "generate_training_plan", side_effect=RuntimeError("boom")):
+            execute_job(job_id)
+        db.expire_all()  # refresh from DB between attempts
+
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "failed"
+    assert job.attempts == 3
+
+
+def test_execute_job_ignores_already_running_or_done_job(db, patch_db_session):
+    """execute_job is a no-op for jobs not in 'pending' status."""
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("generate_plan", {}, user_id=1)
+
+    # Mark it done manually
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    job.status = "done"
+    db.commit()
+
+    with patch.object(ai_mod, "generate_training_plan") as mock_fn:
+        execute_job(job_id)
+
+    mock_fn.assert_not_called()
+
+
+def test_execute_job_raises_on_unknown_task_type(db, patch_db_session):
+    """An unknown task_type should be marked failed immediately."""
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("unknown_type", {}, user_id=1)
+    # Force attempts to max so it hits 'failed' on first error
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    job.attempts = 2  # next attempt = 3 = max_attempts
+    db.commit()
+
+    execute_job(job_id)
+
+    db.expire_all()
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "failed"
+    assert "unknown_type" in job.error_message.lower()
+
+
+# ---------------------------------------------------------------------------
+# API endpoint: GET /jobs/{id}
+# ---------------------------------------------------------------------------
+
+def test_api_get_job_returns_status(client, db):
+    job = AIJob(
+        user_id=1,
+        task_type="analyze_activity",
+        payload_json='{"activity_id": 1}',
+        status="pending",
+        attempts=0,
+        max_attempts=3,
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    resp = client.get(f"/api/v1/jobs/{job.id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == job.id
+    assert body["status"] == "pending"
+    assert body["task_type"] == "analyze_activity"
+    assert body["attempts"] == 0
+    assert body["max_attempts"] == 3
+
+
+def test_api_get_job_404_for_unknown(client):
+    resp = client.get("/api/v1/jobs/99999")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# API endpoint: POST /activities/{id}/analyze now returns job envelope
+# ---------------------------------------------------------------------------
+
+def test_api_analyze_returns_queued_job(client, db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    act = _make_activity(db)
+    resp = client.post(f"/api/v1/activities/{act.id}/analyze")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "queued"
+    assert isinstance(body["job_id"], int)
+
+    # Job row should exist in DB
+    job = db.query(AIJob).filter(AIJob.id == body["job_id"]).first()
+    assert job is not None
+    assert job.task_type == "analyze_activity"
+    assert json.loads(job.payload_json)["activity_id"] == act.id
+
+
+# ---------------------------------------------------------------------------
+# API endpoint: POST /training-plan/generate now returns job envelope
+# ---------------------------------------------------------------------------
+
+def test_api_generate_plan_returns_queued_job(client, db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    resp = client.post("/api/v1/training-plan/generate")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "queued"
+    assert isinstance(body["job_id"], int)
+
+    job = db.query(AIJob).filter(AIJob.id == body["job_id"]).first()
+    assert job is not None
+    assert job.task_type == "generate_plan"


### PR DESCRIPTION
Replaces ephemeral daemon threads and blocking synchronous AI calls with a
persisted ai_jobs ledger polled by an APScheduler worker every 30 s.

- app/models.py: new AIJob model (status, attempts, max_attempts, error_message,
  created/started/completed_at)
- alembic/versions/h1i2j3k4l5m6: migration for ai_jobs table
- app/ai_coach.py: enqueue_job() creates pending rows; execute_job() dispatches
  to analyze_activity_force / analyze_activity_with_feedback / generate_training_plan
  / weekly_review with retry-up-to-max_attempts logic
- app/main.py: _worker_run_pending_jobs() APScheduler job (IntervalTrigger 30 s)
  claims and runs up to 5 pending jobs per cycle
- app/api.py: POST /activities/{id}/analyze and /feedback now enqueue instead
  of spawning daemon threads; POST /training-plan/generate and realign(regenerate)
  return {status, job_id}; new GET /jobs/{id} status endpoint
- app/schemas.py: AIJobEnqueuedResponse, AIJobResponse
- frontend hooks/types: AIJobResponse type, useJobStatus polling hook (2 s
  interval while pending/running, stops on done/failed)
- PlanView: tracks planJobId state, polls useJobStatus, invalidates training-plan
  query on completion
- ActivityDetailView: tracks analysisJobId state, polls useJobStatus, invalidates
  activity query on completion
- tests: new tests/test_job_queue.py (14 tests); updated existing endpoint tests
  to match new job-queue response shape (518 total, all pass)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R2yRbkA79LuoTo6ouBbkLZ