### PR TITLE
feat(P3-2): incremental CTL/ATL/TSB and CP/CV compute

### DIFF
--- a/alembic/versions/i2j3k4l5m6n7_add_daily_load_series.py
+++ b/alembic/versions/i2j3k4l5m6n7_add_daily_load_series.py
@@ -1,0 +1,46 @@
+"""add daily_load_series table for incremental CTL/ATL/TSB compute
+
+Revision ID: i2j3k4l5m6n7
+Revises: h1i2j3k4l5m6
+Create Date: 2026-06-29
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision: str = "i2j3k4l5m6n7"
+down_revision: Union[str, None] = "h1i2j3k4l5m6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    insp = inspect(op.get_bind())
+    if "daily_load_series" not in insp.get_table_names():
+        op.create_table(
+            "daily_load_series",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("user_id", sa.Integer(), nullable=False, default=1),
+            sa.Column("date", sa.Date(), nullable=False),
+            sa.Column("tss", sa.Float(), nullable=False, default=0.0),
+            sa.Column("ctl", sa.Float(), nullable=False),
+            sa.Column("atl", sa.Float(), nullable=False),
+            sa.Column("tsb", sa.Float(), nullable=False),
+            sa.Column("acwr", sa.Float(), nullable=True),
+            sa.Column("ramp_rate_7d", sa.Float(), nullable=True),
+            sa.Column("ramp_rate_28d", sa.Float(), nullable=True),
+            sa.Column("injury_risk", sa.String(20), nullable=True),
+            sa.Column("computed_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("user_id", "date", name="uq_daily_load_series_user_date"),
+        )
+        op.create_index("ix_daily_load_series_user_id", "daily_load_series", ["user_id"])
+        op.create_index("ix_daily_load_series_date", "daily_load_series", ["date"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_daily_load_series_date", "daily_load_series")
+    op.drop_index("ix_daily_load_series_user_id", "daily_load_series")
+    op.drop_table("daily_load_series")

--- a/app/models.py
+++ b/app/models.py
@@ -371,6 +371,33 @@ class ChatMessage(Base):
     activity_id = Column(Integer, nullable=True)  # optional activity context
 
 
+class DailyLoadSeries(Base):
+    """Persisted daily CTL/ATL/TSB series for incremental training load computation.
+
+    One row per (user, date). Updated incrementally: only rows from the earliest
+    "dirty" date (a newly synced activity) are deleted and recomputed, so the EWMA
+    carries forward without re-scanning the full activity history.
+    """
+
+    __tablename__ = "daily_load_series"
+    __table_args__ = (
+        UniqueConstraint("user_id", "date", name="uq_daily_load_series_user_date"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
+    date = Column(Date, nullable=False, index=True)
+    tss = Column(Float, nullable=False, default=0.0)
+    ctl = Column(Float, nullable=False)
+    atl = Column(Float, nullable=False)
+    tsb = Column(Float, nullable=False)
+    acwr = Column(Float, nullable=True)
+    ramp_rate_7d = Column(Float, nullable=True)
+    ramp_rate_28d = Column(Float, nullable=True)
+    injury_risk = Column(String(20), nullable=True)
+    computed_at = Column(DateTime, default=_utcnow)
+
+
 class TrainingPlanDay(Base):
     """One scheduled day within a TrainingPlan."""
 

--- a/app/threshold.py
+++ b/app/threshold.py
@@ -296,11 +296,14 @@ def _confidence_and_note(
 # Individual estimates
 # ---------------------------------------------------------------------------
 
-def _estimate_critical_power(
-    curves: list[tuple[float, dict]]
+def _fit_critical_power_from_frontier(
+    frontier: list[_FrontierPoint],
 ) -> tuple[FieldEstimate, float | None, float | None]:
-    """Estimate CP (W), and the supporting W' (J) and Pmax (W)."""
-    frontier = _build_frontier(curves, "power")
+    """Fit the CP model from a pre-built frontier (skips the _build_frontier call).
+
+    Used by both the full-recompute path and the incremental merge path so the
+    fitting logic is not duplicated.
+    """
     if not frontier:
         return _empty("No power data in recent activities."), None, None
     fit = _fit_two_param(frontier)
@@ -327,9 +330,10 @@ def _estimate_critical_power(
     )
 
 
-def _estimate_threshold_pace(curves: list[tuple[float, dict]]) -> tuple[FieldEstimate, float | None]:
-    """Estimate threshold pace (min/km) and CV (m/s) via critical velocity."""
-    frontier = _build_frontier(curves, "gap_speed")
+def _fit_threshold_pace_from_frontier(
+    frontier: list[_FrontierPoint],
+) -> tuple[FieldEstimate, float | None]:
+    """Fit the CV model from a pre-built frontier (skips the _build_frontier call)."""
     if not frontier:
         return _empty("No pace/GPS data in recent activities."), None
     fit = _fit_two_param(frontier)
@@ -345,6 +349,20 @@ def _estimate_threshold_pace(curves: list[tuple[float, dict]]) -> tuple[FieldEst
                       confidence=conf, sample_size=sample, note=note),
         cv,
     )
+
+
+def _estimate_critical_power(
+    curves: list[tuple[float, dict]]
+) -> tuple[FieldEstimate, float | None, float | None]:
+    """Estimate CP (W), and the supporting W' (J) and Pmax (W)."""
+    frontier = _build_frontier(curves, "power")
+    return _fit_critical_power_from_frontier(frontier)
+
+
+def _estimate_threshold_pace(curves: list[tuple[float, dict]]) -> tuple[FieldEstimate, float | None]:
+    """Estimate threshold pace (min/km) and CV (m/s) via critical velocity."""
+    frontier = _build_frontier(curves, "gap_speed")
+    return _fit_threshold_pace_from_frontier(frontier)
 
 
 def _garmin_lactate_threshold_hr(activities: list[Activity]) -> int | None:
@@ -463,6 +481,55 @@ def _estimate_threshold_hr(
 
 
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Frontier serialization helpers
+# ---------------------------------------------------------------------------
+
+def _frontier_to_list(frontier: list[_FrontierPoint]) -> list[dict]:
+    return [dataclasses.asdict(p) for p in frontier]
+
+
+def _list_to_frontier(data: list[dict]) -> list[_FrontierPoint]:
+    return [_FrontierPoint(**d) for d in data]
+
+
+def _merge_curves_into_frontier(
+    frontier: list[_FrontierPoint],
+    new_curves: list[tuple[float, dict]],
+    metric: str,
+) -> tuple[list[_FrontierPoint], bool]:
+    """Merge new activity curves into an existing frontier.
+
+    Returns ``(updated_frontier, changed)`` where ``changed`` is True only if
+    at least one duration gained a new best value (i.e., a new PR was recorded).
+    The support count for every duration is incremented for each new activity
+    that reaches it, regardless of whether it sets a new best.
+    """
+    best: dict[int, tuple[float, float]] = {p.duration: (p.value, p.weight) for p in frontier}
+    support: dict[int, int] = {p.duration: p.sample_size for p in frontier}
+    changed = False
+    for age_days, curve in new_curves:
+        sub = curve.get(metric) or {}
+        for dur_str, val in sub.items():
+            try:
+                dur = int(dur_str)
+                v = float(val)
+            except (TypeError, ValueError):
+                continue
+            support[dur] = support.get(dur, 0) + 1
+            w = _recency_weight(age_days)
+            if dur not in best or v > best[dur][0]:
+                best[dur] = (v, w)
+                changed = True
+    updated = [
+        _FrontierPoint(duration=d, value=best[d][0], weight=best[d][1],
+                       sample_size=support[d])
+        for d in sorted(best)
+    ]
+    return updated, changed
+
+
+# ---------------------------------------------------------------------------
 # Result cache (SyncStatus-backed memoization)
 # ---------------------------------------------------------------------------
 
@@ -502,10 +569,10 @@ def _deserialize_estimate(d: dict) -> ThresholdEstimate:
     )
 
 
-def _load_cached_threshold(
-    db: Session, lookback_days: int, cutoff: datetime, user_id: int
-) -> ThresholdEstimate | None:
-    """Return the cached estimate when the fingerprint matches, else None."""
+def _load_cached_threshold_raw(
+    db: Session, user_id: int
+) -> dict | None:
+    """Return the raw cache dict (without fingerprint validation) for incremental use."""
     row = (
         db.query(SyncStatus)
         .filter(SyncStatus.user_id == user_id, SyncStatus.key == _THRESHOLD_CACHE_KEY)
@@ -514,8 +581,17 @@ def _load_cached_threshold(
     if not row or not row.value:
         return None
     try:
-        data = json.loads(row.value)
+        return json.loads(row.value)
     except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _load_cached_threshold(
+    db: Session, lookback_days: int, cutoff: datetime, user_id: int
+) -> ThresholdEstimate | None:
+    """Return the cached estimate when the fingerprint matches, else None."""
+    data = _load_cached_threshold_raw(db, user_id)
+    if data is None:
         return None
     if data.get("fp") != _threshold_fingerprint(db, lookback_days, cutoff, user_id):
         return None
@@ -526,25 +602,166 @@ def _load_cached_threshold(
 
 
 def _save_cached_threshold(
-    db: Session, estimate: ThresholdEstimate, lookback_days: int, cutoff: datetime, user_id: int
+    db: Session,
+    estimate: ThresholdEstimate,
+    lookback_days: int,
+    cutoff: datetime,
+    user_id: int,
+    power_frontier: list[_FrontierPoint] | None = None,
+    pace_frontier: list[_FrontierPoint] | None = None,
 ) -> None:
-    """Persist the estimate alongside the current fingerprint."""
-    payload = json.dumps({
+    """Persist the estimate, fingerprint, and optional frontiers to SyncStatus."""
+    payload: dict = {
         "fp": _threshold_fingerprint(db, lookback_days, cutoff, user_id),
         "estimate": dataclasses.asdict(estimate),
-    })
+    }
+    if power_frontier is not None:
+        payload["power_frontier"] = _frontier_to_list(power_frontier)
+    if pace_frontier is not None:
+        payload["pace_frontier"] = _frontier_to_list(pace_frontier)
+    json_payload = json.dumps(payload)
     row = (
         db.query(SyncStatus)
         .filter(SyncStatus.user_id == user_id, SyncStatus.key == _THRESHOLD_CACHE_KEY)
         .first()
     )
     if row:
-        row.value = payload
+        row.value = json_payload
         row.updated_at = datetime.now(timezone.utc)
     else:
-        db.add(SyncStatus(user_id=user_id, key=_THRESHOLD_CACHE_KEY, value=payload,
+        db.add(SyncStatus(user_id=user_id, key=_THRESHOLD_CACHE_KEY, value=json_payload,
                           updated_at=datetime.now(timezone.utc)))
     db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Incremental threshold update (skip full refit when frontier unchanged)
+# ---------------------------------------------------------------------------
+
+def _try_incremental_threshold(
+    db: Session, lookback_days: int, cutoff: datetime, now: datetime, user_id: int
+) -> ThresholdEstimate | None:
+    """Attempt to update the threshold estimate without a full activity re-scan.
+
+    Strategy:
+    1. Load the cached frontier (stored alongside the estimate).
+    2. Parse the old fingerprint to determine how many runs were in the window.
+    3. If the new run count is lower (activities dropped out of the 90-day window),
+       return None — a full rebuild is required.
+    4. Otherwise, find new activities (synced after the last cache) and merge their
+       mean-max curves into the cached frontier.
+    5. If no new PRs result: return the cached estimate with an updated fingerprint.
+    6. If the frontier changed: refit CP/CV from the updated frontier (fast,
+       O(frontier points)) and return — skipping the re-parse of old activities.
+    """
+    cached_data = _load_cached_threshold_raw(db, user_id)
+    if cached_data is None:
+        return None
+    if "power_frontier" not in cached_data and "pace_frontier" not in cached_data:
+        return None  # Old cache entry without frontier; fall back to full rebuild.
+
+    old_fp = cached_data.get("fp", "")
+    parts = old_fp.split("|")
+    if len(parts) < 4:
+        return None
+    try:
+        old_run_count = int(parts[1])
+        old_max_sync_str = parts[3]
+        old_max_sync = datetime.fromisoformat(old_max_sync_str) if old_max_sync_str else None
+    except (ValueError, IndexError):
+        return None
+
+    new_run_count = (
+        db.query(func.count(Activity.id))
+        .filter(Activity.user_id == user_id, Activity.started_at >= cutoff)
+        .scalar() or 0
+    )
+    if new_run_count < old_run_count:
+        return None  # Activities dropped from window — full rebuild needed.
+
+    # Find new run activities with curves synced after the last cache.
+    new_query = (
+        db.query(Activity)
+        .filter(
+            Activity.user_id == user_id,
+            Activity.started_at >= cutoff,
+            Activity.started_at.isnot(None),
+            Activity.mean_max_json.isnot(None),
+        )
+    )
+    if old_max_sync is not None:
+        new_query = new_query.filter(Activity.synced_at > old_max_sync)
+    new_runs = [a for a in new_query.all() if _is_run(a.activity_type)]
+
+    def _age(a: Activity) -> float:
+        return (now - a.started_at).total_seconds() / 86400.0 if a.started_at else 9999.0
+
+    new_curves: list[tuple[float, dict]] = []
+    for a in new_runs:
+        try:
+            curve = json.loads(a.mean_max_json)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        new_curves.append((_age(a), curve))
+
+    power_frontier = _list_to_frontier(cached_data.get("power_frontier") or [])
+    pace_frontier = _list_to_frontier(cached_data.get("pace_frontier") or [])
+
+    if not new_curves:
+        # No new curve data — just refresh the fingerprint and return cached estimate.
+        try:
+            est = _deserialize_estimate(cached_data["estimate"])
+            _save_cached_threshold(db, est, lookback_days, cutoff, user_id,
+                                   power_frontier=power_frontier, pace_frontier=pace_frontier)
+            return est
+        except Exception:
+            return None
+
+    # Merge new curves into frontiers.
+    non_treadmill = [(age, c) for age, c in new_curves if not c.get("is_treadmill")]
+    power_frontier_new, power_changed = _merge_curves_into_frontier(
+        power_frontier, new_curves, "power"
+    )
+    pace_frontier_new, pace_changed = _merge_curves_into_frontier(
+        pace_frontier, non_treadmill, "gap_speed"
+    )
+
+    if not power_changed and not pace_changed:
+        # No new PRs: return cached estimate with updated fingerprint.
+        try:
+            est = _deserialize_estimate(cached_data["estimate"])
+            _save_cached_threshold(db, est, lookback_days, cutoff, user_id,
+                                   power_frontier=power_frontier_new,
+                                   pace_frontier=pace_frontier_new)
+            return est
+        except Exception:
+            return None
+
+    # Frontier changed: refit from the updated frontier (no full activity re-scan).
+    try:
+        cp, w_prime, pmax = _fit_critical_power_from_frontier(power_frontier_new)
+        pace, cv = _fit_threshold_pace_from_frontier(pace_frontier_new)
+        # HR estimates still require the full run list (they use raw laps/streams).
+        all_runs = [
+            a for a in db.query(Activity).filter(
+                Activity.user_id == user_id,
+                Activity.started_at >= cutoff,
+                Activity.started_at.isnot(None),
+            ).all()
+            if _is_run(a.activity_type)
+        ]
+        max_hr_est = _estimate_max_hr(all_runs)
+        thr_hr = _estimate_threshold_hr(all_runs, max_hr_est.value, cv)
+        estimate = ThresholdEstimate(
+            critical_power=cp, w_prime=w_prime, pmax=pmax,
+            threshold_pace_min_km=pace, threshold_hr=thr_hr, max_hr=max_hr_est,
+            lookback_days=lookback_days, activities_analyzed=len(all_runs),
+        )
+        _save_cached_threshold(db, estimate, lookback_days, cutoff, user_id,
+                               power_frontier=power_frontier_new, pace_frontier=pace_frontier_new)
+        return estimate
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -563,9 +780,9 @@ def estimate_thresholds(
 ) -> ThresholdEstimate:
     """Compute threshold estimates from the last ``lookback_days`` of activities.
 
-    Results are memoized in ``SyncStatus``; the cache is invalidated whenever the
-    set of activities in the lookback window changes or new mean-max curves appear
-    (e.g., after a backfill run).
+    On a fingerprint cache hit, returns immediately. On a miss, tries an
+    incremental frontier merge (merging only new activities' curves into the cached
+    frontier) before falling back to a full recompute from all activities.
     """
     now = datetime.utcnow()
     cutoff = now - timedelta(days=lookback_days)
@@ -574,7 +791,12 @@ def estimate_thresholds(
     if cached is not None:
         return cached
 
-    # Self-heal: compute curves for any older activities that predate this feature.
+    # Try incremental update: merge only new activities into the cached frontier.
+    incremental = _try_incremental_threshold(db, lookback_days, cutoff, now, user_id)
+    if incremental is not None:
+        return incremental
+
+    # Full recompute: self-heal missing curves, then rebuild frontier from scratch.
     try:
         streams.backfill_missing_curves(db, user_id=user_id)
     except Exception:
@@ -613,8 +835,12 @@ def estimate_thresholds(
     power_curves = _curves(include_treadmill=True)
     pace_curves = _curves(include_treadmill=False)
 
-    cp, w_prime, pmax = _estimate_critical_power(power_curves)
-    pace, cv = _estimate_threshold_pace(pace_curves)
+    # Build frontiers explicitly so we can cache them for the next incremental update.
+    power_frontier = _build_frontier(power_curves, "power")
+    pace_frontier = _build_frontier(pace_curves, "gap_speed")
+
+    cp, w_prime, pmax = _fit_critical_power_from_frontier(power_frontier)
+    pace, cv = _fit_threshold_pace_from_frontier(pace_frontier)
     max_hr = _estimate_max_hr(runs)
     thr_hr = _estimate_threshold_hr(runs, max_hr.value, cv)
 
@@ -630,7 +856,8 @@ def estimate_thresholds(
     )
 
     try:
-        _save_cached_threshold(db, estimate, lookback_days, cutoff, user_id)
+        _save_cached_threshold(db, estimate, lookback_days, cutoff, user_id,
+                               power_frontier=power_frontier, pace_frontier=pace_frontier)
     except Exception:
         logger.debug("Threshold estimate cache write failed", exc_info=True)
 

--- a/app/training_load.py
+++ b/app/training_load.py
@@ -8,9 +8,14 @@ HR-based hrTSS, then a duration-only floor) so non-power runs still contribute.
 - **CTL** (Chronic Training Load, "Fitness") — 42-day exponentially-weighted average of TSS.
 - **ATL** (Acute Training Load, "Fatigue") — 7-day exponentially-weighted average of TSS.
 - **TSB** (Training Stress Balance, "Form") — CTL − ATL.
+
+Series are persisted incrementally to ``DailyLoadSeries``: on recompute, only
+rows from the first "dirty" date (the earliest newly-synced activity) are deleted
+and re-inserted. The EWMA checkpoint for all earlier days is read directly from
+the table, so a typical new-activity sync re-processes a handful of days instead
+of the full history.
 """
 
-import json
 import logging
 import math
 from collections import defaultdict
@@ -19,12 +24,21 @@ from datetime import date, datetime, timedelta, timezone
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from app.models import DEFAULT_USER_ID, Activity, AthleteProfile, DailySummary, SyncStatus
+from app.models import (
+    DEFAULT_USER_ID,
+    Activity,
+    AthleteProfile,
+    DailyLoadSeries,
+    DailySummary,
+    SyncStatus,
+)
 from app.schemas import TrainingLoadPoint, TrainingReadiness
 
 logger = logging.getLogger(__name__)
 
-_SERIES_CACHE_KEY = "training_load_series"
+# Watermark key: stores max(activity.synced_at) of the last series compute so we
+# can find activities added since then without scanning the full table.
+_LOAD_WATERMARK_KEY = "training_load_watermark"
 
 CTL_DAYS = 42
 ATL_DAYS = 7
@@ -79,69 +93,121 @@ def estimate_tss(activity: Activity, profile: AthleteProfile | None) -> tuple[fl
     return _intensity_to_tss(duration_hr, _DEFAULT_IF), "duration"
 
 
-def _series_fingerprint(db: Session, user_id: int) -> str:
-    """Cheap cache key: activity count + newest sync timestamp + profile update time."""
-    count = db.query(func.count(Activity.id)).filter(Activity.user_id == user_id).scalar() or 0
-    max_sync = db.query(func.max(Activity.synced_at)).filter(Activity.user_id == user_id).scalar()
-    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == user_id).first()
-    return "|".join([
-        str(count),
-        max_sync.isoformat() if max_sync else "",
-        profile.updated_at.isoformat() if (profile and profile.updated_at) else "",
-    ])
+# ---------------------------------------------------------------------------
+# Watermark helpers (dirty-date detection)
+# ---------------------------------------------------------------------------
 
-
-def _load_cached_series(db: Session, user_id: int) -> list[TrainingLoadPoint] | None:
-    """Return the cached full series when the fingerprint matches, else None."""
+def _get_load_watermark(db: Session, user_id: int) -> datetime | None:
+    """Return the synced_at watermark from the last series compute, or None."""
     row = (
         db.query(SyncStatus)
-        .filter(SyncStatus.user_id == user_id, SyncStatus.key == _SERIES_CACHE_KEY)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == _LOAD_WATERMARK_KEY)
         .first()
     )
     if not row or not row.value:
         return None
     try:
-        data = json.loads(row.value)
-    except (json.JSONDecodeError, TypeError):
-        return None
-    if data.get("fp") != _series_fingerprint(db, user_id):
-        return None
-    try:
-        return [TrainingLoadPoint(**p) for p in data["series"]]
-    except Exception:
+        return datetime.fromisoformat(row.value)
+    except (ValueError, TypeError):
         return None
 
 
-def _save_cached_series(db: Session, series: list[TrainingLoadPoint], user_id: int) -> None:
-    """Persist the full series alongside the current fingerprint."""
-    payload = json.dumps({
-        "fp": _series_fingerprint(db, user_id),
-        "series": [p.model_dump(mode="json") for p in series],
-    })
+def _set_load_watermark(db: Session, watermark: datetime | None, user_id: int) -> None:
+    """Persist the watermark (called after a series compute completes)."""
+    value = watermark.isoformat() if watermark else ""
     row = (
         db.query(SyncStatus)
-        .filter(SyncStatus.user_id == user_id, SyncStatus.key == _SERIES_CACHE_KEY)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == _LOAD_WATERMARK_KEY)
         .first()
     )
     if row:
-        row.value = payload
+        row.value = value
         row.updated_at = datetime.now(timezone.utc)
     else:
-        db.add(SyncStatus(user_id=user_id, key=_SERIES_CACHE_KEY, value=payload,
-                          updated_at=datetime.now(timezone.utc)))
-    db.commit()
+        db.add(SyncStatus(
+            user_id=user_id,
+            key=_LOAD_WATERMARK_KEY,
+            value=value,
+            updated_at=datetime.now(timezone.utc),
+        ))
 
 
-def _daily_tss(
-    db: Session, end_date: date, profile: AthleteProfile | None, user_id: int
+def _find_dirty_date(db: Session, user_id: int, watermark: datetime | None) -> date | None:
+    """Return the earliest start date of activities synced after ``watermark``.
+
+    ``None`` means either there is no watermark yet (first compute) or no
+    activities were added since the last compute.
+    """
+    if watermark is None:
+        return None
+    result = (
+        db.query(func.min(Activity.started_at))
+        .filter(
+            Activity.user_id == user_id,
+            Activity.started_at.isnot(None),
+            Activity.synced_at > watermark,
+        )
+        .scalar()
+    )
+    if result is None:
+        return None
+    return result.date() if isinstance(result, datetime) else result
+
+
+# ---------------------------------------------------------------------------
+# DB-backed series read / write
+# ---------------------------------------------------------------------------
+
+def _load_series_points(
+    db: Session,
+    user_id: int,
+    end_date: date,
+    start_date: date | None = None,
+) -> list[TrainingLoadPoint]:
+    """Load persisted series rows as ``TrainingLoadPoint`` objects."""
+    query = (
+        db.query(DailyLoadSeries)
+        .filter(DailyLoadSeries.user_id == user_id, DailyLoadSeries.date <= end_date)
+    )
+    if start_date is not None:
+        query = query.filter(DailyLoadSeries.date >= start_date)
+    rows = query.order_by(DailyLoadSeries.date).all()
+    return [
+        TrainingLoadPoint(
+            date=row.date,
+            tss=row.tss,
+            ctl=row.ctl,
+            atl=row.atl,
+            tsb=row.tsb,
+            acwr=row.acwr,
+            ramp_rate_7d=row.ramp_rate_7d,
+            ramp_rate_28d=row.ramp_rate_28d,
+            injury_risk=row.injury_risk or "low",
+        )
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# TSS aggregation
+# ---------------------------------------------------------------------------
+
+def _daily_tss_range(
+    db: Session,
+    start_date: date,
+    end_date: date,
+    profile: AthleteProfile | None,
+    user_id: int,
 ) -> dict[date, float]:
-    """Sum estimated TSS per calendar day up to and including ``end_date``."""
+    """Sum estimated TSS per calendar day in [start_date, end_date]."""
+    start_dt = datetime.combine(start_date, datetime.min.time())
     end_dt = datetime.combine(end_date + timedelta(days=1), datetime.min.time())
     activities = (
         db.query(Activity)
         .filter(
             Activity.user_id == user_id,
             Activity.started_at.isnot(None),
+            Activity.started_at >= start_dt,
             Activity.started_at < end_dt,
         )
         .all()
@@ -154,6 +220,10 @@ def _daily_tss(
             totals[day] += tss
     return totals
 
+
+# ---------------------------------------------------------------------------
+# Injury risk
+# ---------------------------------------------------------------------------
 
 def _injury_risk(acwr: float | None, ramp_7d: float | None) -> str:
     """Classify injury risk from ACWR and short-term ramp rate."""
@@ -168,54 +238,115 @@ def _injury_risk(acwr: float | None, ramp_7d: float | None) -> str:
     return "low"
 
 
-def _compute_full_series(
-    db: Session, end_date: date, user_id: int = DEFAULT_USER_ID
-) -> list[TrainingLoadPoint]:
-    """Build the daily CTL/ATL/TSB/ACWR series from the first activity to ``end_date``.
+# ---------------------------------------------------------------------------
+# Incremental series compute
+# ---------------------------------------------------------------------------
 
-    Results are memoized in ``SyncStatus`` when ``end_date`` is today; the cache
-    is invalidated whenever the activity set or athlete profile changes.
+def _ensure_series_current(
+    db: Session, end_date: date, user_id: int = DEFAULT_USER_ID
+) -> None:
+    """Ensure ``DailyLoadSeries`` is populated through at least today.
+
+    Incremental strategy:
+    - No persisted rows: full compute from first activity.
+    - Dirty date after last row: extend forward from the last row's CTL/ATL.
+    - Dirty date at/before last row (backfilled activity): delete from dirty date,
+      load CTL/ATL from the preceding row, recompute only from there.
+    - No dirty activities and series already covers today: nothing to do.
     """
     today = date.today()
-    if end_date == today:
-        cached = _load_cached_series(db, user_id)
-        if cached is not None:
-            return cached
+    compute_to = today if end_date <= today else end_date
 
-    first_started = (
-        db.query(func.min(Activity.started_at)).filter(Activity.user_id == user_id).scalar()
+    watermark = _get_load_watermark(db, user_id)
+    dirty_date = _find_dirty_date(db, user_id, watermark)
+
+    last_row = (
+        db.query(DailyLoadSeries)
+        .filter(DailyLoadSeries.user_id == user_id)
+        .order_by(DailyLoadSeries.date.desc())
+        .first()
     )
-    if first_started is None:
-        return []
-    start_date = first_started.date() if isinstance(first_started, datetime) else first_started
-    if start_date > end_date:
-        return []
+
+    # Already up to date with no new activities.
+    if last_row is not None and dirty_date is None and last_row.date >= compute_to:
+        return
+
+    # Determine the recompute start and EWMA seed.
+    if last_row is None:
+        # No persisted data: must build from the user's very first activity.
+        first_started = (
+            db.query(func.min(Activity.started_at))
+            .filter(Activity.user_id == user_id)
+            .scalar()
+        )
+        if first_started is None:
+            return  # No activities yet.
+        recompute_from = (
+            first_started.date() if isinstance(first_started, datetime) else first_started
+        )
+        prev_ctl, prev_atl = 0.0, 0.0
+    elif dirty_date is not None and dirty_date <= last_row.date:
+        # A past activity was added/changed — recompute from dirty_date.
+        recompute_from = dirty_date
+        prev_row = (
+            db.query(DailyLoadSeries)
+            .filter(
+                DailyLoadSeries.user_id == user_id,
+                DailyLoadSeries.date < recompute_from,
+            )
+            .order_by(DailyLoadSeries.date.desc())
+            .first()
+        )
+        prev_ctl = prev_row.ctl if prev_row else 0.0
+        prev_atl = prev_row.atl if prev_row else 0.0
+    else:
+        # Extend forward: new activities are all after the series end, or the
+        # series doesn't reach compute_to yet.
+        recompute_from = (
+            (last_row.date + timedelta(days=1)) if last_row else compute_to
+        )
+        prev_ctl = last_row.ctl if last_row else 0.0
+        prev_atl = last_row.atl if last_row else 0.0
+
+    if recompute_from > compute_to:
+        return  # Nothing to compute.
+
+    # Delete stale rows and query only the needed TSS range.
+    db.query(DailyLoadSeries).filter(
+        DailyLoadSeries.user_id == user_id,
+        DailyLoadSeries.date >= recompute_from,
+    ).delete()
+    db.commit()
 
     profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == user_id).first()
-    daily = _daily_tss(db, end_date, profile, user_id)
+    daily_tss_map = _daily_tss_range(db, recompute_from, compute_to, profile, user_id)
 
-    series: list[TrainingLoadPoint] = []
-    ctl = 0.0
-    atl = 0.0
-    day = start_date
-    while day <= end_date:
-        tss = daily.get(day, 0.0)
+    # Load the 28-day ramp-rate lookback from the persisted table.
+    lookback_start = recompute_from - timedelta(days=28)
+    history = _load_series_points(
+        db, user_id, recompute_from - timedelta(days=1), start_date=lookback_start
+    )
+
+    now_ts = datetime.now(timezone.utc)
+    new_db_rows: list[DailyLoadSeries] = []
+    new_points: list[TrainingLoadPoint] = []
+    ctl, atl = prev_ctl, prev_atl
+    day = recompute_from
+    while day <= compute_to:
+        tss = daily_tss_map.get(day, 0.0)
         ctl += (tss - ctl) * _CTL_ALPHA
         atl += (tss - atl) * _ATL_ALPHA
 
-        # ACWR: only meaningful when CTL is established (> 1 to avoid divide-by-zero).
+        all_before = history + new_points
+        idx = len(all_before)
         acwr: float | None = round(atl / ctl, 3) if ctl > 1.0 else None
+        ramp_7d: float | None = round(ctl - all_before[idx - 7].ctl, 1) if idx >= 7 else None
+        ramp_28d: float | None = (
+            round(ctl - all_before[idx - 28].ctl, 1) if idx >= 28 else None
+        )
+        risk = _injury_risk(acwr, ramp_7d)
 
-        # Ramp rates: CTL change over the last 7 and 28 days.
-        idx = len(series)
-        ramp_7d: float | None = None
-        ramp_28d: float | None = None
-        if idx >= 7:
-            ramp_7d = round(ctl - series[idx - 7].ctl, 1)
-        if idx >= 28:
-            ramp_28d = round(ctl - series[idx - 28].ctl, 1)
-
-        series.append(
+        new_points.append(
             TrainingLoadPoint(
                 date=day,
                 tss=round(tss, 1),
@@ -225,18 +356,43 @@ def _compute_full_series(
                 acwr=acwr,
                 ramp_rate_7d=ramp_7d,
                 ramp_rate_28d=ramp_28d,
-                injury_risk=_injury_risk(acwr, ramp_7d),
+                injury_risk=risk,
+            )
+        )
+        new_db_rows.append(
+            DailyLoadSeries(
+                user_id=user_id,
+                date=day,
+                tss=round(tss, 1),
+                ctl=round(ctl, 1),
+                atl=round(atl, 1),
+                tsb=round(ctl - atl, 1),
+                acwr=acwr,
+                ramp_rate_7d=ramp_7d,
+                ramp_rate_28d=ramp_28d,
+                injury_risk=risk,
+                computed_at=now_ts,
             )
         )
         day += timedelta(days=1)
 
-    if end_date == today and series:
-        try:
-            _save_cached_series(db, series, user_id)
-        except Exception:
-            logger.debug("Training load series cache write failed", exc_info=True)
+    db.bulk_save_objects(new_db_rows)
 
-    return series
+    max_synced = (
+        db.query(func.max(Activity.synced_at))
+        .filter(Activity.user_id == user_id)
+        .scalar()
+    )
+    _set_load_watermark(db, max_synced, user_id)
+    db.commit()
+
+
+def _compute_full_series(
+    db: Session, end_date: date, user_id: int = DEFAULT_USER_ID
+) -> list[TrainingLoadPoint]:
+    """Return the full series up to ``end_date``, computing/extending as needed."""
+    _ensure_series_current(db, end_date, user_id)
+    return _load_series_points(db, user_id, end_date)
 
 
 def compute_load_series(
@@ -244,18 +400,25 @@ def compute_load_series(
 ) -> list[TrainingLoadPoint]:
     """Return the last ``days`` of the CTL/ATL/TSB series ending at ``end_date``."""
     end_date = end_date or date.today()
-    full = _compute_full_series(db, end_date, user_id)
+    _ensure_series_current(db, end_date, user_id)
     if days and days > 0:
-        return full[-days:]
-    return full
+        start_date = end_date - timedelta(days=days - 1)
+        return _load_series_points(db, user_id, end_date, start_date=start_date)
+    return _load_series_points(db, user_id, end_date)
 
 
 def current_load(
     db: Session, as_of: date | None = None, user_id: int = DEFAULT_USER_ID
 ) -> TrainingLoadPoint | None:
     """Return the most recent CTL/ATL/TSB snapshot as of ``as_of``."""
-    full = _compute_full_series(db, as_of or date.today(), user_id)
-    return full[-1] if full else None
+    as_of = as_of or date.today()
+    _ensure_series_current(db, as_of, user_id)
+    points = _load_series_points(db, user_id, as_of, start_date=as_of)
+    if points:
+        return points[-1]
+    # No row exactly on as_of — return the nearest preceding row.
+    all_points = _load_series_points(db, user_id, as_of)
+    return all_points[-1] if all_points else None
 
 
 def _interpret_tsb(tsb: float) -> str:

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -225,7 +225,7 @@ sharpens the closed-loop plan's input signal.
   (`CURRENT_STATE.md`). Add a startup guard that refuses (or loudly warns) when
   auth is disabled and the bind address isn't loopback, and document the safe
   default. **S–M.** Files: `app/main.py`, `app/auth.py`, `app/config.py`, docs.
-- **P3-2 · Incremental load & threshold compute.** Cache misses still recompute
+- ✅ **P3-2 · Incremental load & threshold compute.** Cache misses still recompute
   CTL/ATL/TSB and CP/CV from full history per request. Persist a daily series and
   extend incrementally rather than refitting wholesale. **M.** Files:
   `app/training_load.py`, `app/threshold.py`, optional series table in

--- a/tests/test_threshold.py
+++ b/tests/test_threshold.py
@@ -394,6 +394,48 @@ def test_threshold_cache_roundtrip_preserves_fields(db):
     assert cached.lookback_days == est.lookback_days
 
 
+# --- Incremental threshold compute (frontier caching) ---
+
+def test_frontier_stored_in_cache_after_full_compute(db):
+    """Full compute stores power and pace frontiers alongside the estimate."""
+    _add(db, mean_max=_curve_json(power=_power_curve(250, 15000),
+                                  gap_speed=_gap_curve(3.5, 200)))
+    threshold.estimate_thresholds(db)
+    raw = threshold._load_cached_threshold_raw(db, user_id=1)
+    assert raw is not None
+    assert "power_frontier" in raw
+    assert "pace_frontier" in raw
+    assert len(raw["power_frontier"]) > 0
+
+
+def test_incremental_skips_refit_when_no_new_prs(db):
+    """New activity with lower power than the cached frontier keeps CP unchanged."""
+    _add(db, mean_max=_curve_json(power=_power_curve(250, 15000)), days_ago=10)
+    est1 = threshold.estimate_thresholds(db)
+    assert est1.critical_power.value is not None
+    assert abs(est1.critical_power.value - 250) < 5
+
+    # Lower-power activity — does not set any new PRs on the frontier.
+    _add(db, mean_max=_curve_json(power=_power_curve(150, 5000)), days_ago=5)
+    est2 = threshold.estimate_thresholds(db)
+    assert est2.critical_power.value is not None
+    # CP anchored by the original 250 W activity; incremental path returns it unchanged.
+    assert abs(est2.critical_power.value - 250) < 5
+
+
+def test_incremental_refits_when_new_pr_recorded(db):
+    """New activity with higher power triggers an incremental refit to the higher CP."""
+    _add(db, mean_max=_curve_json(power=_power_curve(250, 15000)), days_ago=10)
+    est1 = threshold.estimate_thresholds(db)
+    assert est1.critical_power.value is not None
+
+    # Stronger activity — sets new PRs across the power frontier.
+    _add(db, mean_max=_curve_json(power=_power_curve(300, 15000)), days_ago=5)
+    est2 = threshold.estimate_thresholds(db)
+    assert est2.critical_power.value is not None
+    assert est2.critical_power.value > est1.critical_power.value
+
+
 # --- Performance curve + race predictions ---
 
 def test_predict_race_times_basic():

--- a/tests/test_training_load.py
+++ b/tests/test_training_load.py
@@ -287,3 +287,64 @@ def test_series_cache_bypassed_for_historical_date(db):
     assert len(series_hist) > 0
     # Historical series ends at the requested date.
     assert series_hist[-1].date == historical_date
+
+
+# --- Incremental series compute (DailyLoadSeries persistence) ---
+
+def test_daily_load_series_rows_persisted_after_compute(db):
+    """compute_load_series writes rows to DailyLoadSeries."""
+    from app.models import DailyLoadSeries
+    base = datetime(2026, 6, 1, 7, 0)
+    for i in range(5):
+        _add_activity(db, base + timedelta(days=i), tss=80.0)
+    training_load.compute_load_series(db)
+    assert db.query(DailyLoadSeries).count() > 0
+
+
+def test_watermark_set_after_series_compute(db):
+    """A training_load_watermark entry is written to SyncStatus after compute."""
+    _add_activity(db, datetime(2026, 6, 20, 7, 0), tss=70.0)
+    training_load.compute_load_series(db)
+    watermark = training_load._get_load_watermark(db, user_id=1)
+    assert watermark is not None
+
+
+def test_backfill_recomputes_ctl_from_dirty_date(db):
+    """Adding a high-TSS backdated activity raises CTL from that date onwards."""
+    from app.models import DailyLoadSeries
+    base = datetime(2026, 6, 10, 7, 0)
+    for i in range(7):
+        _add_activity(db, base + timedelta(days=i), tss=60.0)
+    training_load.compute_load_series(db)
+
+    mid_date = (base + timedelta(days=3)).date()
+    ctl_before = (
+        db.query(DailyLoadSeries)
+        .filter(DailyLoadSeries.date == mid_date)
+        .first()
+        .ctl
+    )
+
+    # Backdated activity on the same calendar day but a different time (unique garmin_id).
+    _add_activity(db, base + timedelta(days=3) + timedelta(hours=10), tss=200.0)
+    training_load.compute_load_series(db)
+
+    ctl_after = (
+        db.query(DailyLoadSeries)
+        .filter(DailyLoadSeries.date == mid_date)
+        .first()
+        .ctl
+    )
+    assert ctl_after > ctl_before
+
+
+def test_second_compute_noop_when_no_new_activities(db):
+    """A second compute with no new activities does not alter the persisted rows."""
+    from app.models import DailyLoadSeries
+    _add_activity(db, datetime(2026, 6, 20, 7, 0), tss=70.0)
+    training_load.compute_load_series(db)
+    count_first = db.query(DailyLoadSeries).count()
+
+    training_load.compute_load_series(db)
+    count_second = db.query(DailyLoadSeries).count()
+    assert count_first == count_second


### PR DESCRIPTION
Replaces full-history recomputes with watermark-based incremental updates:

Training load:
- Add DailyLoadSeries model (one row per user/date) to persist the EWMA series
- _ensure_series_current: on each call, finds the earliest "dirty" date (activity
  synced after watermark), deletes rows from that date forward, and extends/
  backfills only the affected range using the stored prev_ctl/prev_atl as seed
- Watermark (max synced_at) stored in SyncStatus so only truly new activities
  trigger a recompute
- Alembic migration i2j3k4l5m6n7 creates the daily_load_series table

Threshold:
- Split _estimate_critical_power/_estimate_threshold_pace into separate
  _build_frontier + _fit_*_from_frontier steps for reuse in incremental path
- Persist power/pace frontiers alongside the estimate in the SyncStatus cache
- _try_incremental_threshold: on a fingerprint miss, merges only newly-synced
  activity curves into the cached frontier; refits CP/CV only when a new PR
  is recorded; skips the full activity re-scan otherwise
- Adds _load_cached_threshold_raw, _frontier_to_list, _list_to_frontier,
  _merge_curves_into_frontier helpers

Tests: 7 new tests covering series persistence, watermark tracking, backfill
recompute, frontier caching, incremental skip-refit, and incremental refit paths.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SV4sEvdmBXKjobdFY6qg5U