### PR TITLE
feat(P3-5): infinite scroll for activities and daily summaries history

### DIFF
--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -239,7 +239,7 @@ sharpens the closed-loop plan's input signal.
   silently when Garmin changes shape. Add contract/snapshot tests over recorded
   payloads and a sync-health check that flags when expected fields go missing.
   **M.** Files: `tests/` fixtures, `app/garmin_sync.py` health surface.
-- **P3-5 · History browsing UX.** Activities/daily lists use manual page paging;
+- ✅ **P3-5 · History browsing UX.** Activities/daily lists use manual page paging;
   add infinite scroll or a "load all" for long archives
   (`CURRENT_STATE.md` "Pagination UX"). **S–M.** Files:
   `frontend/src/components/activities/*`, `daily/*`, `frontend/src/api/` hooks.

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiGet, apiPost, apiPut, apiDelete } from './client'
 import type {
   AIJobEnqueuedResponse,
@@ -64,12 +64,19 @@ export function useWellnessTrends(days = 90) {
   })
 }
 
-export function useActivities(page: number, type?: string) {
-  const params = new URLSearchParams({ page: String(page), limit: '30' })
-  if (type) params.set('type', type)
-  return useQuery({
-    queryKey: ['activities', page, type],
-    queryFn: () => apiGet<ActivitySummary[]>(`/activities?${params}`),
+export const ACTIVITIES_PAGE_SIZE = 30
+
+export function useActivities(type?: string) {
+  return useInfiniteQuery({
+    queryKey: ['activities', type],
+    queryFn: ({ pageParam }) => {
+      const params = new URLSearchParams({ page: String(pageParam), limit: String(ACTIVITIES_PAGE_SIZE) })
+      if (type) params.set('type', type)
+      return apiGet<ActivitySummary[]>(`/activities?${params}`)
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) =>
+      lastPage.length === ACTIVITIES_PAGE_SIZE ? (lastPageParam as number) + 1 : undefined,
   })
 }
 
@@ -81,10 +88,16 @@ export function useActivity(id: number) {
   })
 }
 
-export function useDailySummaries(page: number) {
-  return useQuery({
-    queryKey: ['daily-summaries', page],
-    queryFn: () => apiGet<DailySummaryResponse[]>(`/daily-summaries?page=${page}&limit=30`),
+export const DAILY_SUMMARIES_PAGE_SIZE = 30
+
+export function useDailySummaries() {
+  return useInfiniteQuery({
+    queryKey: ['daily-summaries'],
+    queryFn: ({ pageParam }) =>
+      apiGet<DailySummaryResponse[]>(`/daily-summaries?page=${pageParam}&limit=${DAILY_SUMMARIES_PAGE_SIZE}`),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) =>
+      lastPage.length === DAILY_SUMMARIES_PAGE_SIZE ? (lastPageParam as number) + 1 : undefined,
   })
 }
 

--- a/frontend/src/api/pagination.test.ts
+++ b/frontend/src/api/pagination.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { ACTIVITIES_PAGE_SIZE, DAILY_SUMMARIES_PAGE_SIZE } from './hooks'
+
+// Mirrors the getNextPageParam logic used in useActivities / useDailySummaries
+function activitiesNextPage(lastPage: unknown[], lastPageParam: number): number | undefined {
+  return lastPage.length === ACTIVITIES_PAGE_SIZE ? lastPageParam + 1 : undefined
+}
+
+function dailyNextPage(lastPage: unknown[], lastPageParam: number): number | undefined {
+  return lastPage.length === DAILY_SUMMARIES_PAGE_SIZE ? lastPageParam + 1 : undefined
+}
+
+describe('infinite query pagination — activities', () => {
+  it('returns next page when current page is full', () => {
+    const fullPage = Array.from({ length: ACTIVITIES_PAGE_SIZE })
+    expect(activitiesNextPage(fullPage, 1)).toBe(2)
+    expect(activitiesNextPage(fullPage, 5)).toBe(6)
+  })
+
+  it('returns undefined when current page is not full', () => {
+    expect(activitiesNextPage([], 1)).toBeUndefined()
+    expect(activitiesNextPage(Array.from({ length: 10 }), 2)).toBeUndefined()
+    expect(activitiesNextPage(Array.from({ length: ACTIVITIES_PAGE_SIZE - 1 }), 3)).toBeUndefined()
+  })
+})
+
+describe('infinite query pagination — daily summaries', () => {
+  it('returns next page when current page is full', () => {
+    const fullPage = Array.from({ length: DAILY_SUMMARIES_PAGE_SIZE })
+    expect(dailyNextPage(fullPage, 1)).toBe(2)
+  })
+
+  it('returns undefined on the last partial page', () => {
+    expect(dailyNextPage(Array.from({ length: 15 }), 2)).toBeUndefined()
+    expect(dailyNextPage([], 1)).toBeUndefined()
+  })
+})
+
+describe('page flattening', () => {
+  it('flattens multiple pages into a single array', () => {
+    const pages = [[1, 2, 3], [4, 5, 6], [7]]
+    expect(pages.flat()).toEqual([1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it('returns empty array for no pages', () => {
+    const pages: number[][] = []
+    expect(pages.flat()).toEqual([])
+  })
+
+  it('preserves order across pages', () => {
+    const pages = [['a', 'b'], ['c', 'd']]
+    expect(pages.flat()).toEqual(['a', 'b', 'c', 'd'])
+  })
+})

--- a/frontend/src/components/activities/ActivitiesView.css
+++ b/frontend/src/components/activities/ActivitiesView.css
@@ -77,3 +77,7 @@
 .load-more-btn:hover {
   background: var(--bg-hover);
 }
+
+.scroll-sentinel {
+  height: 1px;
+}

--- a/frontend/src/components/activities/ActivitiesView.tsx
+++ b/frontend/src/components/activities/ActivitiesView.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import { useActivities } from '../../api/hooks'
 import { format, parseISO } from '../../utils/date'
 import ActivityListItem from './ActivityListItem'
@@ -15,12 +15,13 @@ const FILTERS = [
 
 export default function ActivitiesView() {
   const [activeFilter, setActiveFilter] = useState('')
-  const [page, setPage] = useState(1)
-  const { data: activities, isLoading } = useActivities(page, activeFilter || undefined)
+  const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
+    useActivities(activeFilter || undefined)
+  const sentinelRef = useRef<HTMLDivElement>(null)
 
-  // Group by month
+  const activities = useMemo(() => data?.pages.flat() ?? [], [data])
+
   const grouped = useMemo(() => {
-    if (!activities) return []
     const groups: { month: string; items: typeof activities }[] = []
     let currentMonth = ''
     let currentItems: typeof activities = []
@@ -39,15 +40,29 @@ export default function ActivitiesView() {
     return groups
   }, [activities])
 
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel) return
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage()
+        }
+      },
+      { rootMargin: '200px' },
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage])
+
   return (
     <div className="activities-view">
-      {/* Filter chips */}
       <div className="filter-chips">
         {FILTERS.map(f => (
           <button
             key={f.value}
             className={`chip ${activeFilter === f.value ? 'active' : ''}`}
-            onClick={() => { setActiveFilter(f.value); setPage(1) }}
+            onClick={() => setActiveFilter(f.value)}
           >
             {f.label}
           </button>
@@ -71,13 +86,9 @@ export default function ActivitiesView() {
         </div>
       ))}
 
-      {activities && activities.length >= 30 && (
-        <div className="load-more-wrap">
-          <button className="load-more-btn" onClick={() => setPage(p => p + 1)}>
-            Load more
-          </button>
-        </div>
-      )}
+      <div ref={sentinelRef} className="scroll-sentinel" />
+
+      {isFetchingNextPage && <div className="spinner" />}
     </div>
   )
 }

--- a/frontend/src/components/daily/DailySummariesView.css
+++ b/frontend/src/components/daily/DailySummariesView.css
@@ -83,3 +83,7 @@
 .load-more-btn:hover {
   background: var(--bg-hover);
 }
+
+.scroll-sentinel {
+  height: 1px;
+}

--- a/frontend/src/components/daily/DailySummariesView.tsx
+++ b/frontend/src/components/daily/DailySummariesView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useDailySummaries } from '../../api/hooks'
 import { format, parseISO } from '../../utils/date'
@@ -6,9 +6,27 @@ import { formatSleepHours } from '../../utils/formatting'
 import './DailySummariesView.css'
 
 export default function DailySummariesView() {
-  const [page, setPage] = useState(1)
-  const { data: summaries, isLoading, error } = useDailySummaries(page)
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useDailySummaries()
   const navigate = useNavigate()
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  const summaries = useMemo(() => data?.pages.flat() ?? [], [data])
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel) return
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage()
+        }
+      },
+      { rootMargin: '200px' },
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage])
 
   if (isLoading) return <div className="spinner" />
   if (error) return <div className="empty-state">Failed to load daily summaries</div>
@@ -16,11 +34,11 @@ export default function DailySummariesView() {
   return (
     <div className="daily-view">
       <h2 className="section-title">Daily Summaries</h2>
-      {(!summaries || summaries.length === 0) && (
+      {summaries.length === 0 && (
         <div className="empty-state">No daily summaries yet</div>
       )}
       <div className="daily-list">
-        {summaries?.map(s => (
+        {summaries.map(s => (
           <div key={s.id} className="daily-card card" onClick={() => navigate(`/daily/${s.id}`)}>
             <div className="daily-date-col">
               <span className="daily-day">{format(parseISO(s.date), 'd')}</span>
@@ -64,11 +82,9 @@ export default function DailySummariesView() {
         ))}
       </div>
 
-      {summaries && summaries.length >= 30 && (
-        <div className="load-more-wrap">
-          <button className="load-more-btn" onClick={() => setPage(p => p + 1)}>Load more</button>
-        </div>
-      )}
+      <div ref={sentinelRef} className="scroll-sentinel" />
+
+      {isFetchingNextPage && <div className="spinner" />}
     </div>
   )
 }


### PR DESCRIPTION
Replace manual page-counter pagination with useInfiniteQuery so pages
accumulate rather than replace. An IntersectionObserver sentinel at the
bottom of each list fetches the next page automatically as the user
scrolls. hasNextPage is derived from whether the last page returned a
full batch, so the scroll trigger self-disables at the end of the archive.

- hooks.ts: useActivities / useDailySummaries → useInfiniteQuery; export
  PAGE_SIZE constants reused in tests
- ActivitiesView: flatten data.pages, wire sentinel ref, drop page state
- DailySummariesView: same pattern; drop page state
- pagination.test.ts: unit tests for getNextPageParam logic and flattening

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>