### PR TITLE
P3-1: add startup security guard for auth_enabled=False on public bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ All settings come from environment variables (see `app/config.py`):
 | `AUTH_ENABLED` | `false` | Enable Cloudflare Access JWT auth |
 | `CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD` | — | Required when auth is enabled |
 | `ENCRYPTION_KEY` | — | Fernet key for per-user Garmin passwords |
+| `BIND_HOST` | `127.0.0.1` | Interface uvicorn listens on (must match `--host`); used by the security guard |
+
+> **Safe-default rule:** `AUTH_ENABLED=false` is fine for local development
+> (`BIND_HOST=127.0.0.1`, the default).  If you expose the app on any
+> non-loopback interface — including Docker's `0.0.0.0` — you **must** set
+> `AUTH_ENABLED=true` and configure Cloudflare Access.  The app logs a
+> `CRITICAL` warning at startup when it detects the unsafe combination.
 
 Generate an encryption key once and keep it stable:
 

--- a/app/config.py
+++ b/app/config.py
@@ -36,6 +36,9 @@ class Settings(BaseSettings):
     cf_access_aud: str = ""          # AUD tag from Cloudflare Access app
     dev_user_email: str = ""         # fallback identity when auth_enabled=False
     encryption_key: str = ""         # Fernet key for storing Garmin passwords (Phase 2)
+    # Network binding — used by the startup security guard to detect public exposure
+    # without auth.  Must match the --host value passed to uvicorn.
+    bind_host: str = "127.0.0.1"
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,31 @@ logger = logging.getLogger(__name__)
 
 scheduler = BackgroundScheduler()
 
+_LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def _check_security_config() -> None:
+    """Warn loudly when auth is disabled on a non-loopback bind address.
+
+    Auth-disabled mode trusts a synthetic dev user for every request — anyone
+    who can reach the socket gets full data access.  That is fine on loopback
+    (only local processes can connect) but catastrophic on 0.0.0.0 or any
+    public interface.  This guard fires once at startup so the warning appears
+    prominently in logs and container output.
+    """
+    if not settings.auth_enabled and settings.bind_host not in _LOOPBACK_HOSTS:
+        logger.critical(
+            "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+            "  SECURITY WARNING\n"
+            "  auth_enabled=False  AND  bind_host=%r (non-loopback)\n"
+            "  Every request is accepted without authentication.\n"
+            "  All user data is publicly readable and writable.\n"
+            "  Set AUTH_ENABLED=true (with Cloudflare Access) or restrict\n"
+            "  BIND_HOST to 127.0.0.1 before exposing this instance.\n"
+            "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+            settings.bind_host,
+        )
+
 _libc = None
 
 
@@ -247,6 +272,7 @@ def _run_backfill():
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
+    _check_security_config()
     init_db()
     os.makedirs(settings.garmin_token_dir, exist_ok=True)
     # Seed user #1 from env GARMIN_EMAIL/PASSWORD and migrate the flat token dir

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -220,7 +220,7 @@ sharpens the closed-loop plan's input signal.
 
 ### P3 — Hygiene & scale (largely independent)
 
-- **P3-1 · Security default / exposure guard.** `auth_enabled=False` trusts the
+- ✅ **P3-1 · Security default / exposure guard.** `auth_enabled=False` trusts the
   dev-user fallback, so a publicly exposed instance leaks all data
   (`CURRENT_STATE.md`). Add a startup guard that refuses (or loudly warns) when
   auth is disabled and the bind address isn't loopback, and document the safe

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -175,3 +175,37 @@ def test_spa_catch_all_rejects_api_paths():
     with __import__("pytest").raises(HTTPException) as exc:
         asyncio.run(main.spa_catch_all("api/v1/today"))
     assert exc.value.status_code == 404
+
+
+# --- _check_security_config ------------------------------------------------
+
+def test_security_guard_warns_when_auth_disabled_on_public_host(monkeypatch, caplog):
+    import logging
+    monkeypatch.setattr(main.settings, "auth_enabled", False)
+    monkeypatch.setattr(main.settings, "bind_host", "0.0.0.0")
+    with caplog.at_level(logging.CRITICAL, logger="app.main"):
+        main._check_security_config()
+    assert any("SECURITY WARNING" in r.message for r in caplog.records)
+    assert any(r.levelno == logging.CRITICAL for r in caplog.records)
+
+
+def test_security_guard_silent_when_auth_disabled_on_loopback(monkeypatch, caplog):
+    import logging
+    monkeypatch.setattr(main.settings, "auth_enabled", False)
+    for host in ("127.0.0.1", "::1", "localhost"):
+        caplog.clear()
+        monkeypatch.setattr(main.settings, "bind_host", host)
+        with caplog.at_level(logging.CRITICAL, logger="app.main"):
+            main._check_security_config()
+        assert not any(r.levelno == logging.CRITICAL for r in caplog.records), (
+            f"unexpected CRITICAL log for bind_host={host!r}"
+        )
+
+
+def test_security_guard_silent_when_auth_enabled_on_public_host(monkeypatch, caplog):
+    import logging
+    monkeypatch.setattr(main.settings, "auth_enabled", True)
+    monkeypatch.setattr(main.settings, "bind_host", "0.0.0.0")
+    with caplog.at_level(logging.CRITICAL, logger="app.main"):
+        main._check_security_config()
+    assert not any(r.levelno == logging.CRITICAL for r in caplog.records)


### PR DESCRIPTION
When auth is disabled and the server is bound to a non-loopback address,
every request is accepted without authentication, leaking all user data.
_check_security_config() fires at lifespan startup and emits a CRITICAL
log warning when this unsafe combination is detected. A new BIND_HOST
config setting (default 127.0.0.1) lets operators declare their bind
address so the guard can compare it against the loopback set. README
documents the safe-default rule. Three new tests cover warn/silent paths.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017TyU3C39ghE1Lwpqij9g3g