### PR TITLE
P3-3: lift model catalog from code into Settings.available_models

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -14,7 +14,7 @@ from app import training_load
 from app import threshold as threshold_mod
 from app import adherence as adherence_mod
 from app import intensity as intensity_mod
-from app.config import settings, AVAILABLE_MODELS
+from app.config import settings
 from app.database import db_session
 from app.models import (
     DEFAULT_USER_ID,
@@ -719,11 +719,11 @@ def _get_ai_config(db: Session, user_id: int = DEFAULT_USER_ID) -> tuple[str, st
         .first()
     )
     provider = provider_row.value if provider_row else "claude"
-    if provider not in AVAILABLE_MODELS:
-        logger.warning("Stored AI provider %r is not in AVAILABLE_MODELS; falling back to 'claude'", provider)
+    if provider not in settings.available_models:
+        logger.warning("Stored AI provider %r is not in available_models; falling back to 'claude'", provider)
         provider = "claude"
     stored_model = model_row.value if model_row else None
-    if stored_model and stored_model in AVAILABLE_MODELS.get(provider, []):
+    if stored_model and stored_model in settings.available_models.get(provider, []):
         model = stored_model
     else:
         if stored_model:

--- a/app/api.py
+++ b/app/api.py
@@ -90,7 +90,7 @@ from app import threshold as threshold_mod
 from app import adherence as adherence_mod
 from app import intensity as intensity_mod
 from app import streams as streams_mod
-from app.config import AVAILABLE_MODELS
+from app.config import settings as app_settings
 from app.utils import safe_json_loads, parse_activity_charts, parse_activity_route, calculate_age
 
 logger = logging.getLogger(__name__)
@@ -717,7 +717,6 @@ def api_get_ai_config(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    from app.config import settings as app_settings
     provider_row = (
         db.query(SyncStatus)
         .filter(SyncStatus.user_id == current_user.id, SyncStatus.key == "ai_provider")
@@ -733,8 +732,8 @@ def api_get_ai_config(
     return AiConfigResponse(
         provider=provider,
         model=model,
-        available_providers=list(AVAILABLE_MODELS.keys()),
-        available_models=AVAILABLE_MODELS,
+        available_providers=list(app_settings.available_models.keys()),
+        available_models=app_settings.available_models,
     )
 
 
@@ -744,9 +743,9 @@ def api_set_ai_config(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if config.provider not in AVAILABLE_MODELS:
+    if config.provider not in app_settings.available_models:
         raise HTTPException(status_code=400, detail=f"Unknown provider: {config.provider}")
-    if config.model not in AVAILABLE_MODELS[config.provider]:
+    if config.model not in app_settings.available_models[config.provider]:
         raise HTTPException(status_code=400, detail=f"Model {config.model} not valid for {config.provider}")
 
     for key, value in [("ai_provider", config.provider), ("ai_model", config.model)]:
@@ -764,8 +763,8 @@ def api_set_ai_config(
     return AiConfigResponse(
         provider=config.provider,
         model=config.model,
-        available_providers=list(AVAILABLE_MODELS.keys()),
-        available_models=AVAILABLE_MODELS,
+        available_providers=list(app_settings.available_models.keys()),
+        available_models=app_settings.available_models,
     )
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,6 @@
 from pydantic_settings import BaseSettings
 
-AVAILABLE_MODELS: dict[str, list[str]] = {
+_DEFAULT_AVAILABLE_MODELS: dict[str, list[str]] = {
     "claude": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
     "gemini": [
         "gemini-2.5-flash",
@@ -29,6 +29,9 @@ class Settings(BaseSettings):
     # finalize the morning after.
     daily_sync_window_days: int = 3
     ai_model: str = "claude-sonnet-4-6"
+    # Overridable via AVAILABLE_MODELS env var as a JSON object, e.g.:
+    # AVAILABLE_MODELS='{"claude": ["claude-opus-4-8"], "gemini": ["gemini-2.5-flash"]}'
+    available_models: dict[str, list[str]] = _DEFAULT_AVAILABLE_MODELS
 
     # Auth / multi-user
     auth_enabled: bool = False

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -230,7 +230,7 @@ sharpens the closed-loop plan's input signal.
   extend incrementally rather than refitting wholesale. **M.** Files:
   `app/training_load.py`, `app/threshold.py`, optional series table in
   `app/models.py`.
-- **P3-3 · Model catalog from config/env.** `AVAILABLE_MODELS` still lives in
+- ✅ **P3-3 · Model catalog from config/env.** `AVAILABLE_MODELS` still lives in
   `app/config.py` as code; lift the catalog to env/config so new model IDs don't
   require a code edit (`CURRENT_STATE.md` "Config / Catalog Drift"). **S.** Files:
   `app/config.py`, `app/ai_coach.py`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,52 @@
+"""Tests for P3-3: model catalog lifted into Settings.available_models."""
+
+import json
+import pytest
+from pydantic_settings import BaseSettings
+
+
+def test_default_available_models_has_claude_and_gemini():
+    from app.config import settings
+
+    catalog = settings.available_models
+    assert "claude" in catalog
+    assert "gemini" in catalog
+    assert len(catalog["claude"]) > 0
+    assert len(catalog["gemini"]) > 0
+
+
+def test_default_available_models_contains_known_models():
+    from app.config import settings
+
+    assert "claude-sonnet-4-6" in settings.available_models["claude"]
+    assert "gemini-2.5-flash" in settings.available_models["gemini"]
+
+
+def test_available_models_overridable_via_env(monkeypatch):
+    """AVAILABLE_MODELS env var (JSON) overrides the default catalog."""
+    custom = {"mycloud": ["model-a", "model-b"]}
+    monkeypatch.setenv("AVAILABLE_MODELS", json.dumps(custom))
+
+    # Instantiate a fresh Settings to pick up the env override.
+    from pydantic_settings import BaseSettings
+    from app.config import Settings
+
+    fresh = Settings()
+    assert fresh.available_models == custom
+    assert "mycloud" in fresh.available_models
+    assert "model-a" in fresh.available_models["mycloud"]
+
+
+def test_available_models_env_can_add_provider(monkeypatch):
+    """Operators can extend the catalog without a code change."""
+    from app.config import Settings, _DEFAULT_AVAILABLE_MODELS
+
+    extended = dict(_DEFAULT_AVAILABLE_MODELS)
+    extended["openai"] = ["gpt-4o"]
+    monkeypatch.setenv("AVAILABLE_MODELS", json.dumps(extended))
+
+    fresh = Settings()
+    assert "openai" in fresh.available_models
+    assert "gpt-4o" in fresh.available_models["openai"]
+    # Original providers still present.
+    assert "claude" in fresh.available_models


### PR DESCRIPTION
AVAILABLE_MODELS was a hardcoded module-level dict in app/config.py.
Moving it into the Settings class as available_models lets operators
override the catalog via an AVAILABLE_MODELS env var (JSON object)
without touching source code, closing the Config/Catalog Drift gap.

All call sites in app/ai_coach.py and app/api.py updated to use
settings.available_models; tests/test_config.py covers the default
catalog and the env-var override path.