### PR TITLE
feat: P0-1 weather-adjusted pace and heat-aware coaching

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -14,6 +14,7 @@ from app import training_load
 from app import threshold as threshold_mod
 from app import adherence as adherence_mod
 from app import intensity as intensity_mod
+from app import weather as weather_mod
 from app.config import settings
 from app.database import db_session
 from app.models import (
@@ -278,6 +279,18 @@ def _format_activity_context(
         except (json.JSONDecodeError, TypeError):
             pass
 
+    # Weather-adjusted pace
+    if activity.weather_json:
+        try:
+            weather = weather_mod.parse_weather(activity.weather_json)
+            _, penalty_sec, wx_desc = weather_mod.weather_pace_info(
+                weather, activity.avg_pace_min_km
+            )
+            if wx_desc:
+                parts.append(f"Weather: {wx_desc}")
+        except Exception:
+            pass
+
     return "\n".join(parts)
 
 
@@ -406,6 +419,46 @@ def _format_athlete_profile_context(profile: AthleteProfile, reference_date: dat
     return "## Athlete Profile\n" + "\n".join(lines)
 
 
+def _recent_heat_stress_note(
+    db: Session,
+    reference_date: date,
+    user_id: int = DEFAULT_USER_ID,
+) -> str:
+    """Return a one-line heat-stress note for the readiness section.
+
+    Checks the last 3 running activities with weather data. If any had a
+    notable heat penalty (≥ 5 s/km), surface a coaching note so the AI
+    factors environmental load into its recovery assessment.
+    """
+    cutoff = reference_date - timedelta(days=7)
+    recent = (
+        db.query(Activity)
+        .filter(
+            Activity.user_id == user_id,
+            Activity.started_at >= datetime.combine(cutoff, datetime.min.time(), tzinfo=timezone.utc),
+            Activity.weather_json.isnot(None),
+        )
+        .order_by(Activity.started_at.desc())
+        .limit(3)
+        .all()
+    )
+    hot_runs: list[str] = []
+    for act in recent:
+        try:
+            weather = weather_mod.parse_weather(act.weather_json)
+            _, penalty_sec, _ = weather_mod.weather_pace_info(weather, act.avg_pace_min_km)
+            if penalty_sec is not None and penalty_sec >= 5:
+                date_str = act.started_at.strftime("%m/%d") if act.started_at else "recent"
+                hot_runs.append(f"{date_str} (~{int(penalty_sec)} s/km heat penalty)")
+        except Exception:
+            continue
+
+    if not hot_runs:
+        return ""
+    runs_str = ", ".join(hot_runs)
+    return f"- Recent heat stress: {runs_str} — environmental load may be elevating fatigue"
+
+
 def _build_context(
     db: Session,
     trigger_type: str,
@@ -469,6 +522,13 @@ def _build_context(
     recent_rhr = [row[0] for row in recent_rhr_rows]
     readiness = training_load.compute_readiness(today_summary, load_point, recent_rhr)
     readiness_context = training_load.format_readiness_context(readiness)
+
+    # Append a heat-stress note to readiness when recent runs were hot/humid.
+    # Query the last 3 activities with weather data and check for notable penalties.
+    heat_penalty_note = _recent_heat_stress_note(db, reference_date, user_id)
+    if heat_penalty_note:
+        readiness_context = (readiness_context + "\n" + heat_penalty_note).strip()
+
     if readiness_context:
         insert_pos = min(3, len(sections))
         sections.insert(insert_pos, readiness_context)

--- a/app/api.py
+++ b/app/api.py
@@ -90,6 +90,7 @@ from app import threshold as threshold_mod
 from app import adherence as adherence_mod
 from app import intensity as intensity_mod
 from app import streams as streams_mod
+from app import weather as weather_mod
 from app.config import settings as app_settings
 from app.utils import safe_json_loads, parse_activity_charts, parse_activity_route, calculate_age
 
@@ -454,6 +455,10 @@ def api_activity_detail(
                 workout_steps = adherence_mod.parse_workout_steps(workout_event.raw_json)
                 activity_adherence = adherence_mod.compute_adherence(activity, workout_steps)
 
+    wx_adjusted_pace, wx_penalty_sec, wx_description = weather_mod.weather_pace_info(
+        weather, activity.avg_pace_min_km
+    )
+
     result = ActivityDetail.model_validate(activity)
     result.splits = splits
     result.hr_zones = hr_zones
@@ -466,6 +471,9 @@ def api_activity_detail(
     result.scheduled_workout = scheduled_workout
     result.adherence = activity_adherence
     result.feedback_tags = safe_json_loads(activity.feedback_tags)
+    result.weather_adjusted_pace_min_km = wx_adjusted_pace
+    result.weather_penalty_sec_per_km = wx_penalty_sec
+    result.weather_description = wx_description
     return result
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -156,6 +156,11 @@ class ActivityDetail(BaseModel):
     decoupling_pct: float | None = None
     efficiency_factor: float | None = None
 
+    # Weather-adjusted pace (None when conditions are neutral or no weather data)
+    weather_adjusted_pace_min_km: float | None = None
+    weather_penalty_sec_per_km: float | None = None
+    weather_description: str | None = None
+
     # Parsed JSON fields
     splits: Any | None = None
     hr_zones: Any | None = None

--- a/app/weather.py
+++ b/app/weather.py
@@ -8,6 +8,11 @@ Model (Ely et al. 2007 + running physiology consensus):
   - Dew point contribution:  +0.6 % per °C above 10 °C  (humidity/sweating load)
   - Combined factor ≥ 1.0 — pace is slower by this multiple in hot/humid conditions
   - weather_adjusted_pace = raw_pace / factor  (cool-equivalent effort)
+
+Note: Garmin Connect's activity-weather API returns temp/dewPoint in Fahrenheit
+regardless of the account's locale/display-unit setting — the Garmin app/Connect
+UI converts to Celsius for display, but the raw field stays °F. We convert to
+Celsius before applying the model.
 """
 
 from __future__ import annotations
@@ -34,6 +39,10 @@ def _get_field(data: dict, *keys: str, default=None):
         if k in data and data[k] is not None:
             return data[k]
     return default
+
+
+def _fahrenheit_to_celsius(value: float) -> float:
+    return (value - 32.0) * 5.0 / 9.0
 
 
 def heat_pace_adjustment(
@@ -67,15 +76,18 @@ def weather_pace_info(
     if not weather or avg_pace_min_km is None:
         return None, None, None
 
-    raw_temp = _get_field(weather, "temperature", "temp", "temperatureC", "apparentTemperature")
-    raw_dp = _get_field(weather, "dewPoint", "dew_point", "dewPointC")
+    raw_temp = _get_field(weather, "temp", "temperature", "apparentTemperature")
+    raw_dp = _get_field(weather, "dewPoint", "dew_point")
 
     if raw_temp is None and raw_dp is None:
         return None, None, None
 
+    # Garmin Connect's activity-weather endpoint always returns temp/dewPoint in
+    # Fahrenheit, regardless of the account's display-unit setting (the app
+    # converts for display) — convert here so the °C-based model is correct.
     try:
-        temp = float(raw_temp) if raw_temp is not None else None
-        dp = float(raw_dp) if raw_dp is not None else None
+        temp = _fahrenheit_to_celsius(float(raw_temp)) if raw_temp is not None else None
+        dp = _fahrenheit_to_celsius(float(raw_dp)) if raw_dp is not None else None
     except (TypeError, ValueError):
         return None, None, None
 

--- a/app/weather.py
+++ b/app/weather.py
@@ -1,0 +1,103 @@
+"""Weather-based pace adjustment helpers.
+
+Derives a heat/humidity pace penalty (sec/km) from stored Garmin activity
+weather so the AI coach and activity UI can surface effort-normalized pace.
+
+Model (Ely et al. 2007 + running physiology consensus):
+  - Temperature contribution: +0.4 % per °C above 10 °C
+  - Dew point contribution:  +0.6 % per °C above 10 °C  (humidity/sweating load)
+  - Combined factor ≥ 1.0 — pace is slower by this multiple in hot/humid conditions
+  - weather_adjusted_pace = raw_pace / factor  (cool-equivalent effort)
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def parse_weather(weather_json: str | dict | None) -> dict | None:
+    """Parse and normalize Activity.weather_json to a plain dict."""
+    if weather_json is None:
+        return None
+    if isinstance(weather_json, dict):
+        return weather_json
+    try:
+        data = json.loads(weather_json)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _get_field(data: dict, *keys: str, default=None):
+    """Try multiple key spellings and return the first match."""
+    for k in keys:
+        if k in data and data[k] is not None:
+            return data[k]
+    return default
+
+
+def heat_pace_adjustment(
+    temp_c: float | None,
+    dew_point_c: float | None,
+) -> tuple[float, float]:
+    """Return (adjustment_factor, penalty_pct) for given temp and dew point.
+
+    adjustment_factor >= 1.0 means pace is that multiple slower in these conditions.
+    penalty_pct is the total percentage slowdown (0 = neutral).
+    """
+    temp = float(temp_c) if temp_c is not None else 10.0
+    dp = float(dew_point_c) if dew_point_c is not None else 5.0
+
+    temp_penalty = max(0.0, (temp - 10.0) * 0.4)
+    dp_penalty = max(0.0, (dp - 10.0) * 0.6)
+    total_pct = temp_penalty + dp_penalty
+
+    return 1.0 + total_pct / 100.0, total_pct
+
+
+def weather_pace_info(
+    weather: dict | None,
+    avg_pace_min_km: float | None,
+) -> tuple[float | None, float | None, str | None]:
+    """Compute weather-adjusted pace from a parsed weather dict and raw avg pace.
+
+    Returns (adjusted_pace_min_km, penalty_sec_per_km, description).
+    All three are None when conditions are neutral (< 2 s/km penalty) or data missing.
+    """
+    if not weather or avg_pace_min_km is None:
+        return None, None, None
+
+    raw_temp = _get_field(weather, "temperature", "temp", "temperatureC", "apparentTemperature")
+    raw_dp = _get_field(weather, "dewPoint", "dew_point", "dewPointC")
+
+    if raw_temp is None and raw_dp is None:
+        return None, None, None
+
+    try:
+        temp = float(raw_temp) if raw_temp is not None else None
+        dp = float(raw_dp) if raw_dp is not None else None
+    except (TypeError, ValueError):
+        return None, None, None
+
+    factor, _ = heat_pace_adjustment(temp, dp)
+
+    adjusted_pace = avg_pace_min_km / factor
+    penalty_sec = (avg_pace_min_km - adjusted_pace) * 60.0
+
+    if penalty_sec < 2.0:
+        return None, None, None
+
+    penalty_sec_rounded = round(penalty_sec)
+
+    temp_str = f"{temp:.0f}°C" if temp is not None else "hot conditions"
+    if dp is not None and dp > 10:
+        conditions = f"{temp_str} / dew point {dp:.0f}°C"
+    else:
+        conditions = temp_str
+
+    description = (
+        f"{conditions} — ~{penalty_sec_rounded} s/km heat penalty, "
+        "effort was stronger than the clock"
+    )
+
+    return adjusted_pace, float(penalty_sec_rounded), description

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -92,7 +92,7 @@ present. Effort key: **S** ≈ <1 day · **M** ≈ 1–3 days · **L** ≈ sever
 
 ### P0 — Highest leverage, data/infra already present
 
-#### P0-1 · Weather-adjusted pace & heat-aware coaching
+#### P0-1 · Weather-adjusted pace & heat-aware coaching ✅ DONE (2026-06-30)
 **What:** Use the `Activity.weather_json` we already store. Add a small helper that
 derives a **heat/dew-point pace adjustment** (sec/km) and an effort-normalized
 "weather-adjusted pace" per run, then (a) show it on Activity Detail next to raw
@@ -106,10 +106,11 @@ is the biggest day-to-day pace confounder, and Runna, MeteoPace, and RunWeather 
 made weather-adjusted pace an expectation. Pure analytic add over stored data; no
 new sync.
 **Effort:** S–M.
-**Files:** new helper in `app/streams.py` or `app/pacing.py` (heat-adjustment
-model), `app/ai_coach.py` (`_format_activity_context`, readiness narrative),
-`app/api.py` (activity detail field; optional Today field), `app/schemas.py`,
-`frontend/src/components/activity-detail/*` + `today/*` + types.
+**Files:** `app/weather.py` (new), `app/ai_coach.py` (`_format_activity_context`,
+`_recent_heat_stress_note`, `_build_context`), `app/api.py` (activity detail),
+`app/schemas.py`, `frontend/src/api/types.ts`,
+`frontend/src/components/activity-detail/ActivityDetailView.tsx` + `.css`,
+`tests/test_weather.py` (new, 19 tests).
 
 #### P0-2 · Let the coach act on the conversation (chat tool-use)
 **What:** Give `chat_stream` the same tool-use treatment plan generation already

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -123,6 +123,9 @@ export interface ActivityDetail extends ActivitySummary {
   walk_time_sec: number | null
   decoupling_pct: number | null
   efficiency_factor: number | null
+  weather_adjusted_pace_min_km: number | null
+  weather_penalty_sec_per_km: number | null
+  weather_description: string | null
   splits: any
   hr_zones: any
   weather: any

--- a/frontend/src/components/activity-detail/ActivityDetailView.css
+++ b/frontend/src/components/activity-detail/ActivityDetailView.css
@@ -79,3 +79,10 @@
   overflow: hidden;
   padding: 0;
 }
+
+.weather-description {
+  margin: 8px 0 0;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}

--- a/frontend/src/components/activity-detail/ActivityDetailView.tsx
+++ b/frontend/src/components/activity-detail/ActivityDetailView.tsx
@@ -90,6 +90,15 @@ export default function ActivityDetailView() {
     activity.efficiency_factor != null ? { label: 'EF', value: (activity.efficiency_factor * 1000).toFixed(2), unit: 'mm/s/bpm' } : null,
   ].filter(Boolean) as { label: string; value: string; unit?: string }[]
 
+  const weatherStats = [
+    activity.weather_adjusted_pace_min_km != null
+      ? { label: 'Adj. Pace', value: formatPace(activity.weather_adjusted_pace_min_km), unit: '/km' }
+      : null,
+    activity.weather_penalty_sec_per_km != null
+      ? { label: 'Heat Penalty', value: `+${Math.round(activity.weather_penalty_sec_per_km)}`, unit: 's/km' }
+      : null,
+  ].filter(Boolean) as { label: string; value: string; unit?: string }[]
+
   return (
     <div className="activity-detail">
       {/* Header */}
@@ -161,6 +170,17 @@ export default function ActivityDetailView() {
               <StatHelpButton topic="activity-performance" label="Performance" />
             </div>
             <StatGrid stats={perfStats} columns={3} />
+          </section>
+        )}
+
+        {/* Weather conditions */}
+        {weatherStats.length > 0 && (
+          <section className="detail-section">
+            <h3 className="section-title">Conditions</h3>
+            <StatGrid stats={weatherStats} columns={2} />
+            {activity.weather_description && (
+              <p className="weather-description">{activity.weather_description}</p>
+            )}
           </section>
         )}
 

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,137 @@
+"""Tests for app/weather.py — heat-adjustment helpers."""
+
+import json
+import pytest
+
+from app.weather import heat_pace_adjustment, parse_weather, weather_pace_info
+
+
+# --- parse_weather ---
+
+def test_parse_weather_none():
+    assert parse_weather(None) is None
+
+
+def test_parse_weather_dict_passthrough():
+    d = {"temperature": 20, "dewPoint": 15}
+    assert parse_weather(d) is d
+
+
+def test_parse_weather_valid_json_string():
+    d = {"temperature": 23, "dewPoint": 18}
+    result = parse_weather(json.dumps(d))
+    assert result == d
+
+
+def test_parse_weather_invalid_json():
+    assert parse_weather("not json") is None
+
+
+def test_parse_weather_non_dict_json():
+    assert parse_weather("[1, 2, 3]") is None
+
+
+# --- heat_pace_adjustment ---
+
+def test_no_penalty_at_baseline():
+    factor, pct = heat_pace_adjustment(10.0, 5.0)
+    assert factor == pytest.approx(1.0)
+    assert pct == pytest.approx(0.0)
+
+
+def test_no_penalty_below_baseline():
+    factor, pct = heat_pace_adjustment(5.0, 0.0)
+    assert factor == pytest.approx(1.0)
+    assert pct == pytest.approx(0.0)
+
+
+def test_temperature_only_penalty():
+    # 20°C, low dew point — 10°C above baseline → 4 % temp penalty
+    factor, pct = heat_pace_adjustment(20.0, 5.0)
+    assert pct == pytest.approx(4.0)
+    assert factor == pytest.approx(1.04)
+
+
+def test_dew_point_adds_humidity_penalty():
+    # 20°C + 20°C dew point: 4 % temp + 6 % dp = 10 %
+    factor, pct = heat_pace_adjustment(20.0, 20.0)
+    assert pct == pytest.approx(10.0)
+    assert factor == pytest.approx(1.10)
+
+
+def test_none_inputs_use_defaults():
+    # None temp → assumed 10°C (no temp penalty), None dp → assumed 5°C (no dp penalty)
+    factor, pct = heat_pace_adjustment(None, None)
+    assert factor == pytest.approx(1.0)
+    assert pct == pytest.approx(0.0)
+
+
+def test_hot_humid_conditions():
+    # 30°C, dew point 22°C: (20 * 0.4) + (12 * 0.6) = 8 + 7.2 = 15.2 %
+    factor, pct = heat_pace_adjustment(30.0, 22.0)
+    assert pct == pytest.approx(15.2)
+    assert factor == pytest.approx(1.152)
+
+
+# --- weather_pace_info ---
+
+def test_neutral_conditions_returns_none():
+    # 11°C / no dew point data — penalty ~1.2 s/km, below the 2 s/km threshold
+    weather = {"temperature": 11}
+    adj, pen, desc = weather_pace_info(weather, 5.0)
+    assert adj is None
+    assert pen is None
+    assert desc is None
+
+
+def test_hot_run_returns_adjusted_pace():
+    # 25°C / dew point 18°C with 5:00/km pace
+    weather = {"temperature": 25, "dewPoint": 18}
+    adj, pen, desc = weather_pace_info(weather, 5.0)
+    assert adj is not None
+    assert adj < 5.0  # adjusted pace should be faster (easier-equivalent)
+    assert pen is not None
+    assert pen >= 2.0
+    assert "25°C" in desc
+    assert "18°C" in desc
+    assert "s/km" in desc
+    assert "stronger" in desc
+
+
+def test_no_weather_returns_none():
+    adj, pen, desc = weather_pace_info(None, 5.0)
+    assert (adj, pen, desc) == (None, None, None)
+
+
+def test_no_pace_returns_none():
+    adj, pen, desc = weather_pace_info({"temperature": 30}, None)
+    assert (adj, pen, desc) == (None, None, None)
+
+
+def test_alternative_key_spellings():
+    # Garmin sometimes uses "temp" instead of "temperature"
+    weather = {"temp": 25, "dew_point": 18}
+    adj, pen, desc = weather_pace_info(weather, 5.0)
+    assert adj is not None
+    assert pen is not None
+
+
+def test_temperature_only_no_dew_point():
+    # Hot but dry conditions — temperature key only
+    weather = {"temperature": 28}
+    adj, pen, desc = weather_pace_info(weather, 5.0)
+    assert adj is not None
+    assert "dew point" not in desc  # dew point not mentioned when ≤ 10°C default
+
+
+def test_description_omits_dew_point_when_low():
+    # Dew point at 8°C — below the 10°C threshold, so not mentioned in desc
+    weather = {"temperature": 25, "dewPoint": 8}
+    adj, pen, desc = weather_pace_info(weather, 5.0)
+    if desc is not None:
+        assert "dew point" not in desc
+
+
+def test_empty_weather_dict_returns_none():
+    adj, pen, desc = weather_pace_info({}, 5.0)
+    assert (adj, pen, desc) == (None, None, None)

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -74,19 +74,36 @@ def test_hot_humid_conditions():
 
 
 # --- weather_pace_info ---
+#
+# Garmin's activity-weather API returns temp/dewPoint in Fahrenheit regardless
+# of locale (confirmed: a Garmin app showing 14°C corresponded to a stored
+# "temp": 57 in the raw payload — 57°F == 13.9°C). weather_pace_info converts
+# F -> C internally, so test fixtures below use Fahrenheit values.
 
 def test_neutral_conditions_returns_none():
-    # 11°C / no dew point data — penalty ~1.2 s/km, below the 2 s/km threshold
-    weather = {"temperature": 11}
+    # 52°F -> 11.1°C, no dew point data — penalty ~1.3 s/km, below the 2 s/km threshold
+    weather = {"temperature": 52}
     adj, pen, desc = weather_pace_info(weather, 5.0)
     assert adj is None
     assert pen is None
     assert desc is None
 
 
+def test_garmin_fahrenheit_payload_converts_correctly():
+    # Real-world regression: Garmin app showed 14°C / dew point 11°C, but the
+    # raw activity-weather payload was {"temp": 57, "dewPoint": 52} (°F).
+    weather = {"temp": 57, "dewPoint": 52}
+    adj, pen, desc = weather_pace_info(weather, 5.0)
+    assert desc is not None
+    assert "14°C" in desc
+    assert "11°C" in desc
+    assert "57°C" not in desc
+    assert "52°C" not in desc
+
+
 def test_hot_run_returns_adjusted_pace():
-    # 25°C / dew point 18°C with 5:00/km pace
-    weather = {"temperature": 25, "dewPoint": 18}
+    # 77°F / dew point 64°F == 25°C / dew point ~18°C, with 5:00/km pace
+    weather = {"temperature": 77, "dewPoint": 64}
     adj, pen, desc = weather_pace_info(weather, 5.0)
     assert adj is not None
     assert adj < 5.0  # adjusted pace should be faster (easier-equivalent)
@@ -104,29 +121,31 @@ def test_no_weather_returns_none():
 
 
 def test_no_pace_returns_none():
-    adj, pen, desc = weather_pace_info({"temperature": 30}, None)
+    adj, pen, desc = weather_pace_info({"temperature": 86}, None)
     assert (adj, pen, desc) == (None, None, None)
 
 
 def test_alternative_key_spellings():
-    # Garmin sometimes uses "temp" instead of "temperature"
-    weather = {"temp": 25, "dew_point": 18}
+    # Garmin sometimes uses "temp" instead of "temperature"; values in °F.
+    # 90°F / 80°F dew point == hot and humid once converted to °C.
+    weather = {"temp": 90, "dew_point": 80}
     adj, pen, desc = weather_pace_info(weather, 5.0)
     assert adj is not None
     assert pen is not None
 
 
 def test_temperature_only_no_dew_point():
-    # Hot but dry conditions — temperature key only
-    weather = {"temperature": 28}
+    # Hot but dry conditions — temperature key only (90°F == 32.2°C)
+    weather = {"temperature": 90}
     adj, pen, desc = weather_pace_info(weather, 5.0)
     assert adj is not None
-    assert "dew point" not in desc  # dew point not mentioned when ≤ 10°C default
+    assert "dew point" not in desc  # dew point not mentioned when absent
 
 
 def test_description_omits_dew_point_when_low():
-    # Dew point at 8°C — below the 10°C threshold, so not mentioned in desc
-    weather = {"temperature": 25, "dewPoint": 8}
+    # 77°F == 25°C temp, 45°F == 7.2°C dew point — below the 10°C threshold,
+    # so dew point is not mentioned in the description.
+    weather = {"temperature": 77, "dewPoint": 45}
     adj, pen, desc = weather_pace_info(weather, 5.0)
     if desc is not None:
         assert "dew point" not in desc


### PR DESCRIPTION
Add app/weather.py with a heat/dew-point pace adjustment model (Ely et al.
research-based: +0.4%/°C above 10°C temp, +0.6%/°C above 10°C dew point).

Three deliverables:
(a) Activity Detail now shows "Adj. Pace" and "Heat Penalty" stats plus a
    one-line conditions description when weather data yields ≥ 2 s/km penalty.
(b) _format_activity_context folds the heat note into AI per-activity context
    so the coach knows the effort was stronger than the clock.
(c) _build_context checks the last 3 activities for notable heat stress and
    appends a recovery qualifier to the readiness narrative.

19 new unit tests; total suite: 613 passed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S9VhSoJEq89zLbGYs93wb2