### PR TITLE
feat: P0-2 chat tool-use — let the coach act on the conversation

### DIFF
--- a/alembic/versions/k4l5m6n7o8p9_add_chat_actions_json.py
+++ b/alembic/versions/k4l5m6n7o8p9_add_chat_actions_json.py
@@ -1,0 +1,28 @@
+"""add actions_json to chat_messages
+
+Revision ID: k4l5m6n7o8p9
+Revises: j3k4l5m6n7o8
+Create Date: 2026-06-30
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision: str = "k4l5m6n7o8p9"
+down_revision: Union[str, None] = "j3k4l5m6n7o8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    insp = inspect(op.get_bind())
+    cols = {c["name"] for c in insp.get_columns("chat_messages")}
+    if "actions_json" not in cols:
+        op.add_column("chat_messages", sa.Column("actions_json", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("chat_messages", "actions_json")

--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -924,7 +924,7 @@ def execute_job(job_id: int) -> None:
         elif task_type == "analyze_feedback":
             analyze_activity_with_feedback(payload["activity_id"])
         elif task_type == "generate_plan":
-            generate_training_plan(user_id=user_id)
+            generate_training_plan(user_id=user_id, note=payload.get("note"))
         elif task_type == "weekly_review":
             weekly_review(user_id=user_id)
         else:
@@ -1730,12 +1730,14 @@ def detect_plan_realignment(
 
 
 def generate_training_plan(
-    reference_date: date | None = None, user_id: int = DEFAULT_USER_ID
+    reference_date: date | None = None, user_id: int = DEFAULT_USER_ID, note: str | None = None
 ) -> TrainingPlan | None:
     """Generate and persist a 4-week AI training plan.
 
     Can be called from the API (on demand) or from the scheduler (weekly).
-    Returns the new TrainingPlan or None on failure.
+    `note` carries an optional athlete-stated reason (e.g. from the chat
+    adjust_upcoming_week tool) that should take priority over the default
+    rolling-adherence logic. Returns the new TrainingPlan or None on failure.
     """
     with db_session() as db:
         ref = reference_date or date.today()
@@ -1749,6 +1751,11 @@ def generate_training_plan(
                 f"Generate a 4-week running training plan starting Monday {week_start}.\n\n"
                 f"Athlete context:\n{context}"
             )
+            if note:
+                plan_prompt += (
+                    f"\n\nAthlete note for this regeneration: {note}\n"
+                    "Prioritize accommodating this above the default rolling adherence logic."
+                )
 
             last_exc: Exception = RuntimeError("no attempts made")
             raw = None
@@ -1903,7 +1910,49 @@ Guidelines for chat responses:
 - Answer the specific question asked, then offer one follow-up insight if relevant
 - Reference specific data from their context when it supports your point
 - Keep responses concise (2-4 short paragraphs max) unless they ask for detail
-- Use markdown sparingly — only headers/bullets when they genuinely help clarity"""
+- Use markdown sparingly — only headers/bullets when they genuinely help clarity
+
+You also have tools to act on the conversation, not just talk about it:
+- Use regenerate_plan or adjust_upcoming_week when the athlete asks you to redo,
+  rework, or reschedule their plan — don't just describe what you would do, call
+  the tool. adjust_upcoming_week is for a specific stated reason (travel, illness,
+  a busy week); regenerate_plan is for a general "start over" request.
+- Use mark_setback when the athlete mentions a niggle, injury, or life constraint
+  worth remembering, even mid-conversation about something else.
+- Use explain_workout when asked about a specific scheduled day — look it up
+  rather than guessing from memory.
+- For everything else, just answer normally. Only call a tool when the athlete's
+  message clearly calls for one of these actions."""
+
+
+def _format_upcoming_plan_context(db: Session, user_id: int) -> str:
+    """Append the next 7 days of the active plan so explain_workout has real dates to reference."""
+    plan = (
+        db.query(TrainingPlan)
+        .filter(TrainingPlan.user_id == user_id)
+        .order_by(TrainingPlan.generated_at.desc())
+        .first()
+    )
+    if not plan:
+        return ""
+    today = date.today()
+    days = (
+        db.query(TrainingPlanDay)
+        .filter(
+            TrainingPlanDay.plan_id == plan.id,
+            TrainingPlanDay.day_date >= today,
+            TrainingPlanDay.day_date < today + timedelta(days=7),
+        )
+        .order_by(TrainingPlanDay.day_date.asc())
+        .all()
+    )
+    if not days:
+        return ""
+    lines = [
+        f"- {d.day_date} ({d.day_of_week}): {d.workout_type} — {d.description or 'No description'}"
+        for d in days
+    ]
+    return "\n\n## Upcoming Plan This Week\n" + "\n".join(lines)
 
 
 def _build_chat_context(
@@ -1930,24 +1979,213 @@ def _build_chat_context(
             trigger_data = (
                 f"The athlete is asking about a specific activity:\n\n{activity_context}"
             )
-            return _build_context(db, "chat", trigger_data, user_id=user_id)
+            context = _build_context(db, "chat", trigger_data, user_id=user_id)
+            return context + _format_upcoming_plan_context(db, user_id)
 
     trigger_data = "The athlete is conversing with the AI running coach."
-    return _build_context(db, "chat", trigger_data, user_id=user_id)
+    context = _build_context(db, "chat", trigger_data, user_id=user_id)
+    return context + _format_upcoming_plan_context(db, user_id)
 
 
-def _stream_claude(history: list[dict], system: str, model: str):
-    """Yield text tokens from the Claude streaming API."""
-    client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+# Anthropic tool-use schema for chat — model may call at most one of these per turn.
+_CHAT_TOOL_SCHEMAS = [
+    {
+        "name": "regenerate_plan",
+        "description": (
+            "Regenerate the athlete's rolling training plan from scratch using their "
+            "current training data. Use when the athlete asks you to redo, reset, or "
+            "fully rebuild their plan."
+        ),
+        "input_schema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "adjust_upcoming_week",
+        "description": (
+            "Rework the upcoming training plan to account for a stated life constraint "
+            "(e.g. travel, illness, a busy week, reduced time). Regenerates the plan with "
+            "that reason factored in."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string",
+                    "description": "The athlete's stated reason, in their own words.",
+                },
+            },
+            "required": ["reason"],
+        },
+    },
+    {
+        "name": "mark_setback",
+        "description": (
+            "Record a niggle, injury, or life constraint the athlete mentions so future "
+            "coaching context remembers it, even if no plan change is requested yet."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "tag": {
+                    "type": "string",
+                    "description": "A short label, e.g. 'knee pain', 'low energy', 'travel'.",
+                },
+                "note": {
+                    "type": "string",
+                    "description": "A brief note in the athlete's words.",
+                },
+            },
+            "required": ["tag", "note"],
+        },
+    },
+    {
+        "name": "explain_workout",
+        "description": (
+            "Look up a specific scheduled training day by date and return its full "
+            "prescription so you can explain it to the athlete."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "description": "ISO date (YYYY-MM-DD) of the scheduled day to explain.",
+                },
+            },
+            "required": ["date"],
+        },
+    },
+]
+
+# Gemini function-declaration equivalent (same shape as _PLAN_GEMINI_RESPONSE_SCHEMA's
+# use of raw dicts for schema-bearing config).
+_CHAT_GEMINI_TOOLS = [
+    {
+        "function_declarations": [
+            {
+                "name": schema["name"],
+                "description": schema["description"],
+                "parameters": schema["input_schema"],
+            }
+            for schema in _CHAT_TOOL_SCHEMAS
+        ],
+    },
+]
+
+
+def _dispatch_chat_tool(
+    db: Session, user_id: int, tool_name: str, tool_input: dict
+) -> tuple[dict, dict | None]:
+    """Execute one chat tool call.
+
+    Returns (tool_result, action): tool_result is fed back to the model as the
+    tool result content so it can compose a grounded confirmation; action (if
+    not None) is a small public dict streamed to the client as an SSE 'action'
+    event and persisted alongside the chat message.
+    """
+    if tool_name == "regenerate_plan":
+        job_id = enqueue_job("generate_plan", {}, user_id)
+        return (
+            {"status": "queued", "job_id": job_id},
+            {
+                "type": "regenerate_plan",
+                "status": "queued",
+                "job_id": job_id,
+                "summary": "Regenerating your training plan.",
+            },
+        )
+
+    if tool_name == "adjust_upcoming_week":
+        reason = tool_input.get("reason", "")
+        job_id = enqueue_job("generate_plan", {"note": reason}, user_id)
+        return (
+            {"status": "queued", "job_id": job_id},
+            {
+                "type": "adjust_upcoming_week",
+                "status": "queued",
+                "job_id": job_id,
+                "summary": f"Reworking your plan: {reason}",
+            },
+        )
+
+    if tool_name == "mark_setback":
+        tag = tool_input.get("tag") or "setback"
+        note = tool_input.get("note", "")
+        db.add(Insight(
+            user_id=user_id,
+            created_at=datetime.now(timezone.utc),
+            trigger_type="chat_setback",
+            content=note,
+            summary=tag,
+            category="setback",
+        ))
+        db.commit()
+        return (
+            {"status": "recorded"},
+            {
+                "type": "mark_setback",
+                "status": "recorded",
+                "job_id": None,
+                "summary": f"Noted: {tag}.",
+            },
+        )
+
+    if tool_name == "explain_workout":
+        date_str = tool_input.get("date", "")
+        try:
+            day_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+        except ValueError:
+            return {"status": "invalid_date", "date": date_str}, None
+
+        plan = (
+            db.query(TrainingPlan)
+            .filter(TrainingPlan.user_id == user_id)
+            .order_by(TrainingPlan.generated_at.desc())
+            .first()
+        )
+        day = (
+            db.query(TrainingPlanDay)
+            .filter(
+                TrainingPlanDay.plan_id == plan.id,
+                TrainingPlanDay.day_date == day_date,
+            )
+            .first()
+            if plan
+            else None
+        )
+        if day is None:
+            return {"status": "not_found", "date": date_str}, None
+
+        return (
+            {
+                "status": "ok",
+                "date": date_str,
+                "workout_type": day.workout_type,
+                "target_distance_km": (
+                    round(day.target_distance_m / 1000, 2) if day.target_distance_m else None
+                ),
+                "target_pace_display": day.target_pace_display,
+                "description": day.description,
+                "notes": day.notes,
+            },
+            None,
+        )
+
+    raise ValueError(f"Unknown chat tool: {tool_name!r}")
+
+
+def _claude_stream_tokens(client: "anthropic.Anthropic", **stream_kwargs):
+    """Yield {'type': 'token', 'text': ...} events for one Claude streaming call.
+
+    Returns (via generator return value, retrievable with `yield from`) the
+    final Message once the stream completes, so callers can inspect it for a
+    tool_use block.
+    """
     try:
-        with client.messages.stream(
-            model=model,
-            max_tokens=2048,
-            system=system,
-            messages=history,
-        ) as stream:
-            for text in stream.text_stream:
-                yield text
+        with client.messages.stream(**stream_kwargs) as stream:
+            for event in stream:
+                if event.type == "content_block_delta" and event.delta.type == "text_delta":
+                    yield {"type": "token", "text": event.delta.text}
+            final_message = stream.get_final_message()
     except (
         anthropic.RateLimitError,
         anthropic.APITimeoutError,
@@ -1962,29 +2200,108 @@ def _stream_claude(history: list[dict], system: str, model: str):
         anthropic.NotFoundError,
     ) as exc:
         raise AIFatalError(str(exc)) from exc
+    return final_message
 
 
-def _stream_gemini(history: list[dict], system: str, model: str):
-    """Yield text tokens from the Gemini streaming API."""
-    client = genai.Client(api_key=settings.gemini_api_key)
+def _stream_claude(history: list[dict], system: str, model: str, db: Session, user_id: int):
+    """Yield token/action events from the Claude streaming API, dispatching at most one tool call."""
+    client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+    final_message = yield from _claude_stream_tokens(
+        client, model=model, max_tokens=2048, system=system, tools=_CHAT_TOOL_SCHEMAS, messages=history,
+    )
+
+    tool_use_block = next(
+        (b for b in final_message.content if b.type == "tool_use"), None
+    )
+    if tool_use_block is None:
+        return
+
+    result, action = _dispatch_chat_tool(db, user_id, tool_use_block.name, tool_use_block.input)
+    if action:
+        yield {"type": "action", "action": action}
+
+    followup_messages = history + [
+        {"role": "assistant", "content": final_message.content},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_block.id,
+                    "content": json.dumps(result),
+                }
+            ],
+        },
+    ]
+    yield from _claude_stream_tokens(
+        client, model=model, max_tokens=2048, system=system, messages=followup_messages,
+    )
+
+
+def _gemini_contents(history: list[dict]) -> list[dict]:
     contents = []
     for msg in history:
         role = "user" if msg["role"] == "user" else "model"
         contents.append({"role": role, "parts": [{"text": msg["content"]}]})
+    return contents
+
+
+def _gemini_stream_tokens(client: "genai.Client", **generate_kwargs):
+    """Yield {'type': 'token', 'text': ...} events for one Gemini streaming call.
+
+    Returns (via generator return value) the function_call part if the model
+    called one, else None.
+    """
+    function_call = None
     try:
-        for chunk in client.models.generate_content_stream(
-            model=model,
-            contents=contents,
-            config=_genai_types.GenerateContentConfig(system_instruction=system),
-        ):
+        for chunk in client.models.generate_content_stream(**generate_kwargs):
             if chunk.text:
-                yield chunk.text
+                yield {"type": "token", "text": chunk.text}
+            for candidate in chunk.candidates or []:
+                for part in (candidate.content.parts or []) if candidate.content else []:
+                    fc = getattr(part, "function_call", None)
+                    if fc is not None:
+                        function_call = fc
     except _genai_errors.ServerError as exc:
         raise AITransientError(str(exc)) from exc
     except _genai_errors.ClientError as exc:
         if getattr(exc, "code", None) == 429:
             raise AITransientError(str(exc)) from exc
         raise AIFatalError(str(exc)) from exc
+    return function_call
+
+
+def _stream_gemini(history: list[dict], system: str, model: str, db: Session, user_id: int):
+    """Yield token/action events from the Gemini streaming API, dispatching at most one tool call."""
+    client = genai.Client(api_key=settings.gemini_api_key)
+    contents = _gemini_contents(history)
+
+    function_call = yield from _gemini_stream_tokens(
+        client,
+        model=model,
+        contents=contents,
+        config=_genai_types.GenerateContentConfig(
+            system_instruction=system, tools=_CHAT_GEMINI_TOOLS,
+        ),
+    )
+    if function_call is None:
+        return
+
+    tool_args = dict(function_call.args or {})
+    result, action = _dispatch_chat_tool(db, user_id, function_call.name, tool_args)
+    if action:
+        yield {"type": "action", "action": action}
+
+    followup_contents = contents + [
+        {"role": "model", "parts": [{"function_call": {"name": function_call.name, "args": tool_args}}]},
+        {"role": "user", "parts": [{"function_response": {"name": function_call.name, "response": result}}]},
+    ]
+    yield from _gemini_stream_tokens(
+        client,
+        model=model,
+        contents=followup_contents,
+        config=_genai_types.GenerateContentConfig(system_instruction=system),
+    )
 
 
 def chat_stream(
@@ -1994,11 +2311,15 @@ def chat_stream(
     user_id: int = DEFAULT_USER_ID,
     activity_id: int | None = None,
 ):
-    """Build context and return a token-streaming generator for the chat response."""
+    """Build context and return an event-streaming generator for the chat response.
+
+    Yields dicts of shape {"type": "token", "text": ...} or
+    {"type": "action", "action": {...}} when the model invokes a coach tool.
+    """
     provider, model = _get_ai_config(db, user_id)
     context = _build_chat_context(db, user_id, activity_id)
     system = CHAT_SYSTEM_PROMPT + "\n\n---\n\n" + context
 
     messages = list(history) + [{"role": "user", "content": new_message}]
     stream_fn = _stream_gemini if provider == "gemini" else _stream_claude
-    return stream_fn(messages, system, model)
+    return stream_fn(messages, system, model, db, user_id)

--- a/app/api.py
+++ b/app/api.py
@@ -1662,7 +1662,17 @@ def api_get_chat(
         .all()
     )
     return ChatHistoryResponse(
-        messages=[ChatMessageResponse.model_validate(m) for m in messages]
+        messages=[
+            ChatMessageResponse(
+                id=m.id,
+                role=m.role,
+                content=m.content,
+                created_at=m.created_at,
+                activity_id=m.activity_id,
+                actions=json.loads(m.actions_json) if m.actions_json else None,
+            )
+            for m in messages
+        ]
     )
 
 
@@ -1715,18 +1725,24 @@ def api_post_chat(
 
     def generate():
         full_response: list[str] = []
+        actions: list[dict] = []
         try:
             with make_session() as session:
-                token_iter = _chat_stream(session, new_message, history, user_id, activity_id)
-                for token in token_iter:
-                    full_response.append(token)
-                    yield f"data: {json.dumps({'token': token})}\n\n"
+                event_iter = _chat_stream(session, new_message, history, user_id, activity_id)
+                for event in event_iter:
+                    if event["type"] == "token":
+                        full_response.append(event["text"])
+                        yield f"data: {json.dumps({'token': event['text']})}\n\n"
+                    elif event["type"] == "action":
+                        actions.append(event["action"])
+                        yield f"data: {json.dumps({'action': event['action']})}\n\n"
 
                 # Persist the complete AI response
                 assistant_msg = ChatMessage(
                     user_id=user_id,
                     role="assistant",
                     content="".join(full_response),
+                    actions_json=json.dumps(actions) if actions else None,
                 )
                 session.add(assistant_msg)
                 session.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -369,6 +369,7 @@ class ChatMessage(Base):
     content = Column(Text, nullable=False)
     created_at = Column(DateTime, default=_utcnow, index=True)
     activity_id = Column(Integer, nullable=True)  # optional activity context
+    actions_json = Column(Text, nullable=True)  # JSON list of coach tool actions taken this turn
 
 
 class DailyLoadSeries(Base):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -602,12 +602,20 @@ class PushWorkoutResponse(BaseModel):
     scheduled_date: str
 
 
+class ChatAction(BaseModel):
+    type: str
+    status: str
+    job_id: int | None = None
+    summary: str
+
+
 class ChatMessageResponse(BaseModel):
     id: int
     role: str
     content: str
     created_at: datetime | None = None
     activity_id: int | None = None
+    actions: list[ChatAction] | None = None
 
     class Config:
         from_attributes = True

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -112,10 +112,10 @@ new sync.
 `frontend/src/components/activity-detail/ActivityDetailView.tsx` + `.css`,
 `tests/test_weather.py` (new, 19 tests).
 
-#### P0-2 · Let the coach act on the conversation (chat tool-use)
+#### P0-2 · Let the coach act on the conversation (chat tool-use) ✅ DONE (2026-06-30)
 **What:** Give `chat_stream` the same tool-use treatment plan generation already
 has. Define a small set of coach tools — `regenerate_plan`,
-`adjust_upcoming_week(reason)`, `mark_setback(tag, note)`, `explain_workout(day_id)`
+`adjust_upcoming_week(reason)`, `mark_setback(tag, note)`, `explain_workout(date)`
 — and let the model call them mid-conversation. Tool calls **enqueue `AIJob`s**
 (the durable queue already exists) rather than mutating inline, and the chat streams
 back a confirmation ("Reworked next week around your travel — easy runs Tue/Thu, long
@@ -127,10 +127,15 @@ Coach Leo / HumanGO ("Hugo") / Trenara are built on, and we already own every ha
 part: provider dispatch with tool-use, the context builder, the realignment /
 generation entry points, and the `AIJob` ledger to run them durably.
 **Effort:** M.
-**Files:** `app/ai_coach.py` (chat tool schema + dispatch, reuse
-`enqueue_job`/`generate_training_plan`/`detect_plan_realignment`), `app/api.py`
-(`POST /chat` handling of tool events over SSE), `app/schemas.py`,
-`frontend/src/components/chat/*` (render tool-action confirmations) + hooks/types.
+**Files:** `app/ai_coach.py` (`_CHAT_TOOL_SCHEMAS`/`_CHAT_GEMINI_TOOLS`,
+`_dispatch_chat_tool`, streaming tool-use loop in `_stream_claude`/`_stream_gemini`,
+optional `note` threaded through `generate_training_plan`/`execute_job`, reusing
+`enqueue_job`), `app/models.py` (`ChatMessage.actions_json`), `alembic/versions/`
+(migration), `app/api.py` (`POST /chat` relays `action` SSE events, `GET /chat`
+round-trips them), `app/schemas.py` (`ChatAction`), `frontend/src/api/types.ts`,
+`frontend/src/components/chat/ChatView.tsx` + `.css` (action chips),
+`tests/test_ai_coach.py`, `tests/test_job_queue.py`, `tests/test_api_endpoints.py`
+(17 new tests).
 
 ### P1 — Execution depth & daily adaptation
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -538,12 +538,20 @@ export interface PushWorkoutResponse {
   scheduled_date: string
 }
 
+export interface ChatAction {
+  type: string
+  status: string
+  job_id: number | null
+  summary: string
+}
+
 export interface ChatMessage {
   id: number
   role: 'user' | 'assistant'
   content: string
   created_at: string | null
   activity_id: number | null
+  actions?: ChatAction[] | null
 }
 
 export interface ChatHistoryResponse {

--- a/frontend/src/components/chat/ChatView.css
+++ b/frontend/src/components/chat/ChatView.css
@@ -136,6 +136,27 @@
   margin: 0.15em 0;
 }
 
+.chat-action-chips {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.chat-action-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  max-width: 78%;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 500;
+}
+
 .chat-bubble.streaming::after {
   content: '▋';
   display: inline-block;

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { Send, BrainCircuit, Trash2 } from 'lucide-react'
-import type { ChatMessage } from '../../api/types'
+import { Send, BrainCircuit, Trash2, Zap } from 'lucide-react'
+import type { ChatAction, ChatMessage } from '../../api/types'
 import './ChatView.css'
 
 const BASE = '/api/v1'
@@ -19,11 +19,26 @@ function formatTime(iso: string | null): string {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 }
 
+function ActionChips({ actions }: { actions: ChatAction[] | null | undefined }) {
+  if (!actions || actions.length === 0) return null
+  return (
+    <div className="chat-action-chips">
+      {actions.map((action, i) => (
+        <div key={`${action.type}-${i}`} className="chat-action-chip">
+          <Zap size={12} />
+          {action.summary}
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export default function ChatView() {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
   const [streaming, setStreaming] = useState(false)
   const [streamingContent, setStreamingContent] = useState('')
+  const [streamingActions, setStreamingActions] = useState<ChatAction[]>([])
   const [error, setError] = useState<string | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -70,6 +85,7 @@ export default function ChatView() {
 
     setStreaming(true)
     setStreamingContent('')
+    setStreamingActions([])
 
     const ctrl = new AbortController()
     abortRef.current = ctrl
@@ -90,6 +106,7 @@ export default function ChatView() {
       const decoder = new TextDecoder()
       let buffer = ''
       let fullContent = ''
+      const fullActions: ChatAction[] = []
 
       while (true) {
         const { done, value } = await reader.read()
@@ -110,6 +127,9 @@ export default function ChatView() {
             } else if (parsed.token) {
               fullContent += parsed.token
               setStreamingContent(fullContent)
+            } else if (parsed.action) {
+              fullActions.push(parsed.action)
+              setStreamingActions([...fullActions])
             }
           } catch {
             // ignore malformed SSE lines
@@ -124,6 +144,7 @@ export default function ChatView() {
         content: fullContent,
         created_at: new Date().toISOString(),
         activity_id: null,
+        actions: fullActions.length > 0 ? fullActions : null,
       }
       setMessages(prev => [...prev, assistantMsg])
     } catch (err: any) {
@@ -133,6 +154,7 @@ export default function ChatView() {
     } finally {
       setStreaming(false)
       setStreamingContent('')
+      setStreamingActions([])
       abortRef.current = null
     }
   }, [streaming])
@@ -179,6 +201,7 @@ export default function ChatView() {
                   {msg.role === 'assistant' ? 'AI' : 'Me'}
                 </div>
                 <div>
+                  {msg.role === 'assistant' && <ActionChips actions={msg.actions} />}
                   <div className={`chat-bubble ${msg.role}`}>
                     {msg.role === 'assistant' ? (
                       <ReactMarkdown>{msg.content}</ReactMarkdown>
@@ -200,6 +223,7 @@ export default function ChatView() {
               <div className="chat-bubble-row assistant">
                 <div className="chat-avatar assistant">AI</div>
                 <div>
+                  <ActionChips actions={streamingActions} />
                   <div className={`chat-bubble assistant${streamingContent ? ' streaming' : ''}`}>
                     {streamingContent ? (
                       <ReactMarkdown>{streamingContent}</ReactMarkdown>

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date, datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 from app import ai_coach
 from app.models import (
     Activity,
+    AIJob,
     AthleteProfile,
     DailySummary,
     GarminCalendarEvent,
@@ -941,3 +943,284 @@ def test_plan_tool_schema_includes_routine_id():
         ["properties"]["days"]["items"]["properties"]
     )
     assert "routine_id" in day_props
+
+
+# ---------------------------------------------------------------------------
+# Chat tool-use (P0-2)
+# ---------------------------------------------------------------------------
+
+def test_generate_training_plan_with_note_appends_to_prompt(db, patch_db_session, monkeypatch):
+    """A note (e.g. from chat's adjust_upcoming_week) is folded into the plan prompt."""
+    patch_db_session(ai_coach)
+
+    week_start = date(2026, 7, 7)
+    plan_dict = _minimal_plan_dict(week_start)
+
+    tool_block = MagicMock()
+    tool_block.type = "tool_use"
+    tool_block.name = "generate_plan"
+    tool_block.input = plan_dict
+
+    mock_response = MagicMock()
+    mock_response.content = [tool_block]
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+
+    monkeypatch.setattr(ai_coach, "_get_ai_config", lambda db, user_id=1: ("claude", "claude-sonnet-4-6"))
+    monkeypatch.setattr(ai_coach.anthropic, "Anthropic", lambda **kw: mock_client)
+
+    result = ai_coach.generate_training_plan(reference_date=date(2026, 7, 3), note="travelling next week")
+
+    assert result is not None
+    prompt = mock_client.messages.create.call_args[1]["messages"][0]["content"]
+    assert "travelling next week" in prompt
+
+
+# --- _dispatch_chat_tool ---
+
+def test_dispatch_chat_tool_regenerate_plan(db, patch_db_session):
+    patch_db_session(ai_coach)
+
+    result, action = ai_coach._dispatch_chat_tool(db, 1, "regenerate_plan", {})
+
+    assert result["status"] == "queued"
+    job = db.query(AIJob).filter(AIJob.id == result["job_id"]).first()
+    assert job is not None
+    assert job.task_type == "generate_plan"
+    assert json.loads(job.payload_json) == {}
+    assert action["type"] == "regenerate_plan"
+    assert action["job_id"] == job.id
+
+
+def test_dispatch_chat_tool_adjust_upcoming_week(db, patch_db_session):
+    patch_db_session(ai_coach)
+
+    result, action = ai_coach._dispatch_chat_tool(
+        db, 1, "adjust_upcoming_week", {"reason": "travelling for work"}
+    )
+
+    assert result["status"] == "queued"
+    job = db.query(AIJob).filter(AIJob.id == result["job_id"]).first()
+    assert job is not None
+    assert job.task_type == "generate_plan"
+    assert json.loads(job.payload_json) == {"note": "travelling for work"}
+    assert "travelling for work" in action["summary"]
+
+
+def test_dispatch_chat_tool_mark_setback(db):
+    result, action = ai_coach._dispatch_chat_tool(
+        db, 1, "mark_setback", {"tag": "knee pain", "note": "Sore after long runs."}
+    )
+
+    assert result == {"status": "recorded"}
+    insight = db.query(Insight).filter(Insight.trigger_type == "chat_setback").first()
+    assert insight is not None
+    assert insight.user_id == 1
+    assert insight.summary == "knee pain"
+    assert insight.content == "Sore after long runs."
+    assert insight.category == "setback"
+    assert action["type"] == "mark_setback"
+    assert action["job_id"] is None
+
+
+def test_dispatch_chat_tool_explain_workout_found(db):
+    plan = TrainingPlan(generated_at=datetime(2026, 6, 1, tzinfo=timezone.utc), week_start=date(2026, 6, 15), plan_weeks=4)
+    db.add(plan)
+    db.flush()
+    db.add(TrainingPlanDay(
+        plan_id=plan.id,
+        day_date=date(2026, 6, 18),
+        day_of_week="Thursday",
+        week_number=1,
+        workout_type="tempo",
+        target_distance_m=8000,
+        target_pace_display="4:30/km",
+        description="Tempo run with 20min at threshold.",
+    ))
+    db.commit()
+
+    result, action = ai_coach._dispatch_chat_tool(db, 1, "explain_workout", {"date": "2026-06-18"})
+
+    assert result["status"] == "ok"
+    assert result["workout_type"] == "tempo"
+    assert result["target_distance_km"] == 8.0
+    assert result["description"] == "Tempo run with 20min at threshold."
+    assert action is None
+
+
+def test_dispatch_chat_tool_explain_workout_not_found(db):
+    result, action = ai_coach._dispatch_chat_tool(db, 1, "explain_workout", {"date": "2026-06-18"})
+    assert result == {"status": "not_found", "date": "2026-06-18"}
+    assert action is None
+
+
+def test_dispatch_chat_tool_explain_workout_invalid_date(db):
+    result, action = ai_coach._dispatch_chat_tool(db, 1, "explain_workout", {"date": "not-a-date"})
+    assert result["status"] == "invalid_date"
+    assert action is None
+
+
+def test_dispatch_chat_tool_unknown_raises(db):
+    with pytest.raises(ValueError):
+        ai_coach._dispatch_chat_tool(db, 1, "delete_everything", {})
+
+
+# --- _format_upcoming_plan_context ---
+
+def test_format_upcoming_plan_context_lists_next_7_days(db):
+    from datetime import timedelta
+    plan = TrainingPlan(generated_at=datetime(2026, 6, 1, tzinfo=timezone.utc), week_start=date(2026, 6, 15), plan_weeks=4)
+    db.add(plan)
+    db.flush()
+    today = date.today()
+    db.add(TrainingPlanDay(
+        plan_id=plan.id,
+        day_date=today + timedelta(days=1),
+        day_of_week="X",
+        week_number=1,
+        workout_type="easy",
+        description="Easy 5k",
+    ))
+    db.commit()
+
+    out = ai_coach._format_upcoming_plan_context(db, 1)
+    assert "Upcoming Plan This Week" in out
+    assert "easy" in out
+    assert "Easy 5k" in out
+
+
+def test_format_upcoming_plan_context_empty_when_no_plan(db):
+    assert ai_coach._format_upcoming_plan_context(db, 1) == ""
+
+
+# --- _stream_claude tool-use streaming ---
+
+class _FakeClaudeStream:
+    def __init__(self, events, final_message):
+        self._events = events
+        self._final_message = final_message
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def get_final_message(self):
+        return self._final_message
+
+
+def _text_delta_event(text):
+    return SimpleNamespace(
+        type="content_block_delta",
+        delta=SimpleNamespace(type="text_delta", text=text),
+    )
+
+
+def test_stream_claude_plain_text_no_tool_call(db, monkeypatch):
+    events = [_text_delta_event("Hello"), _text_delta_event(" there")]
+    final_message = SimpleNamespace(content=[SimpleNamespace(type="text", text="Hello there")])
+
+    mock_client = MagicMock()
+    mock_client.messages.stream.return_value = _FakeClaudeStream(events, final_message)
+    monkeypatch.setattr(ai_coach.anthropic, "Anthropic", lambda **kw: mock_client)
+
+    events_out = list(ai_coach._stream_claude([], "system", "claude-sonnet-4-6", db, 1))
+
+    assert events_out == [
+        {"type": "token", "text": "Hello"},
+        {"type": "token", "text": " there"},
+    ]
+    assert mock_client.messages.stream.call_count == 1
+
+
+def test_stream_claude_tool_use_dispatches_and_streams_confirmation(db, patch_db_session, monkeypatch):
+    patch_db_session(ai_coach)
+
+    tool_use_block = SimpleNamespace(type="tool_use", name="regenerate_plan", input={}, id="tu_1")
+    first_final = SimpleNamespace(content=[tool_use_block])
+    first_stream = _FakeClaudeStream([], first_final)
+
+    confirmation_events = [_text_delta_event("Regenerating"), _text_delta_event(" now.")]
+    second_final = SimpleNamespace(content=[SimpleNamespace(type="text", text="Regenerating now.")])
+    second_stream = _FakeClaudeStream(confirmation_events, second_final)
+
+    mock_client = MagicMock()
+    mock_client.messages.stream.side_effect = [first_stream, second_stream]
+    monkeypatch.setattr(ai_coach.anthropic, "Anthropic", lambda **kw: mock_client)
+
+    events_out = list(ai_coach._stream_claude([], "system", "claude-sonnet-4-6", db, 1))
+
+    assert mock_client.messages.stream.call_count == 2
+    action_events = [e for e in events_out if e["type"] == "action"]
+    token_events = [e for e in events_out if e["type"] == "token"]
+    assert len(action_events) == 1
+    assert action_events[0]["action"]["type"] == "regenerate_plan"
+    assert "".join(e["text"] for e in token_events) == "Regenerating now."
+
+    job = db.query(AIJob).filter(AIJob.task_type == "generate_plan").first()
+    assert job is not None
+
+    # First call carries tools; the follow-up confirmation call does not.
+    first_kwargs = mock_client.messages.stream.call_args_list[0][1]
+    second_kwargs = mock_client.messages.stream.call_args_list[1][1]
+    assert "tools" in first_kwargs
+    assert "tools" not in second_kwargs
+    assert second_kwargs["messages"][-1]["content"][0]["type"] == "tool_result"
+
+
+# --- _stream_gemini tool-use streaming ---
+
+def _gemini_text_chunk(text):
+    return SimpleNamespace(text=text, candidates=[])
+
+
+def _gemini_function_call_chunk(name, args):
+    part = SimpleNamespace(function_call=SimpleNamespace(name=name, args=args))
+    candidate = SimpleNamespace(content=SimpleNamespace(parts=[part]))
+    return SimpleNamespace(text=None, candidates=[candidate])
+
+
+def test_stream_gemini_plain_text_no_tool_call(db, monkeypatch):
+    chunks = [_gemini_text_chunk("Hi"), _gemini_text_chunk(" there")]
+    mock_models = MagicMock()
+    mock_models.generate_content_stream.return_value = chunks
+    mock_client = MagicMock()
+    mock_client.models = mock_models
+    monkeypatch.setattr(ai_coach.genai, "Client", lambda **kw: mock_client)
+
+    events_out = list(ai_coach._stream_gemini([], "system", "gemini-2.5-flash", db, 1))
+
+    assert events_out == [
+        {"type": "token", "text": "Hi"},
+        {"type": "token", "text": " there"},
+    ]
+    assert mock_models.generate_content_stream.call_count == 1
+
+
+def test_stream_gemini_tool_use_dispatches_and_streams_confirmation(db, monkeypatch):
+    chunks_first = [_gemini_function_call_chunk("mark_setback", {"tag": "knee pain", "note": "sore"})]
+    chunks_second = [_gemini_text_chunk("Noted, take it easy.")]
+
+    mock_models = MagicMock()
+    mock_models.generate_content_stream.side_effect = [chunks_first, chunks_second]
+    mock_client = MagicMock()
+    mock_client.models = mock_models
+    monkeypatch.setattr(ai_coach.genai, "Client", lambda **kw: mock_client)
+
+    events_out = list(ai_coach._stream_gemini([], "system", "gemini-2.5-flash", db, 1))
+
+    assert mock_models.generate_content_stream.call_count == 2
+    action_events = [e for e in events_out if e["type"] == "action"]
+    token_events = [e for e in events_out if e["type"] == "token"]
+    assert len(action_events) == 1
+    assert action_events[0]["action"]["type"] == "mark_setback"
+    assert "".join(e["text"] for e in token_events) == "Noted, take it easy."
+
+    insight = db.query(Insight).filter(Insight.trigger_type == "chat_setback").first()
+    assert insight is not None
+    assert insight.summary == "knee pain"

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.models import (
     Activity,
+    ChatMessage,
     DailySummary,
     GarminCalendarEvent,
     Insight,
@@ -527,3 +528,83 @@ def test_training_plan_day_no_routine_when_id_missing(client, db):
     body = resp.json()
     day = body["weeks"][0]["days"][0]
     assert day["routine"] is None
+
+
+# ---------------------------------------------------------------------------
+# POST /chat — chat tool-use action events (P0-2)
+# ---------------------------------------------------------------------------
+
+def test_api_post_chat_streams_action_and_persists(client, db, patch_db_session, monkeypatch):
+    """When chat_stream yields an action event, it's relayed over SSE and persisted."""
+    import app.ai_coach as ai_mod
+    import app.database as database_mod
+    patch_db_session(database_mod)
+
+    def fake_chat_stream(db_, new_message, history, user_id, activity_id):
+        yield {
+            "type": "action",
+            "action": {
+                "type": "regenerate_plan",
+                "status": "queued",
+                "job_id": 7,
+                "summary": "Regenerating your training plan.",
+            },
+        }
+        yield {"type": "token", "text": "Done"}
+        yield {"type": "token", "text": "!"}
+
+    monkeypatch.setattr(ai_mod, "chat_stream", fake_chat_stream)
+
+    resp = client.post("/api/v1/chat", json={"message": "rework my plan"})
+    assert resp.status_code == 200
+    body = resp.text
+    assert '"action"' in body
+    assert "[DONE]" in body
+
+    msg = (
+        db.query(ChatMessage)
+        .filter(ChatMessage.role == "assistant")
+        .order_by(ChatMessage.id.desc())
+        .first()
+    )
+    assert msg is not None
+    assert msg.content == "Done!"
+    actions = json.loads(msg.actions_json)
+    assert len(actions) == 1
+    assert actions[0]["type"] == "regenerate_plan"
+    assert actions[0]["job_id"] == 7
+
+    # Round-trips through GET /chat
+    resp2 = client.get("/api/v1/chat")
+    assert resp2.status_code == 200
+    history = resp2.json()["messages"]
+    assistant_entry = [m for m in history if m["role"] == "assistant"][-1]
+    assert assistant_entry["actions"][0]["summary"] == "Regenerating your training plan."
+
+
+def test_api_post_chat_plain_text_has_no_actions(client, db, patch_db_session, monkeypatch):
+    """Plain Q&A turns persist with actions=None, matching pre-P0-2 behavior."""
+    import app.ai_coach as ai_mod
+    import app.database as database_mod
+    patch_db_session(database_mod)
+
+    def fake_chat_stream(db_, new_message, history, user_id, activity_id):
+        yield {"type": "token", "text": "Looks good."}
+
+    monkeypatch.setattr(ai_mod, "chat_stream", fake_chat_stream)
+
+    resp = client.post("/api/v1/chat", json={"message": "how was my week?"})
+    assert resp.status_code == 200
+    assert '"action"' not in resp.text
+
+    msg = (
+        db.query(ChatMessage)
+        .filter(ChatMessage.role == "assistant")
+        .order_by(ChatMessage.id.desc())
+        .first()
+    )
+    assert msg.actions_json is None
+
+    resp2 = client.get("/api/v1/chat")
+    assistant_entry = [m for m in resp2.json()["messages"] if m["role"] == "assistant"][-1]
+    assert assistant_entry["actions"] is None

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -103,7 +103,22 @@ def test_execute_job_dispatches_generate_plan(db, patch_db_session):
     with patch.object(ai_mod, "generate_training_plan") as mock_fn:
         execute_job(job_id)
 
-    mock_fn.assert_called_once_with(user_id=1)
+    mock_fn.assert_called_once_with(user_id=1, note=None)
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "done"
+
+
+def test_execute_job_dispatches_generate_plan_with_note(db, patch_db_session):
+    """A note in the job payload (e.g. from the chat adjust_upcoming_week tool) is threaded through."""
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("generate_plan", {"note": "travelling next week"}, user_id=1)
+
+    with patch.object(ai_mod, "generate_training_plan") as mock_fn:
+        execute_job(job_id)
+
+    mock_fn.assert_called_once_with(user_id=1, note="travelling next week")
     job = db.query(AIJob).filter(AIJob.id == job_id).first()
     assert job.status == "done"
 


### PR DESCRIPTION
Adds four coach tools (regenerate_plan, adjust_upcoming_week, mark_setback,
explain_workout) that the chat model can call mid-conversation, mirroring
the tool-use pattern already used for plan generation. Mutating tools
enqueue durable AIJobs; mark_setback records to Insight; explain_workout
reads the upcoming plan. The frontend renders a confirmation chip for each
action alongside the streamed response.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WyGTznbEzjNWmR4Kyz5dsC