### PR TITLE
feat: P2-3 explicit Running Stress Balance guidance

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -4,7 +4,7 @@ import json
 from datetime import date, datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 
 class ActivitySummary(BaseModel):
@@ -284,6 +284,48 @@ class RaceInfo(BaseModel):
     priority: str | None = None
 
 
+def classify_tsb(tsb: float) -> tuple[str, str]:
+    """Classify Training Stress Balance (form) into a ``(zone_key, label)`` pair."""
+    if tsb > 15:
+        return "very_fresh", "Very fresh — detraining risk"
+    if tsb > 5:
+        return "fresh", "Fresh, tapered"
+    if tsb >= -10:
+        return "neutral", "Neutral — race-ready range"
+    if tsb >= -30:
+        return "productive_fatigue", "Productive training fatigue"
+    return "high_fatigue", "High fatigue — overreaching risk"
+
+
+def classify_acwr(acwr: float) -> tuple[str, str, str]:
+    """Classify ACWR into an explicit Running Stress Balance ``(zone_key, label,
+    recommendation)`` triple — the classic detraining / productive / overreaching
+    read."""
+    if acwr > 1.5:
+        return (
+            "overreaching", "Overreaching — high risk",
+            "ACWR is above 1.5 — significant overreaching and high injury risk. "
+            "Prioritize recovery and avoid hard sessions until the ratio comes down.",
+        )
+    if acwr > 1.3:
+        return (
+            "overreaching", "Overreaching — moderate risk",
+            "ACWR is elevated (1.3–1.5) — moderate injury risk. "
+            "Hold your current load rather than ramping further this week.",
+        )
+    if acwr >= 0.8:
+        return (
+            "productive", "Productive — sweet spot",
+            "ACWR is in the 0.8–1.3 sweet spot — load is well-balanced for fitness "
+            "gains with low injury risk. Keep building at this rate.",
+        )
+    return (
+        "detraining", "Detraining",
+        "ACWR is below 0.8 — recent load is low relative to your base. "
+        "Consider gradually increasing volume to avoid losing fitness.",
+    )
+
+
 class TrainingLoadPoint(BaseModel):
     date: date
     tss: float
@@ -294,6 +336,22 @@ class TrainingLoadPoint(BaseModel):
     ramp_rate_7d: float | None = None  # CTL change over last 7 days
     ramp_rate_28d: float | None = None # CTL change over last 28 days
     injury_risk: str | None = None     # "low" | "moderate" | "high"
+
+    # Explicit Running Stress Balance read, derived from tsb/acwr — see
+    # classify_tsb/classify_acwr above. Always populated from the raw values,
+    # never set directly by callers.
+    form_zone: str | None = None        # "very_fresh" | "fresh" | "neutral" | "productive_fatigue" | "high_fatigue"
+    form_zone_label: str | None = None
+    rsb_zone: str | None = None         # "detraining" | "productive" | "overreaching"
+    rsb_zone_label: str | None = None
+    rsb_recommendation: str | None = None
+
+    @model_validator(mode="after")
+    def _derive_rsb_zones(self) -> "TrainingLoadPoint":
+        self.form_zone, self.form_zone_label = classify_tsb(self.tsb)
+        if self.acwr is not None:
+            self.rsb_zone, self.rsb_zone_label, self.rsb_recommendation = classify_acwr(self.acwr)
+        return self
 
 
 class TrainingReadiness(BaseModel):

--- a/app/training_load.py
+++ b/app/training_load.py
@@ -32,7 +32,7 @@ from app.models import (
     DailySummary,
     SyncStatus,
 )
-from app.schemas import TrainingLoadPoint, TrainingReadiness
+from app.schemas import TrainingLoadPoint, TrainingReadiness, classify_acwr, classify_tsb
 
 logger = logging.getLogger(__name__)
 
@@ -423,13 +423,14 @@ def current_load(
 
 def _interpret_tsb(tsb: float) -> str:
     """Plain-language reading of Training Stress Balance (form)."""
-    if tsb > 15:
+    zone, _label = classify_tsb(tsb)
+    if zone == "very_fresh":
         return "very fresh / detraining risk"
-    if tsb > 5:
+    if zone == "fresh":
         return "fresh, tapered"
-    if tsb >= -10:
+    if zone == "neutral":
         return "neutral / race-ready range"
-    if tsb >= -30:
+    if zone == "productive_fatigue":
         return "productive training fatigue"
     return "high fatigue — overreaching risk"
 
@@ -567,11 +568,14 @@ def compute_readiness(
 
 
 def _interpret_acwr(acwr: float) -> str:
-    if acwr > 1.5:
-        return "high injury risk — significant overreaching"
-    if acwr > 1.3:
-        return "moderate risk — monitor fatigue closely"
-    if acwr >= 0.8:
+    zone, _label, _recommendation = classify_acwr(acwr)
+    if zone == "overreaching":
+        return (
+            "high injury risk — significant overreaching"
+            if acwr > 1.5
+            else "moderate risk — monitor fatigue closely"
+        )
+    if zone == "productive":
         return "sweet spot — optimal training zone"
     return "low / detraining risk"
 
@@ -596,6 +600,8 @@ def format_training_load_context(point: TrainingLoadPoint | None) -> str:
         lines.append(f"- Ramp rate (28d CTL change): {point.ramp_rate_28d:+.1f}")
     if point.injury_risk:
         lines.append(f"- Injury risk: {point.injury_risk}")
+    if point.rsb_zone_label and point.rsb_recommendation:
+        lines.append(f"- Running Stress Balance: {point.rsb_zone_label}. {point.rsb_recommendation}")
     return "\n".join(lines)
 
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -217,7 +217,7 @@ the closed-loop plan around the moments that matter most.
 **Files:** `app/ai_coach.py` (plan prompt/schema + realignment around race dates),
 possibly `app/training_load.py` (recovery-load shaping), `frontend/src/components/plan/*`.
 
-#### P2-3 · Explicit Running Stress Balance guidance
+#### P2-3 · Explicit Running Stress Balance guidance ✅ DONE (2026-07-01)
 **What:** Promote the TSB/ACWR we already compute into an explicit
 **over-/under-training "sweet-spot" read** — a labelled zone (detraining / productive /
 overreaching) with a plain-language recommendation, on Today and in the AI context,
@@ -226,9 +226,14 @@ rather than a raw Form number.
 guidance make this an at-a-glance decision aid; we have the inputs but present them as
 numbers. Cheap interpretation layer over existing series.
 **Effort:** S–M.
-**Files:** `app/training_load.py` (zone/label helper), `app/api.py` (training-load
-response field), `app/ai_coach.py` context, `frontend/src/components/today/*` +
-`trends/*` + types.
+**Files:** `app/schemas.py` (`classify_tsb`/`classify_acwr`, `TrainingLoadPoint`
+zone/label/recommendation fields, auto-derived via a model validator),
+`app/training_load.py` (`_interpret_tsb`/`_interpret_acwr` now reuse the same
+classifiers; `format_training_load_context` renders the RSB recommendation),
+`frontend/src/components/today/TrainingLoadChart.tsx` + `.css` (server-derived zone
+badges replace the old client-side duplicate banding, plus a recommendation line),
+`frontend/src/api/types.ts`, `tests/test_training_load.py`,
+`tests/test_training_load_edge.py` (10 new tests).
 
 ### P3 — Hygiene, scale & carryover (largely independent)
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -250,6 +250,11 @@ export interface TrainingLoadPoint {
   ramp_rate_7d: number | null
   ramp_rate_28d: number | null
   injury_risk: string | null  // "low" | "moderate" | "high"
+  form_zone: string | null  // "very_fresh" | "fresh" | "neutral" | "productive_fatigue" | "high_fatigue"
+  form_zone_label: string | null
+  rsb_zone: string | null  // "detraining" | "productive" | "overreaching"
+  rsb_zone_label: string | null
+  rsb_recommendation: string | null
 }
 
 export interface TrainingReadiness {

--- a/frontend/src/components/today/TrainingLoadChart.css
+++ b/frontend/src/components/today/TrainingLoadChart.css
@@ -51,6 +51,13 @@
 .tl-risk-moderate { background: rgba(253, 203, 110, 0.25); color: #e6a817; }
 .tl-risk-high { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
 
+.tl-rsb-recommendation {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0 0 12px;
+  line-height: 1.4;
+}
+
 .tl-chart {
   width: 100%;
 }

--- a/frontend/src/components/today/TrainingLoadChart.tsx
+++ b/frontend/src/components/today/TrainingLoadChart.tsx
@@ -24,30 +24,20 @@ const ATL_COLOR = '#e17055' // Fatigue — orange
 const TSB_COLOR = '#00b894' // Form — green
 const ACWR_COLOR = '#fdcb6e' // ACWR — amber
 
-function formTone(tsb: number): string {
-  if (tsb > 5) return 'fresh'
-  if (tsb >= -10) return 'neutral'
-  if (tsb >= -30) return 'building'
+// Form (TSB) and RSB (ACWR) zones/labels are computed server-side (see
+// classify_tsb/classify_acwr in app/schemas.py) so this badge and the AI
+// context never drift out of sync with each other.
+function formTone(zone: string | null): string {
+  if (zone === 'very_fresh' || zone === 'fresh') return 'fresh'
+  if (zone === 'neutral') return 'neutral'
+  if (zone === 'productive_fatigue') return 'building'
   return 'fatigued'
 }
 
-function formLabel(tsb: number): string {
-  if (tsb > 5) return 'Fresh'
-  if (tsb >= -10) return 'Neutral'
-  if (tsb >= -30) return 'Building'
-  return 'High fatigue'
-}
-
-function riskTone(risk: string | null): string {
-  if (risk === 'high') return 'high'
-  if (risk === 'moderate') return 'moderate'
+function rsbTone(zone: string | null): string {
+  if (zone === 'overreaching') return 'high'
+  if (zone === 'detraining') return 'moderate'
   return 'low'
-}
-
-function riskLabel(risk: string | null): string {
-  if (risk === 'high') return 'High risk'
-  if (risk === 'moderate') return 'Moderate risk'
-  return 'Low risk'
 }
 
 export default function TrainingLoadChart({ current }: Props) {
@@ -112,18 +102,24 @@ export default function TrainingLoadChart({ current }: Props) {
           <span className="tl-stat-value" style={{ color: TSB_COLOR }}>
             {current.tsb >= 0 ? '+' : ''}{current.tsb.toFixed(0)}
           </span>
-          <span className={`tl-form-badge tl-form-${formTone(current.tsb)}`}>{formLabel(current.tsb)}</span>
+          <span className={`tl-form-badge tl-form-${formTone(current.form_zone)}`}>
+            {current.form_zone_label ?? ''}
+          </span>
         </div>
         {hasAcwr && (
           <div className="tl-stat">
             <span className="tl-stat-label">ACWR</span>
             <span className="tl-stat-value" style={{ color: ACWR_COLOR }}>{current.acwr!.toFixed(2)}</span>
-            <span className={`tl-form-badge tl-risk-${riskTone(current.injury_risk)}`}>
-              {riskLabel(current.injury_risk)}
+            <span className={`tl-form-badge tl-risk-${rsbTone(current.rsb_zone)}`}>
+              {current.rsb_zone_label ?? ''}
             </span>
           </div>
         )}
       </div>
+
+      {hasAcwr && current.rsb_recommendation && (
+        <p className="tl-rsb-recommendation">{current.rsb_recommendation}</p>
+      )}
 
       {chartData.length > 1 && (
         <div className="tl-chart">

--- a/tests/test_training_load.py
+++ b/tests/test_training_load.py
@@ -197,7 +197,42 @@ def test_format_training_load_context_includes_acwr_when_present():
     assert "sweet spot" in ctx
     assert "Ramp rate (7d" in ctx
     assert "Ramp rate (28d" in ctx
-    assert "Injury risk: low" in ctx
+
+
+def test_training_load_point_derives_rsb_zone_fields():
+    from app.schemas import TrainingLoadPoint
+    point = TrainingLoadPoint(
+        date=date(2026, 6, 10),
+        tss=80.0, ctl=40.0, atl=50.0, tsb=-10.0,
+        acwr=1.25,
+    )
+    assert point.form_zone == "neutral"
+    assert point.form_zone_label == "Neutral — race-ready range"
+    assert point.rsb_zone == "productive"
+    assert point.rsb_zone_label == "Productive — sweet spot"
+    assert point.rsb_recommendation
+
+
+def test_training_load_point_rsb_zone_absent_without_acwr():
+    from app.schemas import TrainingLoadPoint
+    point = TrainingLoadPoint(date=date(2026, 6, 10), tss=80.0, ctl=40.0, atl=50.0, tsb=-10.0)
+    assert point.rsb_zone is None
+    assert point.rsb_zone_label is None
+    assert point.rsb_recommendation is None
+    # Form zone doesn't depend on acwr, so it's always populated.
+    assert point.form_zone == "neutral"
+
+
+def test_format_training_load_context_includes_rsb_recommendation():
+    from app.schemas import TrainingLoadPoint
+    point = TrainingLoadPoint(
+        date=date(2026, 6, 10),
+        tss=80.0, ctl=40.0, atl=50.0, tsb=-10.0,
+        acwr=1.6,
+    )
+    ctx = training_load.format_training_load_context(point)
+    assert "Running Stress Balance" in ctx
+    assert "Overreaching — high risk" in ctx
 
 
 def test_training_load_endpoint_includes_acwr_fields(client, db):
@@ -211,6 +246,12 @@ def test_training_load_endpoint_includes_acwr_fields(client, db):
     assert "acwr" in current
     assert "ramp_rate_7d" in current
     assert "injury_risk" in current
+    assert "form_zone" in current
+    assert "form_zone_label" in current
+    if current["acwr"] is not None:
+        assert current["rsb_zone"] in ("detraining", "productive", "overreaching")
+        assert current["rsb_zone_label"]
+        assert current["rsb_recommendation"]
 
 
 def test_build_context_omits_training_load_without_activities(db):

--- a/tests/test_training_load_edge.py
+++ b/tests/test_training_load_edge.py
@@ -1,5 +1,6 @@
 from app import training_load
 from app.models import Activity, AthleteProfile
+from app.schemas import classify_acwr, classify_tsb
 
 
 # --- _interpret_tsb thresholds ---
@@ -10,6 +11,52 @@ def test_interpret_tsb_bands():
     assert training_load._interpret_tsb(0) == "neutral / race-ready range"
     assert training_load._interpret_tsb(-20) == "productive training fatigue"
     assert training_load._interpret_tsb(-40) == "high fatigue — overreaching risk"
+
+
+# --- classify_tsb / classify_acwr (P2-3 explicit RSB zones) ---
+
+def test_classify_tsb_bands():
+    assert classify_tsb(20) == ("very_fresh", "Very fresh — detraining risk")
+    assert classify_tsb(10) == ("fresh", "Fresh, tapered")
+    assert classify_tsb(0) == ("neutral", "Neutral — race-ready range")
+    assert classify_tsb(-20) == ("productive_fatigue", "Productive training fatigue")
+    assert classify_tsb(-40) == ("high_fatigue", "High fatigue — overreaching risk")
+
+
+def test_classify_tsb_boundaries():
+    # >= -10 stays neutral; just below it flips to productive_fatigue.
+    assert classify_tsb(-10)[0] == "neutral"
+    assert classify_tsb(-10.1)[0] == "productive_fatigue"
+    # >= -30 stays productive_fatigue; just below it flips to high_fatigue.
+    assert classify_tsb(-30)[0] == "productive_fatigue"
+    assert classify_tsb(-30.1)[0] == "high_fatigue"
+
+
+def test_classify_acwr_bands():
+    zone, label, recommendation = classify_acwr(1.6)
+    assert zone == "overreaching"
+    assert "high risk" in label.lower()
+    assert recommendation
+
+    zone, label, recommendation = classify_acwr(1.4)
+    assert zone == "overreaching"
+    assert "moderate risk" in label.lower()
+    assert recommendation
+
+    zone, label, recommendation = classify_acwr(1.0)
+    assert zone == "productive"
+    assert "sweet spot" in label.lower()
+    assert recommendation
+
+    zone, label, recommendation = classify_acwr(0.5)
+    assert zone == "detraining"
+    assert recommendation
+
+
+def test_classify_acwr_boundaries():
+    # >= 0.8 is the inclusive sweet-spot floor.
+    assert classify_acwr(0.8)[0] == "productive"
+    assert classify_acwr(0.799)[0] == "detraining"
 
 
 # --- intensity factor cap ---


### PR DESCRIPTION
Promote the TSB/ACWR series we already compute into an explicit,
labelled zone (detraining/productive/overreaching for ACWR-based RSB,
plus a form zone for TSB) with a plain-language recommendation, shown
on Today and folded into the AI context, instead of raw Form/ACWR
numbers.

classify_tsb/classify_acwr live in app/schemas.py and auto-populate
TrainingLoadPoint via a model validator, so every construction site
gets them for free and the frontend's previously duplicated (and
drifting) badge logic in TrainingLoadChart.tsx is replaced with the
backend-derived zone/label.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RNFGvkSEhu2gYae7c18cnE