### PR TITLE
feat: P1-3 persistent athlete memory for the coach

### DIFF
--- a/alembic/versions/l5m6n7o8p9q0_add_coach_memory.py
+++ b/alembic/versions/l5m6n7o8p9q0_add_coach_memory.py
@@ -1,0 +1,41 @@
+"""add coach_memories table
+
+Revision ID: l5m6n7o8p9q0
+Revises: k4l5m6n7o8p9
+Create Date: 2026-07-01
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision: str = "l5m6n7o8p9q0"
+down_revision: Union[str, None] = "k4l5m6n7o8p9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    insp = inspect(op.get_bind())
+    if "coach_memories" not in insp.get_table_names():
+        op.create_table(
+            "coach_memories",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("user_id", sa.Integer(), nullable=False, default=1),
+            sa.Column("category", sa.String(20), nullable=False, server_default="note"),
+            sa.Column("tag", sa.Text(), nullable=False),
+            sa.Column("note", sa.Text(), nullable=False),
+            sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+        )
+        op.create_index("ix_coach_memories_user_id", "coach_memories", ["user_id"])
+        op.create_index("ix_coach_memories_created_at", "coach_memories", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_coach_memories_created_at", "coach_memories")
+    op.drop_index("ix_coach_memories_user_id", "coach_memories")
+    op.drop_table("coach_memories")

--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -21,6 +21,7 @@ from app.models import (
     DEFAULT_USER_ID,
     Activity,
     AthleteProfile,
+    CoachMemory,
     DailySummary,
     GarminCalendarEvent,
     Insight,
@@ -419,6 +420,26 @@ def _format_athlete_profile_context(profile: AthleteProfile, reference_date: dat
     return "## Athlete Profile\n" + "\n".join(lines)
 
 
+# Cap on how many memory entries are injected per turn, so a long history of
+# resolved niggles doesn't crowd out the rest of the context.
+COACH_MEMORY_CONTEXT_LIMIT = 10
+
+
+def _format_coach_memory_context(db: Session, user_id: int) -> str:
+    """Format the athlete's active durable memories as a markdown block."""
+    memories = (
+        db.query(CoachMemory)
+        .filter(CoachMemory.user_id == user_id, CoachMemory.active.is_(True))
+        .order_by(CoachMemory.created_at.desc())
+        .limit(COACH_MEMORY_CONTEXT_LIMIT)
+        .all()
+    )
+    if not memories:
+        return ""
+    lines = [f"- [{m.category}] {m.tag}: {m.note}" for m in memories]
+    return "## What The Coach Remembers\n" + "\n".join(lines)
+
+
 def _recent_heat_stress_note(
     db: Session,
     reference_date: date,
@@ -485,6 +506,11 @@ def _build_context(
         profile_context = _format_athlete_profile_context(profile, reference_date)
         if profile_context:
             sections.insert(1, profile_context)
+
+    # What the coach remembers (durable niggles/constraints/preferences)
+    memory_context = _format_coach_memory_context(db, user_id)
+    if memory_context:
+        sections.insert(min(2, len(sections)), memory_context)
 
     # Auto-derived thresholds — surface only the ones the athlete hasn't set so the
     # AI still has a reference for Critical Power / threshold pace / LTHR.
@@ -2118,6 +2144,14 @@ def _dispatch_chat_tool(
             summary=tag,
             category="setback",
         ))
+        # Also persist as durable coach memory (P1-3) so it stays in context
+        # beyond the last-few-insights window, until resolved or deleted.
+        db.add(CoachMemory(
+            user_id=user_id,
+            category="niggle",
+            tag=tag,
+            note=note,
+        ))
         db.commit()
         return (
             {"status": "recorded"},
@@ -2125,7 +2159,7 @@ def _dispatch_chat_tool(
                 "type": "mark_setback",
                 "status": "recorded",
                 "job_id": None,
-                "summary": f"Noted: {tag}.",
+                "summary": f"Remembered: {tag}.",
             },
         )
 

--- a/app/api.py
+++ b/app/api.py
@@ -18,6 +18,7 @@ from app.models import (
     Activity,
     AthleteProfile,
     ChatMessage,
+    CoachMemory,
     DailySummary,
     GarminCalendarEvent,
     Insight,
@@ -40,6 +41,9 @@ from app.schemas import (
     ChatHistoryResponse,
     ChatMessageResponse,
     ChatRequest,
+    CoachMemoryRequest,
+    CoachMemoryResponse,
+    CoachMemoryUpdateRequest,
     DailySummaryDetail,
     DailySummaryResponse,
     FeedbackRequest,
@@ -1760,6 +1764,79 @@ def api_post_chat(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+# --- Coach Memory ---
+
+@api_router.get("/coach-memory", response_model=list[CoachMemoryResponse])
+def api_list_coach_memory(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    memories = (
+        db.query(CoachMemory)
+        .filter(CoachMemory.user_id == current_user.id)
+        .order_by(CoachMemory.created_at.desc())
+        .all()
+    )
+    return memories
+
+
+@api_router.post("/coach-memory", response_model=CoachMemoryResponse)
+def api_create_coach_memory(
+    req: CoachMemoryRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    memory = CoachMemory(
+        user_id=current_user.id,
+        category=req.category,
+        tag=req.tag,
+        note=req.note,
+    )
+    db.add(memory)
+    db.commit()
+    db.refresh(memory)
+    return memory
+
+
+@api_router.put("/coach-memory/{memory_id}", response_model=CoachMemoryResponse)
+def api_update_coach_memory(
+    memory_id: int,
+    req: CoachMemoryUpdateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    memory = (
+        db.query(CoachMemory)
+        .filter(CoachMemory.id == memory_id, CoachMemory.user_id == current_user.id)
+        .first()
+    )
+    if memory is None:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    for key, value in req.model_dump(exclude_unset=True).items():
+        setattr(memory, key, value)
+    db.commit()
+    db.refresh(memory)
+    return memory
+
+
+@api_router.delete("/coach-memory/{memory_id}")
+def api_delete_coach_memory(
+    memory_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    memory = (
+        db.query(CoachMemory)
+        .filter(CoachMemory.id == memory_id, CoachMemory.user_id == current_user.id)
+        .first()
+    )
+    if memory is None:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    db.delete(memory)
+    db.commit()
+    return {"deleted": True}
 
 
 # --- Helpers ---

--- a/app/models.py
+++ b/app/models.py
@@ -372,6 +372,27 @@ class ChatMessage(Base):
     actions_json = Column(Text, nullable=True)  # JSON list of coach tool actions taken this turn
 
 
+class CoachMemory(Base):
+    """Durable, structured facts the coach remembers about the athlete.
+
+    Unlike ``Insight`` (AI-generated commentary, surfaced only for the last few
+    turns to avoid repetition), these are athlete-facts — niggles, life
+    constraints, preferences — that stay in context until resolved or deleted,
+    recorded either by the athlete directly or by the coach via chat tool-use.
+    """
+
+    __tablename__ = "coach_memories"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
+    category = Column(String(20), nullable=False, default="note")  # niggle | constraint | preference | note
+    tag = Column(Text, nullable=False)
+    note = Column(Text, nullable=False)
+    active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, default=_utcnow, index=True)
+    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
+
+
 class DailyLoadSeries(Base):
     """Persisted daily CTL/ATL/TSB series for incremental training load computation.
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -688,6 +688,32 @@ class ChatHistoryResponse(BaseModel):
     messages: list[ChatMessageResponse] = []
 
 
+class CoachMemoryRequest(BaseModel):
+    category: str = "note"  # niggle | constraint | preference | note
+    tag: str
+    note: str
+
+
+class CoachMemoryUpdateRequest(BaseModel):
+    category: str | None = None
+    tag: str | None = None
+    note: str | None = None
+    active: bool | None = None
+
+
+class CoachMemoryResponse(BaseModel):
+    id: int
+    category: str
+    tag: str
+    note: str
+    active: bool
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    class Config:
+        from_attributes = True
+
+
 class PacingSplit(BaseModel):
     split_number: int
     split_distance_m: float       # this split's distance (m)

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -174,7 +174,7 @@ elevation), optional `app/garmin_sync.py` or new parser for GPX, `app/api.py`
 (`/races/{id}/pacing` params + course upload), `frontend/src/components/plan/` or
 `today/` pacing card + types.
 
-#### P1-3 · Persistent athlete memory for the coach
+#### P1-3 · Persistent athlete memory for the coach ✅ DONE (2026-07-01)
 **What:** A durable, user-scoped **coach memory** the AI reads on every analysis and
 chat turn: structured facts the athlete (or the coach, via P0-2 tool-use) records —
 current niggles, life constraints ("marathon training around shift work"),
@@ -186,10 +186,17 @@ worked, how you felt." We persist chat turns but never distill them into durable
 context, so every session re-derives the athlete from metrics alone. Turns the
 conversational coach from stateless Q&A into a relationship.
 **Effort:** M.
-**Files:** `app/models.py` + Alembic (`CoachMemory` / notes table, or structured
-fields), `app/ai_coach.py` (`_build_context` / `_build_chat_context` injection, a
-distill step), `app/api.py` (memory CRUD), `app/schemas.py`,
-`frontend/src/components/settings/*` or `chat/*` + types.
+**Files:** `app/models.py` (`CoachMemory`: category/tag/note/active) + Alembic
+(`l5m6n7o8p9q0_add_coach_memory`), `app/ai_coach.py`
+(`_format_coach_memory_context` injected into `_build_context`, which
+`_build_chat_context` already delegates to; the `mark_setback` chat tool now also
+writes a durable `CoachMemory` row alongside its existing `Insight`), `app/api.py`
+(`GET/POST /coach-memory`, `PUT/DELETE /coach-memory/{id}`), `app/schemas.py`
+(`CoachMemoryRequest`/`CoachMemoryUpdateRequest`/`CoachMemoryResponse`),
+`frontend/src/components/settings/CoachMemorySection.tsx` + `.css`,
+`frontend/src/api/types.ts`, `frontend/src/api/hooks.ts`,
+`tests/test_coach_memory.py` (new, 9 tests), `tests/test_ai_coach.py` (5 new/updated
+tests).
 
 ### P2 — Breadth & coaching completeness
 

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -26,6 +26,9 @@ import type {
   AiConfigRequest,
   AthleteProfile,
   AthleteProfileRequest,
+  CoachMemory,
+  CoachMemoryRequest,
+  CoachMemoryUpdateRequest,
   TrainingLoadResponse,
   TrainingPlanResponse,
   UserResponse,
@@ -260,6 +263,45 @@ export function useUpdateAthleteProfile() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['athlete-profile'] })
       qc.invalidateQueries({ queryKey: ['zone-configs'] })
+    },
+  })
+}
+
+export function useCoachMemories() {
+  return useQuery({
+    queryKey: ['coach-memory'],
+    queryFn: () => apiGet<CoachMemory[]>('/coach-memory'),
+  })
+}
+
+export function useCreateCoachMemory() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (memory: CoachMemoryRequest) =>
+      apiPost<CoachMemory>('/coach-memory', memory),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['coach-memory'] })
+    },
+  })
+}
+
+export function useUpdateCoachMemory() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, memory }: { id: number; memory: CoachMemoryUpdateRequest }) =>
+      apiPut<CoachMemory>(`/coach-memory/${id}`, memory),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['coach-memory'] })
+    },
+  })
+}
+
+export function useDeleteCoachMemory() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => apiDelete<{ deleted: boolean }>(`/coach-memory/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['coach-memory'] })
     },
   })
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -568,6 +568,31 @@ export interface ChatRequest {
   activity_id?: number | null
 }
 
+export type CoachMemoryCategory = 'niggle' | 'constraint' | 'preference' | 'note'
+
+export interface CoachMemory {
+  id: number
+  category: string
+  tag: string
+  note: string
+  active: boolean
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface CoachMemoryRequest {
+  category?: CoachMemoryCategory
+  tag: string
+  note: string
+}
+
+export interface CoachMemoryUpdateRequest {
+  category?: CoachMemoryCategory
+  tag?: string
+  note?: string
+  active?: boolean
+}
+
 export interface PacingSplit {
   split_number: number
   split_distance_m: number

--- a/frontend/src/components/settings/CoachMemorySection.css
+++ b/frontend/src/components/settings/CoachMemorySection.css
@@ -1,0 +1,119 @@
+.cm-desc {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: -8px 0 12px;
+  line-height: 1.5;
+}
+
+.cm-card {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.cm-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.cm-form input,
+.cm-category-select {
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: 0.88rem;
+}
+
+.cm-form input {
+  flex: 1;
+  min-width: 140px;
+}
+
+.cm-empty {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-style: italic;
+  margin: 0;
+}
+
+.cm-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cm-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+}
+
+.cm-item--inactive {
+  opacity: 0.55;
+}
+
+.cm-category-badge {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: rgba(108, 92, 231, 0.18);
+  color: var(--accent, #6c5ce7);
+  white-space: nowrap;
+}
+
+.cm-item-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.85rem;
+  min-width: 0;
+}
+
+.cm-item-note {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.cm-resolve {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.cm-delete-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.cm-delete-btn:hover {
+  color: #e74c3c;
+}
+
+.cm-error {
+  font-size: 0.8rem;
+  color: #e74c3c;
+}

--- a/frontend/src/components/settings/CoachMemorySection.tsx
+++ b/frontend/src/components/settings/CoachMemorySection.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+import {
+  useCoachMemories,
+  useCreateCoachMemory,
+  useUpdateCoachMemory,
+  useDeleteCoachMemory,
+} from '../../api/hooks'
+import type { CoachMemoryCategory } from '../../api/types'
+import './CoachMemorySection.css'
+
+const CATEGORIES: CoachMemoryCategory[] = ['niggle', 'constraint', 'preference', 'note']
+
+export default function CoachMemorySection() {
+  const { data: memories, isLoading } = useCoachMemories()
+  const create = useCreateCoachMemory()
+  const update = useUpdateCoachMemory()
+  const remove = useDeleteCoachMemory()
+
+  const [category, setCategory] = useState<CoachMemoryCategory>('note')
+  const [tag, setTag] = useState('')
+  const [note, setNote] = useState('')
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!tag.trim() || !note.trim()) return
+    create.mutate(
+      { category, tag: tag.trim(), note: note.trim() },
+      { onSuccess: () => { setTag(''); setNote('') } },
+    )
+  }
+
+  if (isLoading) return null
+
+  return (
+    <section className="settings-section">
+      <h2 className="section-title">Coach Memory</h2>
+      <p className="cm-desc">
+        Durable facts the coach remembers on every chat and analysis — niggles,
+        life constraints, preferences. The coach also records these itself when
+        you mention a setback in chat.
+      </p>
+      <div className="card cm-card">
+        <form className="cm-form" onSubmit={handleAdd}>
+          <select
+            className="cm-category-select"
+            value={category}
+            onChange={e => setCategory(e.target.value as CoachMemoryCategory)}
+          >
+            {CATEGORIES.map(c => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+          <input
+            type="text"
+            placeholder="Short label, e.g. 'knee pain'"
+            value={tag}
+            onChange={e => setTag(e.target.value)}
+          />
+          <input
+            type="text"
+            placeholder="Note"
+            value={note}
+            onChange={e => setNote(e.target.value)}
+          />
+          <button className="sync-btn" type="submit" disabled={create.isPending || !tag.trim() || !note.trim()}>
+            {create.isPending ? 'Adding…' : 'Add'}
+          </button>
+        </form>
+
+        {!memories || memories.length === 0 ? (
+          <p className="cm-empty">Nothing remembered yet.</p>
+        ) : (
+          <ul className="cm-list">
+            {memories.map(m => (
+              <li key={m.id} className={`cm-item${m.active ? '' : ' cm-item--inactive'}`}>
+                <span className="cm-category-badge">{m.category}</span>
+                <span className="cm-item-body">
+                  <strong>{m.tag}</strong>
+                  <span className="cm-item-note">{m.note}</span>
+                </span>
+                <label className="cm-resolve">
+                  <input
+                    type="checkbox"
+                    checked={!m.active}
+                    onChange={e => update.mutate({ id: m.id, memory: { active: !e.target.checked } })}
+                  />
+                  Resolved
+                </label>
+                <button
+                  className="cm-delete-btn"
+                  onClick={() => remove.mutate(m.id)}
+                  aria-label={`Delete ${m.tag}`}
+                >
+                  <X size={14} />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {create.isError && <span className="cm-error">Failed to add memory</span>}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/settings/SettingsView.tsx
+++ b/frontend/src/components/settings/SettingsView.tsx
@@ -12,6 +12,7 @@ import {
   useDisconnectGarmin,
 } from '../../api/hooks'
 import AthleteProfileSection from './AthleteProfileSection'
+import CoachMemorySection from './CoachMemorySection'
 import ThresholdEstimateSection from './ThresholdEstimateSection'
 import ZoneConfigSection from './ZoneConfigSection'
 import './SettingsView.css'
@@ -261,6 +262,9 @@ export default function SettingsView() {
 
       {/* Athlete profile */}
       <AthleteProfileSection />
+
+      {/* Coach memory */}
+      <CoachMemorySection />
 
       {/* Auto-estimated thresholds */}
       <ThresholdEstimateSection />

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -10,6 +10,7 @@ from app.models import (
     Activity,
     AIJob,
     AthleteProfile,
+    CoachMemory,
     DailySummary,
     GarminCalendarEvent,
     Insight,
@@ -168,6 +169,31 @@ def test_format_profile_context_goal_date_only():
     profile = AthleteProfile(goal_race_date=date(2026, 7, 1))
     text = ai_coach._format_athlete_profile_context(profile, reference_date=date(2026, 6, 17))
     assert "Goal Race Date: 2026-07-01 (14 days away)" in text
+
+
+# --- _format_coach_memory_context ---
+
+def test_format_coach_memory_context_emits_active_entries(db):
+    db.add(CoachMemory(user_id=1, category="niggle", tag="knee pain", note="Sore after long runs.", active=True))
+    db.add(CoachMemory(user_id=1, category="constraint", tag="travel", note="Away next week.", active=True))
+    db.add(CoachMemory(user_id=1, category="preference", tag="treadmill", note="Hates treadmills.", active=False))
+    db.commit()
+
+    text = ai_coach._format_coach_memory_context(db, 1)
+    assert "## What The Coach Remembers" in text
+    assert "[niggle] knee pain: Sore after long runs." in text
+    assert "[constraint] travel: Away next week." in text
+    assert "treadmill" not in text  # inactive entries are excluded
+
+
+def test_format_coach_memory_context_empty_returns_blank(db):
+    assert ai_coach._format_coach_memory_context(db, 1) == ""
+
+
+def test_format_coach_memory_context_scoped_to_user(db):
+    db.add(CoachMemory(user_id=2, category="niggle", tag="shin splints", note="Other athlete.", active=True))
+    db.commit()
+    assert ai_coach._format_coach_memory_context(db, 1) == ""
 
 
 # --- _extract_summary_and_category ---
@@ -401,6 +427,8 @@ def test_build_context_full_sections(db):
     # A prior insight to avoid repeating.
     db.add(Insight(trigger_type="activity", trigger_id=1, content="x",
                    summary="Solid aerobic base", category="workout_analysis"))
+    # A durable coach memory.
+    db.add(CoachMemory(user_id=1, category="niggle", tag="knee pain", note="Sore after long runs.", active=True))
     db.commit()
 
     context = ai_coach._build_context(db, "activity", "Trigger data", reference_date=ref)
@@ -413,6 +441,8 @@ def test_build_context_full_sections(db):
     assert "Marathon" in context
     assert "## Recent Insights (avoid repeating these)" in context
     assert "Solid aerobic base" in context
+    assert "## What The Coach Remembers" in context
+    assert "[niggle] knee pain: Sore after long runs." in context
 
 
 def test_weekly_review_generates_insight(db, patch_db_session, monkeypatch):
@@ -1020,6 +1050,12 @@ def test_dispatch_chat_tool_mark_setback(db):
     assert insight.summary == "knee pain"
     assert insight.content == "Sore after long runs."
     assert insight.category == "setback"
+    memory = db.query(CoachMemory).filter(CoachMemory.user_id == 1).first()
+    assert memory is not None
+    assert memory.category == "niggle"
+    assert memory.tag == "knee pain"
+    assert memory.note == "Sore after long runs."
+    assert memory.active is True
     assert action["type"] == "mark_setback"
     assert action["job_id"] is None
 

--- a/tests/test_coach_memory.py
+++ b/tests/test_coach_memory.py
@@ -1,0 +1,70 @@
+from app.models import CoachMemory
+
+
+def test_list_empty_returns_empty_list(client):
+    resp = client.get("/api/v1/coach-memory")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_post_creates_memory(client, db):
+    payload = {"category": "niggle", "tag": "knee pain", "note": "Sore after long runs."}
+    resp = client.post("/api/v1/coach-memory", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] >= 1
+    assert body["category"] == "niggle"
+    assert body["tag"] == "knee pain"
+    assert body["note"] == "Sore after long runs."
+    assert body["active"] is True
+    assert db.query(CoachMemory).count() == 1
+
+
+def test_post_defaults_category_to_note(client):
+    resp = client.post("/api/v1/coach-memory", json={"tag": "hates treadmills", "note": "Prefers outdoor runs."})
+    assert resp.status_code == 200
+    assert resp.json()["category"] == "note"
+
+
+def test_list_returns_newest_first(client):
+    client.post("/api/v1/coach-memory", json={"tag": "first", "note": "a"})
+    client.post("/api/v1/coach-memory", json={"tag": "second", "note": "b"})
+    resp = client.get("/api/v1/coach-memory")
+    tags = [m["tag"] for m in resp.json()]
+    assert tags == ["second", "first"]
+
+
+def test_put_updates_fields(client):
+    created = client.post("/api/v1/coach-memory", json={"tag": "knee pain", "note": "Sore."}).json()
+    resp = client.put(f"/api/v1/coach-memory/{created['id']}", json={"note": "Resolved.", "active": False})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["tag"] == "knee pain"  # unspecified field preserved
+    assert body["note"] == "Resolved."
+    assert body["active"] is False
+
+
+def test_put_missing_returns_404(client):
+    resp = client.put("/api/v1/coach-memory/999", json={"note": "x"})
+    assert resp.status_code == 404
+
+
+def test_delete_removes_memory(client, db):
+    created = client.post("/api/v1/coach-memory", json={"tag": "knee pain", "note": "Sore."}).json()
+    resp = client.delete(f"/api/v1/coach-memory/{created['id']}")
+    assert resp.status_code == 200
+    assert resp.json() == {"deleted": True}
+    assert db.query(CoachMemory).count() == 0
+
+
+def test_delete_missing_returns_404(client):
+    resp = client.delete("/api/v1/coach-memory/999")
+    assert resp.status_code == 404
+
+
+def test_scoped_to_current_user(client, db):
+    """A memory belonging to another user is invisible to this client's user."""
+    db.add(CoachMemory(user_id=999, category="niggle", tag="other user", note="n/a"))
+    db.commit()
+    resp = client.get("/api/v1/coach-memory")
+    assert resp.json() == []


### PR DESCRIPTION
Add a durable, user-scoped CoachMemory store (niggles, life constraints,
preferences) that's injected into every AI analysis and chat context via
_format_coach_memory_context, so the coach doesn't re-derive the athlete
from metrics alone each session. The mark_setback chat tool now also
writes a CoachMemory row alongside its existing Insight, and athletes can
manage entries directly from Settings.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014isr3vfCwxcutfm7Zpt2tK