### PR TITLE
feat: P1-1 daily readiness-driven workout adaptation

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -66,6 +66,7 @@ from app.schemas import (
     TodayResponse,
     TrainingLoadResponse,
     MissedPlanSession,
+    PlanAdaptationRequest,
     PlanRealignmentRequest,
     PlanRealignmentStatus,
     TrainingPlanDayResponse,
@@ -90,6 +91,7 @@ from app.schemas import (
 )
 from app.strength_routines import ROUTINE_LIBRARY, get_routine
 from app import training_load
+from app import plan_adaptation as plan_adaptation_mod
 from app import threshold as threshold_mod
 from app import adherence as adherence_mod
 from app import intensity as intensity_mod
@@ -277,6 +279,25 @@ def api_today(
     recent_rhr = [row[0] for row in recent_rhr_rows]
     readiness = training_load.compute_readiness(daily_summary, current_load, recent_rhr)
 
+    # Readiness-driven plan adaptation suggestion for the selected day's plan day
+    plan_day = (
+        db.query(TrainingPlanDay)
+        .filter(TrainingPlanDay.user_id == uid, TrainingPlanDay.day_date == selected)
+        .first()
+    )
+    plan_adaptation = plan_adaptation_mod.suggest_adaptation(plan_day, readiness)
+    if plan_adaptation is not None:
+        dismissed = (
+            db.query(SyncStatus)
+            .filter(
+                SyncStatus.user_id == uid,
+                SyncStatus.key == f"plan_adaptation_dismissed:{plan_day.id}",
+            )
+            .first()
+        )
+        if dismissed:
+            plan_adaptation = None
+
     return TodayResponse(
         selected_date=selected,
         activities=[ActivitySummary.model_validate(a) for a in activities],
@@ -287,6 +308,7 @@ def api_today(
         scheduled_events=scheduled_events,
         training_load=current_load,
         readiness=readiness,
+        plan_adaptation=plan_adaptation,
     )
 
 
@@ -1195,6 +1217,69 @@ def api_generate_training_plan(current_user: User = Depends(get_current_user)):
     from app.ai_coach import enqueue_job
     job_id = enqueue_job("generate_plan", {}, current_user.id)
     return AIJobEnqueuedResponse(status="queued", job_id=job_id)
+
+
+@api_router.post("/training-plan/adapt-day")
+def api_adapt_plan_day(
+    body: PlanAdaptationRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Accept or dismiss a readiness-driven adaptation suggestion for a plan day."""
+    uid = current_user.id
+    plan_day = (
+        db.query(TrainingPlanDay)
+        .filter(TrainingPlanDay.id == body.plan_day_id, TrainingPlanDay.user_id == uid)
+        .first()
+    )
+    if plan_day is None:
+        raise HTTPException(status_code=404, detail="Plan day not found")
+
+    if body.action == "dismiss":
+        db.add(SyncStatus(
+            user_id=uid,
+            key=f"plan_adaptation_dismissed:{plan_day.id}",
+            value="1",
+        ))
+        db.commit()
+        return {"status": "dismissed"}
+
+    # action == "accept" — re-derive the suggestion server-side and apply it
+    daily_summary = (
+        db.query(DailySummary)
+        .filter(DailySummary.user_id == uid, DailySummary.date == plan_day.day_date)
+        .first()
+    )
+    current_load = training_load.current_load(db, as_of=plan_day.day_date, user_id=uid)
+    rhr_cutoff = plan_day.day_date - timedelta(days=7)
+    recent_rhr_rows = (
+        db.query(DailySummary.resting_hr)
+        .filter(
+            DailySummary.user_id == uid,
+            DailySummary.date >= rhr_cutoff,
+            DailySummary.date < plan_day.day_date,
+            DailySummary.resting_hr.isnot(None),
+        )
+        .all()
+    )
+    recent_rhr = [row[0] for row in recent_rhr_rows]
+    readiness = training_load.compute_readiness(daily_summary, current_load, recent_rhr)
+    suggestion = plan_adaptation_mod.suggest_adaptation(plan_day, readiness)
+    if suggestion is None:
+        raise HTTPException(status_code=409, detail="No adaptation suggestion applies to this plan day")
+
+    plan_day.notes = (
+        f"{suggestion.reason}"
+        + (f"\n{plan_day.notes}" if plan_day.notes else "")
+    )
+    plan_day.workout_type = suggestion.suggested_workout_type
+    plan_day.target_distance_m = suggestion.suggested_target_distance_m
+    if suggestion.direction == "downgrade":
+        plan_day.target_pace_min_km = None
+        plan_day.target_pace_display = None
+    db.commit()
+    db.refresh(plan_day)
+    return _day_to_response(plan_day)
 
 
 @api_router.get("/training-plan/realignment-status", response_model=PlanRealignmentStatus)

--- a/app/plan_adaptation.py
+++ b/app/plan_adaptation.py
@@ -1,0 +1,95 @@
+"""Daily readiness-driven workout adaptation (P1-1).
+
+Closes the loop between the readiness score computed in ``training_load`` and
+the static ``TrainingPlanDay`` prescription: a hard day paired with low
+readiness is downgraded, and an easy day paired with excellent readiness gets
+a small upgrade nudge. Purely rule-based (readiness bands x workout type) —
+no AI involved.
+"""
+
+from __future__ import annotations
+
+from app.models import TrainingPlanDay
+from app.schemas import PlanAdaptationSuggestion, TrainingReadiness
+
+HARD_WORKOUT_TYPES = {"tempo", "interval", "long"}
+EASY_WORKOUT_TYPES = {"easy"}
+
+# Downgrade an easy day's target distance to this fraction when readiness is Fair.
+_DOWNGRADE_DISTANCE_FACTOR = 0.6
+# Upgrade an easy day's target distance by this fraction when readiness is Excellent.
+_UPGRADE_DISTANCE_FACTOR = 0.15
+_UPGRADE_DISTANCE_CAP_M = 2000.0
+
+
+def suggest_adaptation(
+    plan_day: TrainingPlanDay | None,
+    readiness: TrainingReadiness | None,
+) -> PlanAdaptationSuggestion | None:
+    """Propose a rule-based swap for today's plan day, or None if no change is warranted."""
+    if plan_day is None or readiness is None:
+        return None
+
+    workout_type = plan_day.workout_type
+
+    if workout_type in HARD_WORKOUT_TYPES:
+        if readiness.score <= 30:
+            return PlanAdaptationSuggestion(
+                plan_day_id=plan_day.id,
+                direction="downgrade",
+                current_workout_type=workout_type,
+                suggested_workout_type="rest",
+                current_target_distance_m=plan_day.target_distance_m,
+                suggested_target_distance_m=None,
+                reason=(
+                    f"Readiness is Low today ({readiness.score}/100) — consider "
+                    f"resting instead of today's {workout_type} session."
+                ),
+                readiness_score=readiness.score,
+            )
+        if readiness.score <= 50:
+            suggested_distance = (
+                round(plan_day.target_distance_m * _DOWNGRADE_DISTANCE_FACTOR)
+                if plan_day.target_distance_m
+                else None
+            )
+            return PlanAdaptationSuggestion(
+                plan_day_id=plan_day.id,
+                direction="downgrade",
+                current_workout_type=workout_type,
+                suggested_workout_type="easy",
+                current_target_distance_m=plan_day.target_distance_m,
+                suggested_target_distance_m=suggested_distance,
+                reason=(
+                    f"Readiness is Fair today ({readiness.score}/100) — consider "
+                    f"swapping today's {workout_type} for an easy effort."
+                ),
+                readiness_score=readiness.score,
+            )
+        return None
+
+    if workout_type in EASY_WORKOUT_TYPES and readiness.score >= 86:
+        suggested_distance = (
+            min(
+                plan_day.target_distance_m * (1 + _UPGRADE_DISTANCE_FACTOR),
+                plan_day.target_distance_m + _UPGRADE_DISTANCE_CAP_M,
+            )
+            if plan_day.target_distance_m
+            else None
+        )
+        suggested_distance = round(suggested_distance) if suggested_distance else None
+        return PlanAdaptationSuggestion(
+            plan_day_id=plan_day.id,
+            direction="upgrade",
+            current_workout_type=workout_type,
+            suggested_workout_type="easy",
+            current_target_distance_m=plan_day.target_distance_m,
+            suggested_target_distance_m=suggested_distance,
+            reason=(
+                f"Readiness is Excellent today ({readiness.score}/100) — you're "
+                "primed. Feel free to add a few strides or extend today's easy run."
+            ),
+            readiness_score=readiness.score,
+        )
+
+    return None

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -369,6 +369,17 @@ class TrainingLoadResponse(BaseModel):
     current: TrainingLoadPoint | None = None
 
 
+class PlanAdaptationSuggestion(BaseModel):
+    plan_day_id: int
+    direction: Literal["downgrade", "upgrade"]
+    current_workout_type: str
+    suggested_workout_type: str
+    current_target_distance_m: float | None = None
+    suggested_target_distance_m: float | None = None
+    reason: str
+    readiness_score: int
+
+
 class TodayResponse(BaseModel):
     selected_date: date
     activities: list[ActivitySummary] = []
@@ -379,6 +390,7 @@ class TodayResponse(BaseModel):
     scheduled_events: list[CalendarEventResponse] = []
     training_load: TrainingLoadPoint | None = None
     readiness: TrainingReadiness | None = None
+    plan_adaptation: PlanAdaptationSuggestion | None = None
 
 
 class SettingsResponse(BaseModel):
@@ -637,6 +649,11 @@ class PlanRealignmentStatus(BaseModel):
 
 class PlanRealignmentRequest(BaseModel):
     action: Literal["regenerate", "dismiss"]
+
+
+class PlanAdaptationRequest(BaseModel):
+    plan_day_id: int
+    action: Literal["accept", "dismiss"]
 
 
 class IntensityWeek(BaseModel):

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -139,22 +139,29 @@ round-trips them), `app/schemas.py` (`ChatAction`), `frontend/src/api/types.ts`,
 
 ### P1 — Execution depth & daily adaptation
 
-#### P1-1 · Daily readiness-driven workout adaptation
+#### P1-1 · Daily readiness-driven workout adaptation ✅ DONE (2026-07-01)
 **What:** Close the loop between the **readiness score we already compute** and the
-**static plan day**. Each morning (or on Today load), if today's prescribed
-`TrainingPlanDay` is hard and readiness is low, propose a down-regulated swap (hard →
-easy/recovery, or shift the session); if readiness is high on an easy day before a
-key block, allow a nudge up. Surface as an accept/dismiss suggestion on Today, and
-fold the decision into adherence/plan context. Start rule-based (readiness bands ×
-workout type) before involving the AI.
+**static plan day**. On Today load, if the selected day's prescribed `TrainingPlanDay`
+is hard (tempo/interval/long) and readiness is low, propose a down-regulated swap
+(Low readiness → rest, Fair readiness → easy at ~60% distance); if readiness is
+Excellent on an easy day, offer a small upgrade nudge (+15% distance, capped at
++2 km). Surfaced as an accept/dismiss card on Today; accepting mutates the
+`TrainingPlanDay` in place (so adherence/plan context automatically reflects the
+swap), dismissing snoozes it via the existing `SyncStatus` key/value store. Purely
+rule-based (readiness bands × workout type) — no AI involved.
 **Rationale:** Garmin DSW's core loop. We have the inputs (readiness, the plan, the
 calendar) but never act on them day-to-day — the plan is regenerated weekly and
 otherwise frozen. High-signal, mostly deterministic, and it makes readiness
 *actionable* instead of merely displayed.
 **Effort:** M.
-**Files:** new adaptation helper (over `app/training_load.py` readiness +
-`TrainingPlanDay`), `app/api.py` (Today suggestion + accept endpoint), `app/ai_coach.py`
-(optional narrative), `frontend/src/components/today/*` + hooks/types.
+**Files:** `app/plan_adaptation.py` (new, `suggest_adaptation`), `app/schemas.py`
+(`PlanAdaptationSuggestion`, `PlanAdaptationRequest`, `TodayResponse.plan_adaptation`),
+`app/api.py` (`GET /today` attaches the suggestion; new
+`POST /training-plan/adapt-day` accept/dismiss endpoint, reusing `SyncStatus` — no
+migration needed), `frontend/src/api/types.ts`, `frontend/src/api/hooks.ts`
+(`useAdaptPlanDay`), `frontend/src/components/today/PlanAdaptationCard.tsx` + `.css`,
+`TodayView.tsx`, `tests/test_plan_adaptation.py` (new, 11 tests),
+`tests/test_api_endpoints.py` (9 new tests).
 
 #### P1-2 · Terrain / GAP-aware race pacing (+ optional course import)
 **What:** Extend `app/pacing.py` beyond flat even/negative splits to allocate pace by

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -30,6 +30,7 @@ import type {
   CoachMemoryRequest,
   CoachMemoryUpdateRequest,
   TrainingLoadResponse,
+  TrainingPlanDay,
   TrainingPlanResponse,
   UserResponse,
   ZoneConfigBulkUpdate,
@@ -395,6 +396,21 @@ export function useRealignPlan() {
         qc.invalidateQueries({ queryKey: ['realignment-status'] })
       }
       // For 'regenerate', the caller polls via useJobStatus and invalidates on done
+    },
+  })
+}
+
+export function useAdaptPlanDay() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ planDayId, action }: { planDayId: number; action: 'accept' | 'dismiss' }) =>
+      apiPost<TrainingPlanDay | { status: string }>('/training-plan/adapt-day', {
+        plan_day_id: planDayId,
+        action,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['today'] })
+      qc.invalidateQueries({ queryKey: ['training-plan'] })
     },
   })
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -272,6 +272,17 @@ export interface TrainingLoadResponse {
   current: TrainingLoadPoint | null
 }
 
+export interface PlanAdaptationSuggestion {
+  plan_day_id: number
+  direction: 'downgrade' | 'upgrade'
+  current_workout_type: string
+  suggested_workout_type: string
+  current_target_distance_m: number | null
+  suggested_target_distance_m: number | null
+  reason: string
+  readiness_score: number
+}
+
 export interface TodayResponse {
   selected_date: string
   activities: ActivitySummary[]
@@ -282,6 +293,7 @@ export interface TodayResponse {
   scheduled_events: CalendarEvent[]
   training_load: TrainingLoadPoint | null
   readiness: TrainingReadiness | null
+  plan_adaptation: PlanAdaptationSuggestion | null
 }
 
 export interface SettingsResponse {

--- a/frontend/src/components/today/PlanAdaptationCard.css
+++ b/frontend/src/components/today/PlanAdaptationCard.css
@@ -1,0 +1,101 @@
+.plan-adaptation-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.plan-adaptation-downgrade {
+  border: 1px solid color-mix(in srgb, var(--color-tempo) 40%, transparent);
+  background: color-mix(in srgb, var(--color-tempo) 8%, var(--bg-card));
+}
+
+.plan-adaptation-upgrade {
+  border: 1px solid color-mix(in srgb, var(--color-easy) 40%, transparent);
+  background: color-mix(in srgb, var(--color-easy) 8%, var(--bg-card));
+}
+
+.plan-adaptation-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.plan-adaptation-downgrade .plan-adaptation-header {
+  color: var(--color-tempo);
+}
+
+.plan-adaptation-upgrade .plan-adaptation-header {
+  color: var(--color-easy);
+}
+
+.plan-adaptation-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.plan-adaptation-reason {
+  font-size: 0.85rem;
+  color: var(--text);
+  line-height: 1.4;
+  margin: 0;
+}
+
+.plan-adaptation-swap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  text-transform: capitalize;
+}
+
+.plan-adaptation-to {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.plan-adaptation-arrow {
+  color: var(--text-muted);
+}
+
+.plan-adaptation-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 2px;
+}
+
+.plan-adaptation-accept {
+  font-size: 0.8rem;
+  padding: 6px 14px;
+}
+
+.plan-adaptation-dismiss {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s;
+}
+
+.plan-adaptation-dismiss:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.plan-adaptation-dismiss:disabled,
+.plan-adaptation-accept:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.plan-adaptation-accept .spin {
+  animation: plan-adaptation-spin 1s linear infinite;
+}
+
+@keyframes plan-adaptation-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/frontend/src/components/today/PlanAdaptationCard.tsx
+++ b/frontend/src/components/today/PlanAdaptationCard.tsx
@@ -1,0 +1,59 @@
+import { useAdaptPlanDay } from '../../api/hooks'
+import type { PlanAdaptationSuggestion } from '../../api/types'
+import { TrendingDown, TrendingUp, RefreshCw } from 'lucide-react'
+import './PlanAdaptationCard.css'
+
+interface Props {
+  suggestion: PlanAdaptationSuggestion
+}
+
+function formatDistance(m: number | null): string | null {
+  if (m == null) return null
+  return `${(m / 1000).toFixed(1)} km`
+}
+
+export default function PlanAdaptationCard({ suggestion }: Props) {
+  const { mutate: adapt, isPending } = useAdaptPlanDay()
+  const isDowngrade = suggestion.direction === 'downgrade'
+
+  const currentDist = formatDistance(suggestion.current_target_distance_m)
+  const suggestedDist = formatDistance(suggestion.suggested_target_distance_m)
+
+  return (
+    <div className={`card plan-adaptation-card plan-adaptation-${suggestion.direction}`}>
+      <div className="plan-adaptation-header">
+        {isDowngrade ? <TrendingDown size={16} /> : <TrendingUp size={16} />}
+        <span className="plan-adaptation-title">
+          {isDowngrade ? 'Suggested: ease off today' : 'Suggested: you\'re primed'}
+        </span>
+      </div>
+      <p className="plan-adaptation-reason">{suggestion.reason}</p>
+      <div className="plan-adaptation-swap">
+        <span className="plan-adaptation-from">
+          {suggestion.current_workout_type}{currentDist ? ` · ${currentDist}` : ''}
+        </span>
+        <span className="plan-adaptation-arrow">&rarr;</span>
+        <span className="plan-adaptation-to">
+          {suggestion.suggested_workout_type}{suggestedDist ? ` · ${suggestedDist}` : ''}
+        </span>
+      </div>
+      <div className="plan-adaptation-actions">
+        <button
+          className="btn-primary plan-adaptation-accept"
+          onClick={() => adapt({ planDayId: suggestion.plan_day_id, action: 'accept' })}
+          disabled={isPending}
+        >
+          {isPending ? <RefreshCw size={13} className="spin" /> : null}
+          Accept
+        </button>
+        <button
+          className="plan-adaptation-dismiss"
+          onClick={() => adapt({ planDayId: suggestion.plan_day_id, action: 'dismiss' })}
+          disabled={isPending}
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/today/TodayView.tsx
+++ b/frontend/src/components/today/TodayView.tsx
@@ -7,6 +7,7 @@ import ScheduledWorkoutCard from './ScheduledWorkoutCard'
 import WeekOverview from './WeekOverview'
 import TrainingLoadChart from './TrainingLoadChart'
 import ReadinessCard from './ReadinessCard'
+import PlanAdaptationCard from './PlanAdaptationCard'
 import InsightsList from './InsightsList'
 import RacePacingCard from './RacePacingCard'
 import StatHelpButton from '../info/StatHelpButton'
@@ -127,6 +128,13 @@ export default function TodayView() {
       {data?.readiness && (
         <section className="today-section">
           <ReadinessCard readiness={data.readiness} />
+        </section>
+      )}
+
+      {/* Readiness-driven plan adaptation suggestion */}
+      {data?.plan_adaptation && (
+        <section className="today-section">
+          <PlanAdaptationCard suggestion={data.plan_adaptation} />
         </section>
       )}
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -442,6 +442,183 @@ def test_realign_invalid_action(client):
     assert resp.status_code == 422
 
 
+# --- Daily readiness-driven plan adaptation (P1-1) ---
+
+def _seed_low_readiness_daily(db, day):
+    """Seed a DailySummary that scores readiness ~0 (Low band)."""
+    db.add(DailySummary(
+        date=day,
+        sleep_score=0,
+        sleep_seconds=5 * 3600,
+        stress_avg=100,
+        body_battery_high=0,
+    ))
+    db.commit()
+
+
+def _seed_fair_readiness_daily(db, day):
+    """Seed a DailySummary that scores readiness ~40 (Fair band)."""
+    db.add(DailySummary(
+        date=day,
+        sleep_score=40,
+        stress_avg=60,
+        body_battery_high=40,
+    ))
+    db.commit()
+
+
+def _seed_excellent_readiness_daily(db, day):
+    """Seed a DailySummary that scores readiness ~100 (Excellent band)."""
+    db.add(DailySummary(
+        date=day,
+        sleep_score=100,
+        sleep_seconds=8 * 3600,
+        stress_avg=0,
+        body_battery_high=100,
+    ))
+    db.commit()
+
+
+def test_today_includes_plan_adaptation_downgrade_suggestion(client, db):
+    day = date(2026, 6, 17)
+    _seed_low_readiness_daily(db, day)
+    plan = _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "tempo", "dist_m": 10000},
+    ])
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["plan_adaptation"] is not None
+    assert body["plan_adaptation"]["direction"] == "downgrade"
+    assert body["plan_adaptation"]["suggested_workout_type"] == "rest"
+
+
+def test_today_no_plan_adaptation_when_readiness_good(client, db):
+    day = date(2026, 6, 17)
+    db.add(DailySummary(date=day, sleep_score=80, stress_avg=20, body_battery_high=80))
+    db.commit()
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "tempo", "dist_m": 10000},
+    ])
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    assert resp.json()["plan_adaptation"] is None
+
+
+def test_today_plan_adaptation_suppressed_when_dismissed(client, db):
+    day = date(2026, 6, 17)
+    _seed_low_readiness_daily(db, day)
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "tempo", "dist_m": 10000},
+    ])
+    plan_day = db.query(TrainingPlanDay).filter(TrainingPlanDay.day_date == day).first()
+    db.add(SyncStatus(key=f"plan_adaptation_dismissed:{plan_day.id}", value="1"))
+    db.commit()
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    assert resp.json()["plan_adaptation"] is None
+
+
+def test_adapt_day_accept_downgrade_to_rest(client, db):
+    day = date(2026, 6, 17)
+    _seed_low_readiness_daily(db, day)
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "long", "dist_m": 20000},
+    ])
+    plan_day = db.query(TrainingPlanDay).filter(TrainingPlanDay.day_date == day).first()
+
+    resp = client.post("/api/v1/training-plan/adapt-day", json={
+        "plan_day_id": plan_day.id, "action": "accept",
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["workout_type"] == "rest"
+    assert body["target_distance_m"] is None
+
+    db.expire_all()
+    updated = db.query(TrainingPlanDay).filter(TrainingPlanDay.id == plan_day.id).first()
+    assert updated.workout_type == "rest"
+    assert updated.target_distance_m is None
+    assert "Low" in updated.notes
+
+    # The now-rest day no longer triggers a suggestion.
+    resp2 = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp2.json()["plan_adaptation"] is None
+
+
+def test_adapt_day_accept_downgrade_to_easy_reduces_distance(client, db):
+    day = date(2026, 6, 17)
+    _seed_fair_readiness_daily(db, day)
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "tempo", "dist_m": 10000},
+    ])
+    plan_day = db.query(TrainingPlanDay).filter(TrainingPlanDay.day_date == day).first()
+
+    resp = client.post("/api/v1/training-plan/adapt-day", json={
+        "plan_day_id": plan_day.id, "action": "accept",
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["workout_type"] == "easy"
+    assert body["target_distance_m"] == pytest.approx(6000.0)
+
+
+def test_adapt_day_dismiss(client, db):
+    day = date(2026, 6, 17)
+    _seed_fair_readiness_daily(db, day)
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "tempo", "dist_m": 10000},
+    ])
+    plan_day = db.query(TrainingPlanDay).filter(TrainingPlanDay.day_date == day).first()
+
+    resp = client.post("/api/v1/training-plan/adapt-day", json={
+        "plan_day_id": plan_day.id, "action": "dismiss",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "dismissed"
+
+    row = db.query(SyncStatus).filter(
+        SyncStatus.key == f"plan_adaptation_dismissed:{plan_day.id}"
+    ).first()
+    assert row is not None
+
+    resp2 = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp2.json()["plan_adaptation"] is None
+
+
+def test_adapt_day_accept_no_suggestion_conflict(client, db):
+    day = date(2026, 6, 17)
+    db.add(DailySummary(date=day, sleep_score=80, stress_avg=20, body_battery_high=80))
+    db.commit()
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "tempo", "dist_m": 10000},
+    ])
+    plan_day = db.query(TrainingPlanDay).filter(TrainingPlanDay.day_date == day).first()
+
+    resp = client.post("/api/v1/training-plan/adapt-day", json={
+        "plan_day_id": plan_day.id, "action": "accept",
+    })
+    assert resp.status_code == 409
+
+
+def test_adapt_day_not_found(client):
+    resp = client.post("/api/v1/training-plan/adapt-day", json={
+        "plan_day_id": 999999, "action": "dismiss",
+    })
+    assert resp.status_code == 404
+
+
+def test_adapt_day_invalid_action(client, db):
+    _seed_plan_and_days(db, [
+        {"date": date(2026, 6, 17), "workout_type": "tempo", "dist_m": 10000},
+    ])
+    plan_day = db.query(TrainingPlanDay).first()
+    resp = client.post("/api/v1/training-plan/adapt-day", json={
+        "plan_day_id": plan_day.id, "action": "bogus",
+    })
+    assert resp.status_code == 422
+
+
 # --- P2-2: /strength-routines ---
 
 def test_strength_routines_returns_catalog(client):

--- a/tests/test_plan_adaptation.py
+++ b/tests/test_plan_adaptation.py
@@ -1,0 +1,95 @@
+"""Tests for readiness-driven plan day adaptation (P1-1)."""
+
+from app.models import TrainingPlanDay
+from app.plan_adaptation import suggest_adaptation
+from app.schemas import TrainingReadiness
+
+
+def _day(workout_type="tempo", target_distance_m=10000.0, day_id=1):
+    return TrainingPlanDay(
+        id=day_id,
+        plan_id=1,
+        day_date=None,
+        day_of_week="Monday",
+        week_number=1,
+        workout_type=workout_type,
+        target_distance_m=target_distance_m,
+    )
+
+
+def _readiness(score, label="Fair"):
+    return TrainingReadiness(score=score, label=label)
+
+
+def test_no_suggestion_without_plan_day():
+    assert suggest_adaptation(None, _readiness(20)) is None
+
+
+def test_no_suggestion_without_readiness():
+    assert suggest_adaptation(_day(), None) is None
+
+
+def test_hard_day_low_readiness_downgrades_to_rest():
+    day = _day(workout_type="interval", target_distance_m=8000.0)
+    suggestion = suggest_adaptation(day, _readiness(25, "Low"))
+    assert suggestion is not None
+    assert suggestion.direction == "downgrade"
+    assert suggestion.plan_day_id == day.id
+    assert suggestion.current_workout_type == "interval"
+    assert suggestion.suggested_workout_type == "rest"
+    assert suggestion.suggested_target_distance_m is None
+    assert "Low" in suggestion.reason
+
+
+def test_hard_day_fair_readiness_downgrades_to_easy_with_reduced_distance():
+    day = _day(workout_type="tempo", target_distance_m=10000.0)
+    suggestion = suggest_adaptation(day, _readiness(45, "Fair"))
+    assert suggestion is not None
+    assert suggestion.direction == "downgrade"
+    assert suggestion.suggested_workout_type == "easy"
+    assert suggestion.suggested_target_distance_m == 6000.0
+    assert suggestion.current_target_distance_m == 10000.0
+
+
+def test_hard_day_fair_readiness_without_target_distance():
+    day = _day(workout_type="long", target_distance_m=None)
+    suggestion = suggest_adaptation(day, _readiness(40, "Fair"))
+    assert suggestion is not None
+    assert suggestion.suggested_target_distance_m is None
+
+
+def test_hard_day_good_readiness_no_suggestion():
+    day = _day(workout_type="tempo")
+    assert suggest_adaptation(day, _readiness(51, "Good")) is None
+
+
+def test_easy_day_excellent_readiness_upgrades():
+    day = _day(workout_type="easy", target_distance_m=8000.0)
+    suggestion = suggest_adaptation(day, _readiness(90, "Excellent"))
+    assert suggestion is not None
+    assert suggestion.direction == "upgrade"
+    assert suggestion.suggested_workout_type == "easy"
+    assert suggestion.suggested_target_distance_m == 9200.0  # +15%, under the 2km cap
+
+
+def test_easy_day_upgrade_distance_capped():
+    day = _day(workout_type="easy", target_distance_m=20000.0)
+    suggestion = suggest_adaptation(day, _readiness(90, "Excellent"))
+    assert suggestion is not None
+    assert suggestion.suggested_target_distance_m == 22000.0  # capped at +2km, not +15%
+
+
+def test_easy_day_good_readiness_no_suggestion():
+    day = _day(workout_type="easy")
+    assert suggest_adaptation(day, _readiness(60, "Good")) is None
+
+
+def test_rest_day_never_suggests():
+    day = _day(workout_type="rest")
+    assert suggest_adaptation(day, _readiness(20, "Low")) is None
+    assert suggest_adaptation(day, _readiness(95, "Excellent")) is None
+
+
+def test_strength_and_cross_days_never_suggest():
+    assert suggest_adaptation(_day(workout_type="strength"), _readiness(95)) is None
+    assert suggest_adaptation(_day(workout_type="cross"), _readiness(95)) is None


### PR DESCRIPTION
Close the loop between the readiness score and the static plan day: a
hard day (tempo/interval/long) with low readiness gets a down-regulated
swap (Low -> rest, Fair -> easy at ~60% distance), and an easy day with
excellent readiness gets a small upgrade nudge. Surfaced as an
accept/dismiss card on Today; accepting mutates the TrainingPlanDay in
place, dismissing snoozes it via the existing SyncStatus store. Purely
rule-based, no AI involved.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0179P1hPEFq5uLjxuncY2As6