### PR TITLE
Fix CV model race predictions being faster than threshold pace

### DIFF
--- a/app/threshold.py
+++ b/app/threshold.py
@@ -54,6 +54,10 @@ DEFAULT_LOOKBACK_DAYS = 90
 # anaerobically dominated, longer ones drift below the asymptote.
 _FIT_MIN_S = 120
 _FIT_MAX_S = 2400
+# Riegel (1977) fatigue exponent, used to extrapolate race predictions beyond
+# _FIT_MAX_S: the CV/D' model has no fatigue term, so left unbounded it predicts
+# every race pace as faster than CV, no matter how long the race.
+_RIEGEL_FATIGUE_EXPONENT = 1.06
 # Anchors that make a fit well-conditioned.
 _SHORT_ANCHOR_S = 300
 _LONG_ANCHOR_S = 1200
@@ -905,14 +909,27 @@ class PerformanceCurveData:
 
 
 def _predict_race_times(cv: float, d_prime: float) -> list[RacePrediction]:
-    """Predict finish times for standard distances using the CV model: t = (D - D') / CV."""
+    """Predict finish times for standard distances.
+
+    Within the model's fitted window (t <= _FIT_MAX_S) uses the CV model
+    directly: t = (D - D') / CV. Beyond it, extrapolates with the Riegel
+    fatigue exponent anchored at the model's own _FIT_MAX_S prediction, so
+    long-race predictions taper below CV pace instead of the CV model's
+    unbounded (and unphysiological) faster-than-CV asymptote.
+    """
+    anchor_t = _FIT_MAX_S
+    anchor_d = cv * anchor_t + d_prime
     predictions: list[RacePrediction] = []
     for label, dist_m in RACE_DISTANCES:
         if d_prime >= dist_m:
             continue
-        t_sec = (dist_m - d_prime) / cv
-        if t_sec <= 0:
+        t_cv = (dist_m - d_prime) / cv
+        if t_cv <= 0:
             continue
+        if t_cv <= anchor_t:
+            t_sec = t_cv
+        else:
+            t_sec = anchor_t * (dist_m / anchor_d) ** _RIEGEL_FATIGUE_EXPONENT
         pace_min_km = (t_sec / dist_m) * 1000.0 / 60.0
         predictions.append(RacePrediction(
             distance_label=label,

--- a/frontend/src/components/info/statInfo.ts
+++ b/frontend/src/components/info/statInfo.ts
@@ -203,10 +203,12 @@ export const STAT_INFO: Record<string, InfoTopic> = {
         name: 'Critical Velocity',
         acronym: 'CV (Critical Velocity)',
         description:
-          'The highest sustainable aerobic running speed — essentially your running "threshold pace". ' +
-          'Estimated by fitting a two-parameter (hyperbolic) model to the mean-maximal pace curve. ' +
-          'It represents the asymptote the curve approaches as duration grows: the speed you could ' +
-          'theoretically hold forever on fresh legs.',
+          'The highest sustainable aerobic running speed — essentially your running "threshold pace", ' +
+          'typically sustainable for roughly 30–60 minutes rather than indefinitely. Estimated by ' +
+          'fitting a two-parameter (hyperbolic) model to the mean-maximal pace curve. CV is the ' +
+          'mathematical asymptote that curve approaches as duration grows — not a literal forever-pace; ' +
+          'real-world limiters (glycogen depletion, heat, dehydration) still bring you below it well ' +
+          'before "forever".',
         formula:
           'speed(d) = CV + D′ ÷ d  →  CV is the slope (m/s), D′ is the y-intercept offset (m)',
         limits:
@@ -258,15 +260,20 @@ export const STAT_INFO: Record<string, InfoTopic> = {
         name: 'Race Predictions',
         description:
           'Estimated finish times for standard distances (5 K, 10 K, Half Marathon, Marathon) ' +
-          'derived from the Critical Velocity model. For each distance the model solves for the ' +
-          'duration at which average speed equals CV + D′ / duration.',
+          'derived from the Critical Velocity model. For durations within the model\'s fitted range ' +
+          '(≈2–40 min) the model solves directly for the duration at which average speed equals ' +
+          'CV + D′ / duration. Beyond ~40 min — where the CV model is no longer trustworthy — the ' +
+          'prediction instead extrapolates with a fatigue (Riegel) exponent anchored to the model\'s ' +
+          'own 40-minute prediction, so marathon-length predictions taper to a pace slower than CV ' +
+          'instead of implying you could hold "threshold" pace for a whole marathon.',
         formula:
-          'time(dist) = D′ ÷ (target_speed − CV),  where target_speed satisfies dist = target_speed × time(dist)',
+          'time(dist) = D′ ÷ (target_speed − CV) for efforts ≤ ~40 min; beyond that, ' +
+          'time(dist) = T_anchor × (dist ÷ D_anchor)^1.06, anchored at the model\'s own 40-minute prediction',
         limits:
           'Predictions assume ideal conditions and fully fresh legs. They get more accurate as more ' +
           'varied-effort runs enter the window. They are most reliable close to race distances you ' +
           'have actually trained at — extrapolating to the marathon from only 5-km efforts ' +
-          'is speculative.',
+          'is still speculative, even with the fatigue adjustment.',
       },
     ],
   },

--- a/tests/test_threshold.py
+++ b/tests/test_threshold.py
@@ -468,6 +468,38 @@ def test_predict_race_times_skips_when_d_prime_exceeds_distance():
     assert "Half Marathon" in labels
 
 
+def test_predict_race_times_marathon_slower_than_cv():
+    # Values matching the reported bug: marathon predicted faster than CV.
+    cv = 1000.0 / 291.0    # 4:51/km
+    d_prime = 245.0
+    cv_pace_min_km = (1000.0 / cv) / 60.0
+    preds = {p.distance_label: p for p in threshold._predict_race_times(cv, d_prime)}
+
+    # 5K is well inside the fitted window (~2-40 min) — unaffected, still
+    # faster than CV, matching the direct CV-model formula.
+    assert preds["5K"].predicted_pace_min_km < cv_pace_min_km
+
+    # Marathon (and half marathon) fall outside the fitted window and should
+    # now be extrapolated to a pace slower than CV, not faster.
+    assert preds["Marathon"].predicted_pace_min_km >= cv_pace_min_km
+    assert preds["Half Marathon"].predicted_pace_min_km >= preds["5K"].predicted_pace_min_km
+
+
+def test_predict_race_times_continuous_at_fit_boundary():
+    # A synthetic distance whose direct CV-model time lands exactly at
+    # _FIT_MAX_S should be unaffected by the Riegel branch (continuity check).
+    cv = 3.5
+    d_prime = 200.0
+    anchor_dist = cv * threshold._FIT_MAX_S + d_prime
+    direct_t = (anchor_dist - d_prime) / cv
+    assert direct_t == threshold._FIT_MAX_S
+
+    # Distance just beyond the anchor should equal the direct-formula time
+    # at that same point (both branches agree at the boundary).
+    riegel_t_at_anchor = threshold._FIT_MAX_S * (anchor_dist / anchor_dist) ** threshold._RIEGEL_FATIGUE_EXPONENT
+    assert abs(riegel_t_at_anchor - direct_t) < 1e-9
+
+
 def test_get_performance_curve_data_empty_db(db):
     data = threshold.get_performance_curve_data(db)
     assert data.power_points == []


### PR DESCRIPTION
The Critical Velocity model (v(t) = CV + D'/t) is only fit/valid on
2-40 min efforts, but race predictions extrapolated it unbounded out
to marathon distance. Since D'/t is always positive, this guaranteed
every predicted race pace was faster than CV — e.g. a marathon
predicted at 4:49/km against a 4:51/km "threshold" pace.

Predictions beyond the model's fitted window (_FIT_MAX_S = 40 min) now
extrapolate with the Riegel fatigue exponent, anchored at the model's
own 40-minute prediction, so long-race predictions taper to a pace
slower than CV as intended. Also corrected the "hold forever" CV
description in the stat info panel to reflect that CV is a
30-60 minute sustainable pace, not a literal infinite-duration one.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wah69v1zPi88K6xWvBcetp