### PR TITLE
Add terrain/GAP-aware race pacing (P1-2)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1391,10 +1391,47 @@ def _get_race_event(race_id: int, user_id: int, db: Session) -> GarminCalendarEv
     return race
 
 
+_MIN_COURSE_PROFILE_SAMPLES = 10
+
+
+def _matched_course_profile(
+    race: GarminCalendarEvent, user_id: int, db: Session,
+) -> tuple[list[tuple[float, float]], Activity] | None:
+    """Find the athlete's closest-distance past run with a usable elevation stream
+    and build a (distance_m, elevation_m) course profile from it.
+    """
+    candidates = (
+        db.query(Activity)
+        .filter(
+            Activity.user_id == user_id,
+            Activity.activity_type == "running",
+            Activity.laps_json.isnot(None),
+            Activity.distance_m.isnot(None),
+        )
+        .order_by(func.abs(Activity.distance_m - race.distance_m))
+        .limit(20)
+        .all()
+    )
+    for act in candidates:
+        details = safe_json_loads(act.laps_json)
+        parsed = streams_mod.parse_streams(details)
+        if not parsed:
+            continue
+        profile = sorted(
+            (d, e)
+            for d, e in zip(parsed["distance"], parsed["elevation"])
+            if isinstance(d, (int, float)) and isinstance(e, (int, float))
+        )
+        if len(profile) < _MIN_COURSE_PROFILE_SAMPLES or profile[-1][0] - profile[0][0] <= 0:
+            continue
+        return profile, act
+    return None
+
+
 @api_router.get("/races/{race_id}/pacing", response_model=PacingStrategyResponse)
 def api_race_pacing(
     race_id: int,
-    strategy: str = Query("even", pattern="^(even|negative_split)$"),
+    strategy: str = Query("even", pattern="^(even|negative_split|terrain)$"),
     split_unit: str = Query("km", pattern="^(km|mile)$"),
     target_time_sec: int | None = Query(None),
     db: Session = Depends(get_db),
@@ -1403,7 +1440,8 @@ def api_race_pacing(
     """Generate a race-day split-by-split pacing strategy.
 
     target_time_sec overrides goal_time_sec; if neither is set, falls back to
-    the CV-model prediction from the performance curve.
+    the CV-model prediction from the performance curve. "terrain" strategy
+    sources an elevation profile from the athlete's closest-distance past run.
     """
     from app import pacing as pacing_mod
 
@@ -1451,6 +1489,17 @@ def api_race_pacing(
         except Exception:
             pass
 
+    course_activity: Activity | None = None
+    elevation_profile: list[tuple[float, float]] | None = None
+    if strategy == "terrain":
+        match = _matched_course_profile(race, current_user.id, db)
+        if not match:
+            raise HTTPException(
+                status_code=422,
+                detail="No terrain profile available: sync a past run with elevation data close to this race's distance.",
+            )
+        elevation_profile, course_activity = match
+
     plan = pacing_mod.generate_pacing_strategy(
         distance_m=race.distance_m,
         target_time_sec=float(effective_target),
@@ -1458,6 +1507,7 @@ def api_race_pacing(
         split_unit=split_unit,
         predicted_time_sec=predicted_time,
         source=source,
+        elevation_profile=elevation_profile,
     )
 
     return PacingStrategyResponse(
@@ -1478,11 +1528,14 @@ def api_race_pacing(
                 "target_pace_min_km": s.target_pace_min_km,
                 "split_time_sec": s.split_time_sec,
                 "cumulative_time_sec": s.cumulative_time_sec,
+                "grade_pct": s.grade_pct,
             }
             for s in plan.splits
         ],
         predicted_time_sec=plan.predicted_time_sec,
         source=plan.source,
+        course_activity_id=course_activity.id if course_activity else None,
+        course_activity_name=course_activity.name if course_activity else None,
     )
 
 
@@ -1528,10 +1581,21 @@ def api_push_race_pacing(
                 detail="No target time available to build pacing plan.",
             )
 
+    elevation_profile: list[tuple[float, float]] | None = None
+    if body.strategy == "terrain":
+        match = _matched_course_profile(race, current_user.id, db)
+        if not match:
+            raise HTTPException(
+                status_code=422,
+                detail="No terrain profile available: sync a past run with elevation data close to this race's distance.",
+            )
+        elevation_profile, _course_activity = match
+
     plan = pacing_mod.generate_pacing_strategy(
         distance_m=race.distance_m,
         target_time_sec=float(effective_target),
         strategy=body.strategy,
+        elevation_profile=elevation_profile,
         split_unit=body.split_unit,
     )
 

--- a/app/pacing.py
+++ b/app/pacing.py
@@ -1,11 +1,14 @@
 """Race-day pacing strategy: generate per-km/mile split targets.
 
-Given a target finish time and race distance, produces even or negative-split
-pacing plans anchored to the CV model where possible.
+Given a target finish time and race distance, produces even, negative-split, or
+terrain (grade-adjusted-effort) pacing plans anchored to the CV model where
+possible.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+
+from app.streams import minetti_factor
 
 _MILE_IN_METERS = 1609.344
 
@@ -18,6 +21,7 @@ class PacingSplit:
     target_pace_min_km: float     # target pace for this split
     split_time_sec: float         # time for this split
     cumulative_time_sec: float    # running total
+    grade_pct: float | None = None  # avg grade over this split (terrain strategy only)
 
 
 @dataclass
@@ -82,6 +86,83 @@ def _build_splits(
     return splits
 
 
+def _split_boundaries(distance_m: float, split_dist_m: float) -> list[tuple[float, float]]:
+    """(start, end) distance pairs for each split, in course order."""
+    n_full = int(distance_m // split_dist_m)
+    remainder_m = distance_m - n_full * split_dist_m
+    boundaries = [(i * split_dist_m, (i + 1) * split_dist_m) for i in range(n_full)]
+    if remainder_m > 0.5:
+        boundaries.append((n_full * split_dist_m, distance_m))
+    return boundaries
+
+
+def _elevation_at(profile: list[tuple[float, float]], profile_span: float, course_dist_m: float, d: float) -> float:
+    """Interpolate elevation at course distance ``d``, mapping onto the profile's own span."""
+    frac = 0.0 if course_dist_m <= 0 else d / course_dist_m
+    target = profile[0][0] + frac * profile_span
+    for i in range(1, len(profile)):
+        d0, e0 = profile[i - 1]
+        d1, e1 = profile[i]
+        if target <= d1 or i == len(profile) - 1:
+            if d1 == d0:
+                return e1
+            t = max(0.0, min(1.0, (target - d0) / (d1 - d0)))
+            return e0 + t * (e1 - e0)
+    raise AssertionError("unreachable: loop always returns on its final iteration")
+
+
+def _profile_grade(profile: list[tuple[float, float]], profile_span: float, course_dist_m: float, d0: float, d1: float) -> float:
+    """Average grade (rise/run) between course distances ``d0`` and ``d1``."""
+    if d1 <= d0 or profile_span <= 0:
+        return 0.0
+    e0 = _elevation_at(profile, profile_span, course_dist_m, d0)
+    e1 = _elevation_at(profile, profile_span, course_dist_m, d1)
+    return (e1 - e0) / (d1 - d0)
+
+
+def _build_terrain_splits(
+    distance_m: float,
+    split_dist_m: float,
+    target_time_sec: float,
+    elevation_profile: list[tuple[float, float]],
+) -> list[PacingSplit]:
+    """Grade-adjusted-effort splits: hold GAP-equivalent pace constant across the
+    course profile so uphill splits run slower and downhill splits run faster,
+    while the sum of split times still equals ``target_time_sec``.
+    """
+    profile = sorted(elevation_profile, key=lambda p: p[0])
+    profile_span = profile[-1][0] - profile[0][0]
+
+    boundaries = _split_boundaries(distance_m, split_dist_m)
+    grades = [_profile_grade(profile, profile_span, distance_m, d0, d1) for d0, d1 in boundaries]
+    factors = [minetti_factor(g) for g in grades]
+    dists = [d1 - d0 for d0, d1 in boundaries]
+
+    # effort_speed (m/s, flat-equivalent) such that Σ(dist·factor/effort_speed) == target_time_sec
+    weighted = sum(d * f for d, f in zip(dists, factors))
+    effort_speed = weighted / target_time_sec
+
+    splits: list[PacingSplit] = []
+    cumulative_time = 0.0
+    cumulative_dist = 0.0
+    for i, ((d0, d1), grade, factor) in enumerate(zip(boundaries, grades, factors)):
+        dist = d1 - d0
+        pace = 1000.0 * factor / (effort_speed * 60.0)
+        t = _split_time(pace, dist)
+        cumulative_time += t
+        cumulative_dist += dist
+        splits.append(PacingSplit(
+            split_number=i + 1,
+            split_distance_m=round(dist, 1),
+            cumulative_distance_m=round(cumulative_dist, 1),
+            target_pace_min_km=round(pace, 3),
+            split_time_sec=round(t, 1),
+            cumulative_time_sec=round(cumulative_time, 1),
+            grade_pct=round(grade * 100.0, 1),
+        ))
+    return splits
+
+
 def generate_pacing_strategy(
     distance_m: float,
     target_time_sec: float,
@@ -89,17 +170,23 @@ def generate_pacing_strategy(
     split_unit: str = "km",
     predicted_time_sec: float | None = None,
     source: str = "goal",
+    elevation_profile: list[tuple[float, float]] | None = None,
 ) -> PacingPlan:
     """Generate a race-day pacing plan.
 
     Args:
         distance_m: Race distance in metres.
         target_time_sec: Target finish time in seconds.
-        strategy: "even" (constant pace) or "negative_split" (first half 2% slower,
-                  second half 2% faster, preserving total time).
+        strategy: "even" (constant pace), "negative_split" (first half 2% slower,
+                  second half 2% faster, preserving total time), or "terrain"
+                  (grade-adjusted-effort splits from ``elevation_profile``).
         split_unit: "km" or "mile".
         predicted_time_sec: CP/CV model prediction for display only.
         source: Origin of target_time_sec — "goal", "predicted", or "custom".
+        elevation_profile: (distance_m, elevation_m) pairs describing a course,
+                            required when ``strategy == "terrain"``. Its distance
+                            axis is scaled to ``distance_m``, so it doesn't need
+                            to span the exact race distance.
     """
     if distance_m <= 0 or target_time_sec <= 0:
         raise ValueError("distance_m and target_time_sec must be positive")
@@ -107,18 +194,19 @@ def generate_pacing_strategy(
     split_dist_m = _MILE_IN_METERS if split_unit == "mile" else 1000.0
     overall_pace = (target_time_sec / distance_m) * 1000.0 / 60.0
 
-    n_total_approx = (distance_m / split_dist_m)
-    half_idx = int(n_total_approx) // 2  # first half/second half boundary index
-
-    if strategy == "negative_split":
+    if strategy == "terrain":
+        if not elevation_profile or len(elevation_profile) < 2:
+            raise ValueError("terrain strategy requires an elevation_profile with at least 2 points")
+        splits = _build_terrain_splits(distance_m, split_dist_m, target_time_sec, elevation_profile)
+    elif strategy == "negative_split":
         # First half: 2% slower; second half: 2% faster → net time unchanged.
         def pace_fn(i: int, n: int) -> float:
             return overall_pace * (1.02 if i < n // 2 else 0.98)
+        splits = _build_splits(distance_m, split_dist_m, pace_fn)
     else:
         def pace_fn(i: int, n: int) -> float:
             return overall_pace
-
-    splits = _build_splits(distance_m, split_dist_m, pace_fn)
+        splits = _build_splits(distance_m, split_dist_m, pace_fn)
 
     return PacingPlan(
         distance_m=distance_m,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -738,6 +738,7 @@ class PacingSplit(BaseModel):
     target_pace_min_km: float     # target pace for this split (min/km)
     split_time_sec: float         # time for this split (s)
     cumulative_time_sec: float    # running total (s)
+    grade_pct: float | None = None  # avg grade over this split (terrain strategy only)
 
 
 class PacingStrategyResponse(BaseModel):
@@ -748,11 +749,13 @@ class PacingStrategyResponse(BaseModel):
     race_date: date
     target_time_sec: float
     target_pace_min_km: float
-    strategy: str               # "even" | "negative_split"
+    strategy: str               # "even" | "negative_split" | "terrain"
     split_unit: str             # "km" | "mile"
     splits: list[PacingSplit]
     predicted_time_sec: float | None = None
     source: str                 # "goal" | "predicted" | "custom"
+    course_activity_id: int | None = None    # activity the terrain profile was sourced from
+    course_activity_name: str | None = None
 
 
 class PacingPushRequest(BaseModel):

--- a/app/streams.py
+++ b/app/streams.py
@@ -154,7 +154,7 @@ def _clamp(v, lo: float, hi: float) -> float | None:
     return float(v)
 
 
-def _minetti_factor(grade: float) -> float:
+def minetti_factor(grade: float) -> float:
     """Flat-equivalent speed multiplier for a running gradient ``grade``.
 
     Ratio of Minetti's energy cost of running at ``grade`` to the flat cost, so
@@ -194,7 +194,7 @@ def grade_adjusted_speed(
         if dd <= 0:
             continue
         grade = (e1 - e0) / dd
-        out[i] = s * _minetti_factor(grade)
+        out[i] = s * minetti_factor(grade)
     return out
 
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -163,23 +163,29 @@ migration needed), `frontend/src/api/types.ts`, `frontend/src/api/hooks.ts`
 `TodayView.tsx`, `tests/test_plan_adaptation.py` (new, 11 tests),
 `tests/test_api_endpoints.py` (9 new tests).
 
-#### P1-2 · Terrain / GAP-aware race pacing (+ optional course import)
+#### P1-2 · Terrain / GAP-aware race pacing ✅ DONE (2026-07-01)
 **What:** Extend `app/pacing.py` beyond flat even/negative splits to allocate pace by
-**gradient** using the GAP model already in `app/streams.py`: given a course
-elevation profile, hold *effort* (GAP-pace / power band) constant so uphill splits are
-slower and downhills faster while hitting the target time. Source the profile from an
-uploaded **GPX** (new lightweight parser) or from a matched prior activity's elevation
-stream. Render the elevation-aware split table and keep the existing push-to-watch
-path.
+**gradient** using the Minetti grade-cost model already in `app/streams.py`: given a
+course elevation profile, hold *effort* (GAP-equivalent pace) constant so uphill
+splits are slower and downhill splits faster while still hitting the target time.
+The profile is sourced from the athlete's own closest-distance past run (its stored
+elevation/distance stream) — no new upload path. Renders an elevation-aware split
+table (grade % per split) and keeps the existing push-to-watch path unchanged.
 **Rationale:** We compute GAP everywhere but pace races as if every course were flat —
 Stryd's Event Planner and Garmin PacePro pace the *actual course*. The natural
-"execute the real race" upgrade to the pacing feature shipped in v3; reuses GAP,
-race prediction, and the workout translator.
-**Effort:** M (L if GPX upload + course matching UI).
-**Files:** `app/pacing.py` (gradient-aware allocation), `app/streams.py` (reuse GAP /
-elevation), optional `app/garmin_sync.py` or new parser for GPX, `app/api.py`
-(`/races/{id}/pacing` params + course upload), `frontend/src/components/plan/` or
-`today/` pacing card + types.
+"execute the real race" upgrade to the pacing feature shipped in v3; reuses the
+Minetti model, race prediction, and the workout translator.
+**Effort:** M. (GPX/course-upload import remains a future L-effort follow-up, not
+implemented here.)
+**Files:** `app/pacing.py` (`"terrain"` strategy, gradient-aware split allocation,
+`grade_pct` on `PacingSplit`), `app/streams.py` (`minetti_factor` made public and
+reused), `app/api.py` (`_matched_course_profile` helper; `strategy=terrain` on
+`GET /races/{id}/pacing` and `POST /races/{id}/pacing/push`), `app/schemas.py`
+(`PacingSplit.grade_pct`, `PacingStrategyResponse.course_activity_id/name`),
+`frontend/src/api/types.ts`, `frontend/src/components/today/RacePacingCard.tsx` +
+`.css` (Terrain strategy button, grade column, course-source note),
+`tests/test_pacing.py` (new terrain-strategy unit tests),
+`tests/test_api_endpoints.py` (new terrain-pacing endpoint tests).
 
 #### P1-3 · Persistent athlete memory for the coach ✅ DONE (2026-07-01)
 **What:** A durable, user-scoped **coach memory** the AI reads on every analysis and

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -612,6 +612,7 @@ export interface PacingSplit {
   target_pace_min_km: number
   split_time_sec: number
   cumulative_time_sec: number
+  grade_pct: number | null
 }
 
 export interface PacingStrategyResponse {
@@ -622,11 +623,13 @@ export interface PacingStrategyResponse {
   race_date: string
   target_time_sec: number
   target_pace_min_km: number
-  strategy: string        // "even" | "negative_split"
+  strategy: string        // "even" | "negative_split" | "terrain"
   split_unit: string      // "km" | "mile"
   splits: PacingSplit[]
   predicted_time_sec: number | null
   source: string          // "goal" | "predicted" | "custom"
+  course_activity_id: number | null
+  course_activity_name: string | null
 }
 
 export interface PacingPushRequest {

--- a/frontend/src/components/today/RacePacingCard.css
+++ b/frontend/src/components/today/RacePacingCard.css
@@ -105,6 +105,14 @@
   font-weight: 500;
 }
 
+/* Terrain course note */
+.race-pacing-course-note {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.6);
+  text-align: center;
+  padding: 0 4px;
+}
+
 /* Split table */
 .race-pacing-table-wrap {
   overflow-x: auto;
@@ -160,6 +168,11 @@
 
 .race-pacing-cumul {
   color: rgba(255, 255, 255, 0.6) !important;
+  font-variant-numeric: tabular-nums;
+}
+
+.race-pacing-grade {
+  color: rgba(255, 255, 255, 0.55) !important;
   font-variant-numeric: tabular-nums;
 }
 

--- a/frontend/src/components/today/RacePacingCard.tsx
+++ b/frontend/src/components/today/RacePacingCard.tsx
@@ -18,17 +18,22 @@ function formatSplitDist(distM: number, splitUnit: string): string {
   return distM >= 950 ? `${(distM / 1000).toFixed(0)} km` : `${Math.round(distM)} m`
 }
 
+function formatGrade(gradePct: number): string {
+  const sign = gradePct > 0 ? '+' : ''
+  return `${sign}${gradePct.toFixed(1)}%`
+}
+
 interface Props {
   race: RaceInfo
 }
 
 export default function RacePacingCard({ race }: Props) {
   const [expanded, setExpanded] = useState(false)
-  const [strategy, setStrategy] = useState<'even' | 'negative_split'>('even')
+  const [strategy, setStrategy] = useState<'even' | 'negative_split' | 'terrain'>('even')
   const [splitUnit] = useState<'km' | 'mile'>('km')
   const [pushed, setPushed] = useState(false)
 
-  const { data: plan, isLoading, isError } = useRacePacing(race.id, {
+  const { data: plan, isLoading, isError, error } = useRacePacing(race.id, {
     strategy,
     splitUnit,
   })
@@ -69,13 +74,21 @@ export default function RacePacingCard({ race }: Props) {
               >
                 Negative Split
               </button>
+              <button
+                className={`race-pacing-strategy-btn${strategy === 'terrain' ? ' active' : ''}`}
+                onClick={() => setStrategy('terrain')}
+              >
+                Terrain
+              </button>
             </div>
           </div>
 
           {isLoading && <div className="race-pacing-loading">Loading splits…</div>}
           {isError && (
             <div className="race-pacing-error">
-              Unable to generate pacing plan. Set a goal time or sync more runs to build a fitness model.
+              {error instanceof Error && error.message
+                ? error.message
+                : 'Unable to generate pacing plan. Set a goal time or sync more runs to build a fitness model.'}
             </div>
           )}
 
@@ -104,12 +117,19 @@ export default function RacePacingCard({ race }: Props) {
                 </span>
               </div>
 
+              {strategy === 'terrain' && plan.course_activity_name && (
+                <div className="race-pacing-course-note">
+                  Course profile from "{plan.course_activity_name}" — effort held constant over the grade.
+                </div>
+              )}
+
               <div className="race-pacing-table-wrap">
                 <table className="race-pacing-table">
                   <thead>
                     <tr>
                       <th>Split</th>
                       <th>Dist</th>
+                      {strategy === 'terrain' && <th>Grade</th>}
                       <th>Pace</th>
                       <th>Time</th>
                       <th>Cumul.</th>
@@ -120,6 +140,11 @@ export default function RacePacingCard({ race }: Props) {
                       <tr key={s.split_number}>
                         <td>{s.split_number}</td>
                         <td>{formatSplitDist(s.split_distance_m, plan.split_unit)}</td>
+                        {strategy === 'terrain' && (
+                          <td className="race-pacing-grade">
+                            {s.grade_pct != null ? formatGrade(s.grade_pct) : '—'}
+                          </td>
+                        )}
                         <td className="race-pacing-pace">{formatPace(s.target_pace_min_km)}</td>
                         <td>{formatDuration(s.split_time_sec)}</td>
                         <td className="race-pacing-cumul">{formatDuration(s.cumulative_time_sec)}</td>

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -785,3 +785,80 @@ def test_api_post_chat_plain_text_has_no_actions(client, db, patch_db_session, m
     resp2 = client.get("/api/v1/chat")
     assistant_entry = [m for m in resp2.json()["messages"] if m["role"] == "assistant"][-1]
     assert assistant_entry["actions"] is None
+
+
+# --- /races/{id}/pacing terrain strategy ---
+
+def _elevation_details(samples: list[tuple[float, float]]) -> str:
+    """Build a minimal Garmin details payload (distance, elevation) as laps_json."""
+    descriptors = [
+        {"metricsIndex": 0, "key": "sumDistance"},
+        {"metricsIndex": 1, "key": "directElevation"},
+    ]
+    rows = [{"metrics": [dist, elev]} for dist, elev in samples]
+    return json.dumps({"metricDescriptors": descriptors, "activityDetailMetrics": rows})
+
+
+def _hilly_10k_samples() -> list[tuple[float, float]]:
+    # Climb for the first half, descend back down for the second half.
+    return [(float(i * 500), (i * 50.0 if i <= 10 else (20 - i) * 50.0)) for i in range(21)]
+
+
+def _add_race(db, **kw):
+    defaults = dict(
+        garmin_id="race-1", event_type="race", date=date(2026, 10, 11),
+        title="Test 10K", distance_m=10000.0, distance_label="10K",
+        goal_time_sec=2400,
+    )
+    defaults.update(kw)
+    race = GarminCalendarEvent(**defaults)
+    db.add(race)
+    db.commit()
+    db.refresh(race)
+    return race
+
+
+def test_race_pacing_terrain_uses_matched_activity(client, db):
+    race = _add_race(db)
+    act = _add_activity(
+        db, datetime(2026, 5, 1, 7, 0),
+        distance_m=10000, name="Hilly 10K",
+        laps_json=_elevation_details(_hilly_10k_samples()),
+    )
+
+    resp = client.get(f"/api/v1/races/{race.id}/pacing?strategy=terrain")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["strategy"] == "terrain"
+    assert body["course_activity_id"] == act.id
+    assert body["course_activity_name"] == "Hilly 10K"
+    # Early (uphill) splits should be slower than late (downhill) splits.
+    assert body["splits"][0]["target_pace_min_km"] > body["splits"][-1]["target_pace_min_km"]
+    assert body["splits"][0]["grade_pct"] is not None
+
+
+def test_race_pacing_terrain_no_matching_activity_422(client, db):
+    race = _add_race(db)
+    resp = client.get(f"/api/v1/races/{race.id}/pacing?strategy=terrain")
+    assert resp.status_code == 422
+    assert "terrain profile" in resp.json()["detail"].lower()
+
+
+def test_race_pacing_terrain_ignores_activity_without_elevation_stream(client, db):
+    race = _add_race(db)
+    _add_activity(db, datetime(2026, 5, 1, 7, 0), distance_m=10000, laps_json=None)
+    resp = client.get(f"/api/v1/races/{race.id}/pacing?strategy=terrain")
+    assert resp.status_code == 422
+
+
+def test_race_pacing_even_strategy_has_no_course_activity(client, db):
+    race = _add_race(db)
+    _add_activity(
+        db, datetime(2026, 5, 1, 7, 0), distance_m=10000,
+        laps_json=_elevation_details(_hilly_10k_samples()),
+    )
+    resp = client.get(f"/api/v1/races/{race.id}/pacing?strategy=even")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["course_activity_id"] is None
+    assert all(s["grade_pct"] is None for s in body["splits"])

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -6,6 +6,8 @@ import pytest
 from app.pacing import (
     PacingPlan,
     PacingSplit,
+    _elevation_at,
+    _profile_grade,
     _split_time,
     generate_pacing_strategy,
 )
@@ -212,6 +214,115 @@ def test_distance_stored_on_plan():
 def test_target_time_stored():
     plan = generate_pacing_strategy(5000, 1500)
     assert plan.target_time_sec == pytest.approx(1500.0)
+
+
+# ---------------------------------------------------------------------------
+# Terrain strategy — grade-adjusted-effort splits
+# ---------------------------------------------------------------------------
+
+def test_terrain_requires_elevation_profile():
+    with pytest.raises(ValueError, match="elevation_profile"):
+        generate_pacing_strategy(10000, 2400, strategy="terrain")
+
+
+def test_terrain_requires_at_least_two_points():
+    with pytest.raises(ValueError, match="elevation_profile"):
+        generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=[(0.0, 10.0)])
+
+
+def test_terrain_flat_profile_matches_even_pace():
+    # A perfectly flat course should produce ~even splits, same as "even" strategy.
+    flat_profile = [(0.0, 100.0), (10000.0, 100.0)]
+    plan = generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=flat_profile)
+    even_plan = generate_pacing_strategy(10000, 2400, strategy="even")
+    for terrain_split, even_split in zip(plan.splits, even_plan.splits):
+        assert terrain_split.target_pace_min_km == pytest.approx(even_split.target_pace_min_km, rel=1e-6)
+
+
+def test_terrain_uphill_split_is_slower_than_downhill_split():
+    # Climb for the first half, descend back down for the second half.
+    hill_profile = [(0.0, 0.0), (5000.0, 300.0), (10000.0, 0.0)]
+    plan = generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=hill_profile)
+    uphill_pace = plan.splits[0].target_pace_min_km
+    downhill_pace = plan.splits[-1].target_pace_min_km
+    assert uphill_pace > downhill_pace
+
+
+def test_terrain_downhill_split_is_faster_than_uphill_split():
+    # Descend for the first half, climb back up for the second half.
+    valley_profile = [(0.0, 300.0), (5000.0, 0.0), (10000.0, 300.0)]
+    plan = generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=valley_profile)
+    downhill_pace = plan.splits[0].target_pace_min_km
+    uphill_pace = plan.splits[-1].target_pace_min_km
+    assert downhill_pace < uphill_pace
+
+
+def test_terrain_hill_then_flat_paces_vary_by_split():
+    # Climb in the first half, flat in the second: early splits should be
+    # slower than late splits.
+    hill_profile = [(0.0, 0.0), (5000.0, 200.0), (10000.0, 200.0)]
+    plan = generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=hill_profile)
+    first_split_pace = plan.splits[0].target_pace_min_km
+    last_split_pace = plan.splits[-1].target_pace_min_km
+    assert first_split_pace > last_split_pace
+
+
+def test_terrain_total_time_preserved():
+    hill_profile = [(0.0, 0.0), (5000.0, 200.0), (10000.0, 100.0)]
+    plan = generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=hill_profile)
+    assert plan.splits[-1].cumulative_time_sec == pytest.approx(2400.0, abs=1.0)
+
+
+def test_terrain_splits_carry_grade_pct():
+    climb_profile = [(0.0, 0.0), (10000.0, 500.0)]
+    plan = generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=climb_profile)
+    for s in plan.splits:
+        assert s.grade_pct == pytest.approx(5.0, abs=0.1)
+
+
+def test_non_terrain_splits_have_no_grade_pct():
+    plan = generate_pacing_strategy(10000, 2400, strategy="even")
+    assert all(s.grade_pct is None for s in plan.splits)
+
+
+def test_terrain_profile_scales_to_mismatched_course_length():
+    # A profile recorded over a different total distance than the race should
+    # still be usable — its distance axis is scaled to the race distance.
+    short_profile = [(0.0, 0.0), (5000.0, 250.0)]  # only spans half the race
+    plan = generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=short_profile)
+    assert len(plan.splits) == 10
+    assert plan.splits[-1].cumulative_time_sec == pytest.approx(2400.0, abs=1.0)
+
+
+def test_terrain_half_marathon_has_remainder_split():
+    # 21097.5 m → 21 full km + 97.5 m remainder split.
+    profile = [(0.0, 0.0), (21097.5, 100.0)]
+    plan = generate_pacing_strategy(21097.5, 6300, strategy="terrain", elevation_profile=profile)
+    assert len(plan.splits) == 22
+    assert plan.splits[-1].split_distance_m == pytest.approx(97.5, abs=1.0)
+    assert plan.splits[-1].cumulative_time_sec == pytest.approx(6300.0, abs=2.0)
+
+
+def test_elevation_at_flat_segment_returns_endpoint():
+    # Duplicate distance points (zero-length segment) should fall back to the
+    # segment's end elevation rather than dividing by zero.
+    profile = [(0.0, 10.0), (0.0, 20.0), (1000.0, 20.0)]
+    assert _elevation_at(profile, 1000.0, 1000.0, 0.0) == pytest.approx(20.0)
+
+
+def test_profile_grade_zero_span_is_flat():
+    profile = [(0.0, 5.0), (0.0, 5.0)]
+    assert _profile_grade(profile, 0.0, 1000.0, 0.0, 1000.0) == 0.0
+
+
+def test_terrain_profile_unsorted_input_is_sorted():
+    # Same hill-then-descent course, but points supplied out of distance order.
+    sorted_profile = [(0.0, 0.0), (5000.0, 300.0), (10000.0, 0.0)]
+    shuffled_profile = [(10000.0, 0.0), (0.0, 0.0), (5000.0, 300.0)]
+    sorted_plan = generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=sorted_profile)
+    shuffled_plan = generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=shuffled_profile)
+    for s1, s2 in zip(sorted_plan.splits, shuffled_plan.splits):
+        assert s1.target_pace_min_km == pytest.approx(s2.target_pace_min_km, rel=1e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -72,9 +72,9 @@ def test_parse_streams_rebases_epoch_timestamp():
 # --- grade adjustment ---
 
 def test_minetti_factor_uphill_increases_downhill_decreases():
-    assert streams._minetti_factor(0.0) == 1.0
-    assert streams._minetti_factor(0.10) > 1.0
-    assert streams._minetti_factor(-0.10) < 1.0
+    assert streams.minetti_factor(0.0) == 1.0
+    assert streams.minetti_factor(0.10) > 1.0
+    assert streams.minetti_factor(-0.10) < 1.0
 
 
 def test_grade_adjusted_speed_uphill_faster_equivalent():


### PR DESCRIPTION
Extend race pacing beyond flat even/negative splits with a "terrain"
strategy that allocates pace by gradient: holds GAP-equivalent effort
constant across a course elevation profile (via the existing Minetti
grade-cost model) so uphill splits run slower and downhill splits run
faster while still hitting the target time. The profile is sourced from
the athlete's own closest-distance past run rather than a new upload.

Makes app.streams.minetti_factor public for reuse, adds grade_pct to
pacing splits, and surfaces the new strategy + course source in the
pacing endpoints and RacePacingCard UI.