### PR TITLE
Add race-aware taper/recovery automation to training plans (P2-2)

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -1289,6 +1289,11 @@ Rules:
 - Anchor pace targets to the athlete's threshold pace if available.
 - Distribute load progressively: build 2 weeks, recover 1 week, then race-specific or peak.
 - Account for any upcoming races as goal events (taper if race is within 3 weeks).
+- When a "Race Periodization Directives" section is present in the athlete context, the
+  per-week volume/intensity caps listed there are mandatory and override the generic
+  progressive-build, adherence, and strength rules above for the specific weeks listed —
+  do not increase volume during a listed RACE WEEK, TAPER, or RECOVERY week even if
+  adherence has been excellent.
 - Respect injury history — avoid high-impact volume if relevant injuries are listed.
 - Strength & cross-training:
   * Include 1–2 `strength` sessions per week during base and build phases; 0–1 during taper
@@ -1508,8 +1513,152 @@ def _build_plan_adherence_context(
     return "\n".join(lines)
 
 
+# Taper/recovery length (in weeks) by race distance category — the closer
+# categories to a marathon need longer taper and recovery windows.
+_TAPER_WEEKS_BY_CATEGORY = {"marathon": 3, "half": 2, "10k": 1, "short": 1}
+_RECOVERY_WEEKS_BY_CATEGORY = {"marathon": 2, "half": 2, "10k": 1, "short": 1}
+
+_RACE_WEEK_GUIDANCE = (
+    "cap weekly volume at ~40-50% of a normal build week; only easy shakeout runs "
+    "plus short race-pace strides; no hard efforts within 4 days of race day"
+)
+_TAPER_GUIDANCE = {
+    1: (
+        "final taper week — target ~65-75% of peak weekly volume, cut the long run "
+        "to ~50-60% of its peak length, one short race-pace tune-up early in the week, "
+        "nothing hard in the final 4 days"
+    ),
+    2: (
+        "target ~80-85% of peak weekly volume, begin trimming the long run, keep one "
+        "quality session but shorten it"
+    ),
+    3: (
+        "target ~85-90% of peak weekly volume, start easing off big long runs while "
+        "keeping intensity"
+    ),
+}
+_RECOVERY_GUIDANCE = {
+    1: (
+        "days 1-3 rest or easy cross-training only; days 4-7 easy running at ~30-40% "
+        "of the pre-race weekly volume; no quality sessions"
+    ),
+    2: (
+        "~55-70% of the pre-race weekly volume, still easy/moderate only, no quality "
+        "sessions until this week is complete"
+    ),
+}
+
+
+def _race_distance_category(distance_m: float | None) -> str:
+    """Classify a race distance into a taper/recovery category.
+
+    marathon >=30km, half >=18km, 10k >=8km, else short (5K or unknown distance).
+    """
+    if not distance_m:
+        return "short"
+    if distance_m >= 30000:
+        return "marathon"
+    if distance_m >= 18000:
+        return "half"
+    if distance_m >= 8000:
+        return "10k"
+    return "short"
+
+
+def _build_race_periodization_context(
+    db: Session, week_start: date, plan_weeks: int, user_id: int = DEFAULT_USER_ID
+) -> str | None:
+    """Deterministic taper/recovery directives for each week of the plan.
+
+    Scans tracked races (GarminCalendarEvent, event_type="race") in a window
+    bracketing the plan and, for every plan week that falls in a race week, its
+    taper, or its recovery block, emits a mandatory volume/intensity directive
+    scaled by race distance. Weeks with no nearby race get no directive, leaving
+    the generic progression rules in the system prompt in charge.
+    """
+    window_start = week_start - timedelta(days=21)
+    window_end = week_start + timedelta(days=7 * plan_weeks + 21)
+    races = (
+        db.query(GarminCalendarEvent)
+        .filter(
+            GarminCalendarEvent.user_id == user_id,
+            GarminCalendarEvent.event_type == "race",
+            GarminCalendarEvent.date >= window_start,
+            GarminCalendarEvent.date <= window_end,
+        )
+        .order_by(GarminCalendarEvent.date.asc())
+        .all()
+    )
+    if not races:
+        return None
+
+    lines: list[str] = []
+    for week_idx in range(plan_weeks):
+        w_start = week_start + timedelta(days=7 * week_idx)
+        w_end = w_start + timedelta(days=6)
+
+        race_week = next((r for r in races if w_start <= r.date <= w_end), None)
+        if race_week:
+            priority = f" (Priority {race_week.priority})" if race_week.priority else ""
+            lines.append(
+                f"- Week {week_idx + 1} ({w_start}–{w_end}): RACE WEEK — "
+                f"{race_week.title or 'race'}{priority} on {race_week.date}. "
+                f"{_RACE_WEEK_GUIDANCE}."
+            )
+            continue
+
+        # Recovery takes priority over taper (safety first) when both could apply.
+        recovery_hit: tuple[GarminCalendarEvent, int] | None = None
+        for r in races:
+            if r.date >= w_start:
+                continue
+            weeks_since = -(-(w_start - r.date).days // 7)  # ceil division
+            category = _race_distance_category(r.distance_m)
+            if 1 <= weeks_since <= _RECOVERY_WEEKS_BY_CATEGORY[category]:
+                if recovery_hit is None or weeks_since < recovery_hit[1]:
+                    recovery_hit = (r, weeks_since)
+        if recovery_hit:
+            r, weeks_since = recovery_hit
+            guidance = _RECOVERY_GUIDANCE.get(weeks_since, _RECOVERY_GUIDANCE[1])
+            lines.append(
+                f"- Week {week_idx + 1} ({w_start}–{w_end}): RECOVERY (week "
+                f"{weeks_since} post-race) — after {r.title or 'race'} on {r.date}. "
+                f"{guidance}."
+            )
+            continue
+
+        taper_hit: tuple[GarminCalendarEvent, int] | None = None
+        for r in races:
+            if r.date <= w_end:
+                continue
+            weeks_before = -(-(r.date - w_end).days // 7)  # ceil division
+            category = _race_distance_category(r.distance_m)
+            if 1 <= weeks_before <= _TAPER_WEEKS_BY_CATEGORY[category]:
+                if taper_hit is None or weeks_before < taper_hit[1]:
+                    taper_hit = (r, weeks_before)
+        if taper_hit:
+            r, weeks_before = taper_hit
+            guidance = _TAPER_GUIDANCE.get(weeks_before, _TAPER_GUIDANCE[1])
+            plural = "s" if weeks_before != 1 else ""
+            lines.append(
+                f"- Week {week_idx + 1} ({w_start}–{w_end}): TAPER ({weeks_before} "
+                f"week{plural} out) — {r.title or 'race'} on {r.date}. {guidance}."
+            )
+
+    if not lines:
+        return None
+    return (
+        "## Race Periodization Directives (mandatory — override default "
+        "progression for these weeks)\n" + "\n".join(lines)
+    )
+
+
 def _build_plan_context(
-    db: Session, reference_date: date, user_id: int = DEFAULT_USER_ID
+    db: Session,
+    reference_date: date,
+    user_id: int = DEFAULT_USER_ID,
+    week_start: date | None = None,
+    plan_weeks: int = 4,
 ) -> str:
     """Build context string for plan generation (profile + load + recent history)."""
     sections: list[str] = [f"Today's date: {reference_date}"]
@@ -1558,20 +1707,20 @@ def _build_plan_context(
     # Weekly volume last 8 weeks
     weeks = []
     for w in range(8):
-        week_start = reference_date - timedelta(days=reference_date.weekday() + 7 * w)
-        week_end = week_start + timedelta(days=7)
+        vol_week_start = reference_date - timedelta(days=reference_date.weekday() + 7 * w)
+        vol_week_end = vol_week_start + timedelta(days=7)
         result = (
             db.query(func.count(Activity.id), func.sum(Activity.distance_m))
             .filter(
                 Activity.user_id == user_id,
-                Activity.started_at >= datetime.combine(week_start, datetime.min.time()),
-                Activity.started_at < datetime.combine(week_end, datetime.min.time()),
+                Activity.started_at >= datetime.combine(vol_week_start, datetime.min.time()),
+                Activity.started_at < datetime.combine(vol_week_end, datetime.min.time()),
             )
             .first()
         )
         count, dist = result
         if count and count > 0:
-            weeks.append(f"- Week of {week_start}: {count} runs, {(dist or 0) / 1000:.1f} km")
+            weeks.append(f"- Week of {vol_week_start}: {count} runs, {(dist or 0) / 1000:.1f} km")
     if weeks:
         sections.append("## Recent Weekly Volume\n" + "\n".join(weeks))
 
@@ -1601,6 +1750,14 @@ def _build_plan_context(
                 f"({days_until} days away){priority}"
             )
         sections.append("## Upcoming Races\n" + "\n".join(race_lines))
+
+    # Deterministic taper/recovery directives for this plan's weeks
+    resolved_week_start = week_start or _next_monday(reference_date)
+    periodization_ctx = _build_race_periodization_context(
+        db, resolved_week_start, plan_weeks, user_id
+    )
+    if periodization_ctx:
+        sections.append(periodization_ctx)
 
     return "\n\n".join(sections)
 
@@ -1700,7 +1857,13 @@ def detect_plan_realignment(
         .order_by(TrainingPlan.generated_at.desc())
         .first()
     )
-    empty = {"should_prompt": False, "missed_count": 0, "total_scheduled": 0, "missed_sessions": []}
+    empty = {
+        "should_prompt": False,
+        "missed_count": 0,
+        "total_scheduled": 0,
+        "missed_sessions": [],
+        "race_note": None,
+    }
     if not plan:
         return empty
 
@@ -1746,11 +1909,38 @@ def detect_plan_realignment(
                 "target_distance_km": plan_day.target_distance_m / 1000 if plan_day.target_distance_m else None,
             })
 
+    # Race-aware realignment: a race that completed after this plan was
+    # generated means the plan predates it and won't reflect a recovery block.
+    race_note = None
+    completed_race = (
+        db.query(GarminCalendarEvent)
+        .filter(
+            GarminCalendarEvent.user_id == user_id,
+            GarminCalendarEvent.event_type == "race",
+            GarminCalendarEvent.date >= plan.generated_at.date(),
+            GarminCalendarEvent.date < reference_date,
+        )
+        .order_by(GarminCalendarEvent.date.desc())
+        .first()
+    )
+    if completed_race:
+        category = _race_distance_category(completed_race.distance_m)
+        recovery_days = _RECOVERY_WEEKS_BY_CATEGORY[category] * 7
+        if (reference_date - completed_race.date).days <= recovery_days:
+            race_note = (
+                f"Your plan predates {completed_race.title or 'your race'} on "
+                f"{completed_race.date} — regenerate to apply a recovery block."
+            )
+
     missed_count = len(missed_sessions)
     return {
-        "should_prompt": missed_count >= _REALIGNMENT_MISSED_THRESHOLD and not dismissed,
+        "should_prompt": (
+            (missed_count >= _REALIGNMENT_MISSED_THRESHOLD or race_note is not None)
+            and not dismissed
+        ),
         "missed_count": missed_count,
         "total_scheduled": len(past_days),
+        "race_note": race_note,
         "missed_sessions": missed_sessions,
     }
 
@@ -1770,7 +1960,7 @@ def generate_training_plan(
         week_start = _next_monday(ref)
 
         try:
-            context = _build_plan_context(db, ref, user_id)
+            context = _build_plan_context(db, ref, user_id, week_start=week_start)
             provider, model = _get_ai_config(db, user_id)
 
             plan_prompt = (

--- a/app/api.py
+++ b/app/api.py
@@ -1302,6 +1302,7 @@ def api_get_realignment_status(
             )
             for s in result["missed_sessions"]
         ],
+        race_note=result["race_note"],
     )
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -645,6 +645,7 @@ class PlanRealignmentStatus(BaseModel):
     missed_count: int
     total_scheduled: int
     missed_sessions: list[MissedPlanSession] = []
+    race_note: str | None = None
 
 
 class PlanRealignmentRequest(BaseModel):

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -225,17 +225,29 @@ not fuel. Builds on profile + weather data already present.
 **Files:** new `app/nutrition.py` (targets model), `app/ai_coach.py` (plan/long-run
 context), `app/api.py`, `frontend/src/components/workout-detail/*` + `plan/*` + types.
 
-#### P2-2 · Post-race recovery & race-aware taper automation
-**What:** Use the `Race` / Garmin race calendar we already track to auto-shape the
-plan around key races: a **taper** ramp into an A-race and a structured **recovery
-block** after it (reduced volume, easy/cross days), folded into plan generation and
-realignment rather than left to the athlete.
+#### P2-2 · Post-race recovery & race-aware taper automation ✅ DONE (2026-07-01)
+**What:** Use the Garmin race calendar we already track (`GarminCalendarEvent`,
+`event_type="race"`, with `priority`/`distance_m`) to auto-shape the plan around key
+races: a **taper** ramp into a race and a structured **recovery block** after it
+(reduced volume, easy/cross days), folded into plan generation and realignment rather
+than left to the athlete.
 **Rationale:** Runna is adding post-race recovery setup; tapering/recovery is core
 periodization we don't automate despite knowing every race date and priority. Sharpens
 the closed-loop plan around the moments that matter most.
 **Effort:** M.
-**Files:** `app/ai_coach.py` (plan prompt/schema + realignment around race dates),
-possibly `app/training_load.py` (recovery-load shaping), `frontend/src/components/plan/*`.
+**Files:** `app/ai_coach.py` (`_build_race_periodization_context` computes
+deterministic, distance-scaled RACE WEEK / TAPER (1-3 wks out) / RECOVERY (1-2 wks
+post-race) directives, injected into `_build_plan_context` as a mandatory
+"Race Periodization Directives" section that `generate_training_plan` picks up on
+every regeneration — both the weekly cron and the realignment "Regenerate" path;
+`detect_plan_realignment` also flags `should_prompt`/`race_note` when a tracked race
+completed after the active plan was generated and is still within its recovery
+window, even with zero missed sessions), `app/schemas.py`
+(`PlanRealignmentStatus.race_note`), `app/api.py` (realignment-status endpoint),
+`frontend/src/api/types.ts`, `frontend/src/components/plan/PlanView.tsx`,
+`frontend/src/components/today/TodayView.tsx` (both realignment banners surface
+`race_note`), `tests/test_ai_coach.py` (10 new tests), `tests/test_api_endpoints.py`
+(2 new tests).
 
 #### P2-3 · Explicit Running Stress Balance guidance ✅ DONE (2026-07-01)
 **What:** Promote the TSB/ACWR we already compute into an explicit

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -494,6 +494,7 @@ export interface PlanRealignmentStatus {
   missed_count: number
   total_scheduled: number
   missed_sessions: MissedPlanSession[]
+  race_note: string | null
 }
 
 export interface PerformanceCurvePoint {

--- a/frontend/src/components/plan/PlanView.tsx
+++ b/frontend/src/components/plan/PlanView.tsx
@@ -171,8 +171,12 @@ function RealignmentBanner({ onJobEnqueued }: { onJobEnqueued: (jobId: number) =
       <AlertTriangle size={16} className="realignment-icon" />
       <div className="realignment-body">
         <span className="realignment-msg">
-          {status.missed_count} planned session{status.missed_count !== 1 ? 's' : ''} missed.
-          Regenerate to adapt your plan?
+          {status.race_note ?? (
+            <>
+              {status.missed_count} planned session{status.missed_count !== 1 ? 's' : ''} missed.
+              Regenerate to adapt your plan?
+            </>
+          )}
         </span>
         <div className="realignment-actions">
           <button

--- a/frontend/src/components/today/TodayView.tsx
+++ b/frontend/src/components/today/TodayView.tsx
@@ -33,8 +33,12 @@ function TodayRealignmentBanner() {
         <AlertTriangle size={16} className="today-realignment-icon" />
         <div className="today-realignment-body">
           <span className="today-realignment-msg">
-            {status.missed_count} planned session{status.missed_count !== 1 ? 's' : ''} missed.
-            Regenerate to adapt your plan?
+            {status.race_note ?? (
+              <>
+                {status.missed_count} planned session{status.missed_count !== 1 ? 's' : ''} missed.
+                Regenerate to adapt your plan?
+              </>
+            )}
           </span>
           <div className="today-realignment-actions">
             <button

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -626,6 +626,105 @@ def test_build_plan_context_no_adherence_when_no_plan(db):
     assert "## Current Plan Adherence" not in context
 
 
+# --- _race_distance_category / _build_race_periodization_context (P2-2) ---
+
+def test_race_distance_category_thresholds():
+    assert ai_coach._race_distance_category(42195) == "marathon"
+    assert ai_coach._race_distance_category(21097) == "half"
+    assert ai_coach._race_distance_category(10000) == "10k"
+    assert ai_coach._race_distance_category(5000) == "short"
+    assert ai_coach._race_distance_category(None) == "short"
+
+
+def test_periodization_no_races_returns_none(db):
+    result = ai_coach._build_race_periodization_context(db, date(2026, 6, 15), 4)
+    assert result is None
+
+
+def test_periodization_race_week_directive(db):
+    db.add(GarminCalendarEvent(
+        garmin_id="r1", event_type="race", date=date(2026, 6, 20),
+        title="City 10K", distance_label="10K", distance_m=10000, priority="B",
+    ))
+    db.commit()
+
+    result = ai_coach._build_race_periodization_context(db, date(2026, 6, 15), 4)
+
+    assert result is not None
+    assert "RACE WEEK" in result
+    assert "City 10K" in result
+    assert "(Priority B)" in result
+    assert "Week 1" in result
+
+
+def test_periodization_marathon_taper_three_weeks(db):
+    # Marathon on a Saturday 3 plan-weeks into the window (week 4 of the plan).
+    db.add(GarminCalendarEvent(
+        garmin_id="r2", event_type="race", date=date(2026, 7, 4),
+        title="City Marathon", distance_label="Marathon", distance_m=42195, priority="A",
+    ))
+    db.commit()
+
+    result = ai_coach._build_race_periodization_context(db, date(2026, 6, 8), 4)
+
+    assert result is not None
+    assert "Week 1" in result and "TAPER (3 weeks out)" in result
+    assert "Week 2" in result and "TAPER (2 weeks out)" in result
+    assert "Week 3" in result and "TAPER (1 week out)" in result
+    assert "Week 4" in result and "RACE WEEK" in result
+
+
+def test_periodization_short_race_taper_one_week_only(db):
+    # 5K race two weeks into the plan window — short races only taper 1 week out.
+    db.add(GarminCalendarEvent(
+        garmin_id="r3", event_type="race", date=date(2026, 6, 27),
+        title="Parkrun 5K", distance_label="5K", distance_m=5000, priority="C",
+    ))
+    db.commit()
+
+    result = ai_coach._build_race_periodization_context(db, date(2026, 6, 8), 4)
+
+    assert result is not None
+    # Week 1 is too far out for a short race's 1-week taper window, so it gets
+    # no directive at all.
+    assert "- Week 1 (" not in result
+    assert "- Week 2 (" in result and "TAPER (1 week out)" in result
+    assert "- Week 3 (" in result and "RACE WEEK" in result
+
+
+def test_periodization_marathon_recovery_two_weeks(db):
+    # Marathon 3 days before the plan window starts.
+    db.add(GarminCalendarEvent(
+        garmin_id="r4", event_type="race", date=date(2026, 6, 5),
+        title="Spring Marathon", distance_label="Marathon", distance_m=42195,
+    ))
+    db.commit()
+
+    result = ai_coach._build_race_periodization_context(db, date(2026, 6, 8), 4)
+
+    assert result is not None
+    assert "- Week 1 (" in result and "RECOVERY (week 1 post-race)" in result
+    assert "- Week 2 (" in result and "RECOVERY (week 2 post-race)" in result
+    # Marathon recovery caps out at 2 weeks — weeks 3 and 4 get no directive.
+    assert "- Week 3 (" not in result
+    assert "- Week 4 (" not in result
+
+
+def test_build_plan_context_includes_periodization_directives(db):
+    db.add(GarminCalendarEvent(
+        garmin_id="r5", event_type="race", date=date(2026, 6, 20),
+        title="City 10K", distance_label="10K", distance_m=10000,
+    ))
+    db.commit()
+
+    context = ai_coach._build_plan_context(
+        db, date(2026, 6, 15), week_start=date(2026, 6, 15), plan_weeks=4
+    )
+
+    assert "## Race Periodization Directives" in context
+    assert "RACE WEEK" in context
+
+
 # --- detect_plan_realignment ---
 
 def _seed_plan_with_days(db, plan_start, days_config):
@@ -741,6 +840,76 @@ def test_detect_realignment_expired_dismiss_prompts(db):
     db.commit()
     result = ai_coach.detect_plan_realignment(db, ref)
     assert result["should_prompt"] is True
+
+
+# --- detect_plan_realignment: race-aware (P2-2) ---
+
+def test_detect_realignment_post_race_prompts_without_missed_sessions(db):
+    ref = date(2026, 6, 21)
+    _seed_plan_with_days(db, date(2026, 6, 16), [
+        {"date": date(2026, 6, 17), "workout_type": "easy", "dist_m": 8000},
+    ])
+    db.add(Activity(
+        garmin_id=601, name="Easy Run", activity_type="running",
+        started_at=datetime(2026, 6, 17, 8, 0), distance_m=8000,
+    ))
+    # Race completed after the plan was generated (generated_at=2026-06-01).
+    db.add(GarminCalendarEvent(
+        garmin_id="race1", event_type="race", date=date(2026, 6, 18),
+        title="City 10K", distance_label="10K", distance_m=10000,
+    ))
+    db.commit()
+
+    result = ai_coach.detect_plan_realignment(db, ref)
+
+    assert result["missed_count"] == 0
+    assert result["should_prompt"] is True
+    assert result["race_note"] is not None
+    assert "City 10K" in result["race_note"]
+
+
+def test_detect_realignment_no_race_note_when_race_predates_plan(db):
+    ref = date(2026, 6, 21)
+    _seed_plan_with_days(db, date(2026, 6, 16), [
+        {"date": date(2026, 6, 17), "workout_type": "easy", "dist_m": 8000},
+    ])
+    db.add(Activity(
+        garmin_id=602, name="Easy Run", activity_type="running",
+        started_at=datetime(2026, 6, 17, 8, 0), distance_m=8000,
+    ))
+    # Race happened before the plan was even generated — already accounted for.
+    db.add(GarminCalendarEvent(
+        garmin_id="race2", event_type="race", date=date(2026, 5, 20),
+        title="Old Race", distance_label="10K", distance_m=10000,
+    ))
+    db.commit()
+
+    result = ai_coach.detect_plan_realignment(db, ref)
+
+    assert result["should_prompt"] is False
+    assert result["race_note"] is None
+
+
+def test_detect_realignment_no_race_note_outside_recovery_window(db):
+    ref = date(2026, 6, 21)
+    _seed_plan_with_days(db, date(2026, 6, 16), [
+        {"date": date(2026, 6, 17), "workout_type": "easy", "dist_m": 8000},
+    ])
+    db.add(Activity(
+        garmin_id=603, name="Easy Run", activity_type="running",
+        started_at=datetime(2026, 6, 17, 8, 0), distance_m=8000,
+    ))
+    # A 5K's recovery window is 1 week; 12 days out is past it.
+    db.add(GarminCalendarEvent(
+        garmin_id="race3", event_type="race", date=date(2026, 6, 9),
+        title="Parkrun", distance_label="5K", distance_m=5000,
+    ))
+    db.commit()
+
+    result = ai_coach.detect_plan_realignment(db, ref)
+
+    assert result["should_prompt"] is False
+    assert result["race_note"] is None
 
 
 # --- generate_training_plan – P1-3 structured output ---

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -382,6 +382,38 @@ def test_realignment_status_dismissed(client, db):
     assert body["missed_count"] == 2  # detected but suppressed
 
 
+def test_realignment_status_race_note_prompts(client, db):
+    """A race completed since the plan was generated flags should_prompt/race_note."""
+    _seed_plan_and_days(db, [
+        {"date": date(2026, 6, 17), "workout_type": "easy", "dist_m": 8000},
+    ])
+    _add_activity(db, datetime(2026, 6, 17, 8, 0), distance_m=8000)
+    db.add(GarminCalendarEvent(
+        garmin_id="race_ep", event_type="race", date=date.today() - timedelta(days=3),
+        title="Sunday 10K", distance_label="10K", distance_m=10000,
+    ))
+    db.commit()
+    resp = client.get("/api/v1/training-plan/realignment-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["should_prompt"] is True
+    assert body["race_note"] is not None
+    assert "Sunday 10K" in body["race_note"]
+
+
+def test_realignment_status_race_note_absent_by_default(client, db):
+    _seed_plan_and_days(db, [
+        {"date": date(2026, 6, 17), "workout_type": "easy", "dist_m": 8000},
+    ])
+    _add_activity(db, datetime(2026, 6, 17, 8, 0), distance_m=8000)
+    db.commit()
+    resp = client.get("/api/v1/training-plan/realignment-status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["should_prompt"] is False
+    assert body["race_note"] is None
+
+
 # --- /training-plan/realign ---
 
 def test_realign_dismiss(client, db):


### PR DESCRIPTION
Injects deterministic, distance-scaled RACE WEEK / TAPER / RECOVERY
directives into plan generation based on tracked races (GarminCalendarEvent),
overriding the generic progression rules for the weeks around a race. The
plan realignment banner now also fires when a tracked race completes after
the active plan was generated, prompting a regenerate to apply the recovery
block even with no missed sessions.