### PR TITLE
Add fuelling/hydration guidance for long runs and races (P2-1)

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -440,16 +440,14 @@ def _format_coach_memory_context(db: Session, user_id: int) -> str:
     return "## What The Coach Remembers\n" + "\n".join(lines)
 
 
-def _recent_heat_stress_note(
+def _recent_hot_runs(
     db: Session,
     reference_date: date,
     user_id: int = DEFAULT_USER_ID,
-) -> str:
-    """Return a one-line heat-stress note for the readiness section.
+) -> list[str]:
+    """Return descriptions of recent runs with a notable heat penalty (>= 5 s/km).
 
-    Checks the last 3 running activities with weather data. If any had a
-    notable heat penalty (≥ 5 s/km), surface a coaching note so the AI
-    factors environmental load into its recovery assessment.
+    Checks the last 3 running activities with weather data in the past 7 days.
     """
     cutoff = reference_date - timedelta(days=7)
     recent = (
@@ -473,11 +471,38 @@ def _recent_heat_stress_note(
                 hot_runs.append(f"{date_str} (~{int(penalty_sec)} s/km heat penalty)")
         except Exception:
             continue
+    return hot_runs
 
+
+def _recent_heat_stress_note(
+    db: Session,
+    reference_date: date,
+    user_id: int = DEFAULT_USER_ID,
+) -> str:
+    """Return a one-line heat-stress note for the readiness section.
+
+    If any of the last 3 weathered runs had a notable heat penalty, surface a
+    coaching note so the AI factors environmental load into its recovery
+    assessment.
+    """
+    hot_runs = _recent_hot_runs(db, reference_date, user_id)
     if not hot_runs:
         return ""
     runs_str = ", ".join(hot_runs)
     return f"- Recent heat stress: {runs_str} — environmental load may be elevating fatigue"
+
+
+def recent_heat_stress(
+    db: Session,
+    reference_date: date,
+    user_id: int = DEFAULT_USER_ID,
+) -> bool:
+    """Whether any of the last 3 weathered runs (past 7 days) had a notable heat penalty.
+
+    Used to scale fluid targets in fuelling guidance (app/nutrition.py) for
+    upcoming long runs/races, where no direct weather reading exists yet.
+    """
+    return bool(_recent_hot_runs(db, reference_date, user_id))
 
 
 def _build_context(

--- a/app/api.py
+++ b/app/api.py
@@ -47,6 +47,7 @@ from app.schemas import (
     DailySummaryDetail,
     DailySummaryResponse,
     FeedbackRequest,
+    FuellingGuidance,
     GarminConnectResult,
     GarminConnectionStatus,
     GarminCredentialsRequest,
@@ -97,6 +98,7 @@ from app import adherence as adherence_mod
 from app import intensity as intensity_mod
 from app import streams as streams_mod
 from app import weather as weather_mod
+from app import nutrition as nutrition_mod
 from app.config import settings as app_settings
 from app.utils import safe_json_loads, parse_activity_charts, parse_activity_route, calculate_age
 
@@ -699,7 +701,33 @@ def api_calendar_event_detail(
     )
     if not event:
         raise HTTPException(status_code=404, detail="Calendar event not found")
-    return _enrich_event_with_steps(event)
+    resp = _enrich_event_with_steps(event)
+
+    if event.event_type == "race":
+        duration_sec = (
+            event.goal_time_sec
+            or event.projected_race_time_sec
+            or event.predicted_race_time_sec
+        )
+        if duration_sec:
+            from app.ai_coach import recent_heat_stress
+
+            profile = (
+                db.query(AthleteProfile)
+                .filter(AthleteProfile.user_id == current_user.id)
+                .first()
+            )
+            heat_stress = recent_heat_stress(db, date.today(), current_user.id)
+            guidance = nutrition_mod.compute_fuelling_guidance(
+                duration_sec=float(duration_sec),
+                intensity="race",
+                weight_kg=profile.weight_kg if profile else None,
+                heat_stress=heat_stress,
+            )
+            if guidance:
+                resp.fuelling_guidance = FuellingGuidance(**guidance.__dict__)
+
+    return resp
 
 
 # --- Insights ---
@@ -1134,18 +1162,38 @@ def api_get_aerobic_trends(
 
 # --- Training Plan ---
 
-def _day_to_response(d: TrainingPlanDay) -> TrainingPlanDayResponse:
+def _day_to_response(
+    d: TrainingPlanDay,
+    weight_kg: float | None = None,
+    heat_stress: bool = False,
+) -> TrainingPlanDayResponse:
     """Convert a TrainingPlanDay ORM row to its response schema, hydrating routine."""
     resp = TrainingPlanDayResponse.model_validate(d)
     if d.routine_id:
         raw = get_routine(d.routine_id)
         if raw:
             resp.routine = StrengthRoutine.model_validate(raw)
+    if d.workout_type == "long" and d.target_distance_m and d.target_pace_min_km:
+        duration_sec = (d.target_distance_m / 1000.0) * d.target_pace_min_km * 60.0
+        guidance = nutrition_mod.compute_fuelling_guidance(
+            duration_sec=duration_sec,
+            intensity="long",
+            weight_kg=weight_kg,
+            heat_stress=heat_stress,
+        )
+        if guidance:
+            resp.fuelling_guidance = FuellingGuidance(**guidance.__dict__)
     return resp
 
 
 def _build_plan_response(plan: TrainingPlan, db: Session) -> TrainingPlanResponse:
     """Assemble a TrainingPlanResponse with nested week/day structure."""
+    from app.ai_coach import recent_heat_stress
+
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == plan.user_id).first()
+    weight_kg = profile.weight_kg if profile else None
+    heat_stress = recent_heat_stress(db, date.today(), plan.user_id)
+
     days = (
         db.query(TrainingPlanDay)
         .filter(TrainingPlanDay.plan_id == plan.id, TrainingPlanDay.user_id == plan.user_id)
@@ -1170,7 +1218,7 @@ def _build_plan_response(plan: TrainingPlan, db: Session) -> TrainingPlanRespons
             week_start=week_start_date,
             week_end=week_end_date,
             theme=theme,
-            days=[_day_to_response(d) for d in sorted_days],
+            days=[_day_to_response(d, weight_kg, heat_stress) for d in sorted_days],
         ))
 
     return TrainingPlanResponse(
@@ -1279,7 +1327,10 @@ def api_adapt_plan_day(
         plan_day.target_pace_display = None
     db.commit()
     db.refresh(plan_day)
-    return _day_to_response(plan_day)
+    profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == uid).first()
+    from app.ai_coach import recent_heat_stress
+    heat_stress = recent_heat_stress(db, date.today(), uid)
+    return _day_to_response(plan_day, profile.weight_kg if profile else None, heat_stress)
 
 
 @api_router.get("/training-plan/realignment-status", response_model=PlanRealignmentStatus)

--- a/app/nutrition.py
+++ b/app/nutrition.py
@@ -1,0 +1,100 @@
+"""Fuelling/hydration target helpers for long runs and races.
+
+Derives carb-per-hour and fluid-per-hour targets from effort duration,
+intensity, athlete body weight, and recent heat exposure (reusing the
+heat-stress signal from ``app/weather.py`` via ``app.ai_coach``).
+
+Model (sports-nutrition consensus for endurance running):
+  - No fuelling guidance under 60 min — glycogen stores cover shorter efforts.
+  - Carbs: 30 g/hr (60-90 min) -> 60 g/hr (90-150 min) -> 90 g/hr (150 min+),
+    +15 g/hr at race intensity (higher glycogen turnover than an easy long run).
+  - Fluid: ~6.5 mL per kg body weight per hour at neutral conditions
+    (70 kg assumed when weight is unknown), +15% when recent runs show
+    notable heat stress.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_DEFAULT_WEIGHT_KG = 70.0
+_FLUID_ML_PER_KG_PER_HOUR = 6.5
+_HEAT_FLUID_BUMP = 1.15
+_RACE_CARB_BUMP_G = 15
+
+
+@dataclass
+class FuellingGuidance:
+    duration_sec: float
+    carbs_g_per_hour: int
+    fluid_ml_per_hour: int
+    total_carbs_g: int
+    total_fluid_ml: int
+    note: str
+
+
+def _carbs_g_per_hour(duration_sec: float, intensity: str) -> int:
+    hours = duration_sec / 3600.0
+    if hours < 1.5:
+        base = 30
+    elif hours < 2.5:
+        base = 60
+    else:
+        base = 90
+    if intensity == "race":
+        base += _RACE_CARB_BUMP_G
+    return base
+
+
+def _fluid_ml_per_hour(weight_kg: float | None, heat_stress: bool) -> int:
+    weight = weight_kg if weight_kg and weight_kg > 0 else _DEFAULT_WEIGHT_KG
+    fluid = _FLUID_ML_PER_KG_PER_HOUR * weight
+    if heat_stress:
+        fluid *= _HEAT_FLUID_BUMP
+    return round(fluid / 25) * 25
+
+
+def _format_duration(duration_sec: float) -> str:
+    total_min = round(duration_sec / 60)
+    hours, minutes = divmod(total_min, 60)
+    if hours and minutes:
+        return f"{hours}h{minutes:02d}m"
+    if hours:
+        return f"{hours}h"
+    return f"{minutes}m"
+
+
+def compute_fuelling_guidance(
+    duration_sec: float,
+    intensity: str = "long",
+    weight_kg: float | None = None,
+    heat_stress: bool = False,
+) -> FuellingGuidance | None:
+    """Return carb/fluid targets for an effort, or None if too short to need them.
+
+    intensity: "long" (easy aerobic effort) or "race" (higher glycogen turnover).
+    """
+    if duration_sec is None or duration_sec < 3600:
+        return None
+
+    hours = duration_sec / 3600.0
+    carbs_per_hour = _carbs_g_per_hour(duration_sec, intensity)
+    fluid_per_hour = _fluid_ml_per_hour(weight_kg, heat_stress)
+    total_carbs = round(carbs_per_hour * hours)
+    total_fluid = round(fluid_per_hour * hours / 25) * 25
+
+    note = (
+        f"~{carbs_per_hour} g carbs/hr and ~{fluid_per_hour} ml fluid/hr "
+        f"over this {_format_duration(duration_sec)} effort"
+    )
+    if heat_stress:
+        note += " — recent heat means extra fluid"
+
+    return FuellingGuidance(
+        duration_sec=duration_sec,
+        carbs_g_per_hour=carbs_per_hour,
+        fluid_ml_per_hour=fluid_per_hour,
+        total_carbs_g=total_carbs,
+        total_fluid_ml=total_fluid,
+        note=note,
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -245,6 +245,15 @@ class WorkoutStepResponse(BaseModel):
     steps: list["WorkoutStepResponse"] | None = None
 
 
+class FuellingGuidance(BaseModel):
+    duration_sec: float
+    carbs_g_per_hour: int
+    fluid_ml_per_hour: int
+    total_carbs_g: int
+    total_fluid_ml: int
+    note: str
+
+
 class CalendarEventResponse(BaseModel):
     id: int
     event_type: str | None = None
@@ -257,6 +266,7 @@ class CalendarEventResponse(BaseModel):
     workout_type: str | None = None
     workout_description: str | None = None
     workout_steps: list[WorkoutStepResponse] | None = None
+    fuelling_guidance: FuellingGuidance | None = None
 
     class Config:
         from_attributes = True
@@ -608,6 +618,7 @@ class TrainingPlanDayResponse(BaseModel):
     notes: str | None = None
     week_theme: str | None = None
     routine: StrengthRoutine | None = None
+    fuelling_guidance: FuellingGuidance | None = None
 
     class Config:
         from_attributes = True

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -213,7 +213,7 @@ tests).
 
 ### P2 — Breadth & coaching completeness
 
-#### P2-1 · Fuelling & hydration guidance
+#### P2-1 · Fuelling & hydration guidance ✅ DONE (2026-07-01)
 **What:** Generate simple, personalized **fuelling/hydration** guidance for long runs
 and races — carb-per-hour and fluid targets scaled by duration, intensity, body weight
 (in `AthleteProfile`), and recent **heat** (reuses P0-1) — rendered on the long-run /
@@ -222,8 +222,20 @@ race workout detail, and optionally as in-plan reminders.
 reminders) and a recurring holistic-coaching differentiator; we cover strength now but
 not fuel. Builds on profile + weather data already present.
 **Effort:** M.
-**Files:** new `app/nutrition.py` (targets model), `app/ai_coach.py` (plan/long-run
-context), `app/api.py`, `frontend/src/components/workout-detail/*` + `plan/*` + types.
+**Files:** `app/nutrition.py` (new, `compute_fuelling_guidance` — duration-gated at 60
+min, carb tiers by duration/intensity, fluid scaled by body weight + heat stress),
+`app/ai_coach.py` (`_recent_hot_runs` extracted from `_recent_heat_stress_note`; new
+public `recent_heat_stress` reused for fuelling's heat signal on future/undated
+efforts), `app/schemas.py` (`FuellingGuidance`, added to `TrainingPlanDayResponse` and
+`CalendarEventResponse`), `app/api.py` (`_day_to_response` attaches guidance to `long`
+plan days with a known duration; `GET /calendar-events/{id}` attaches guidance to
+`race` events using `goal_time_sec`/projected/predicted finish time — both reuse a
+single profile + heat-stress lookup per response, no per-day queries),
+`frontend/src/api/types.ts`, `frontend/src/components/plan/PlanView.tsx` + `.css`
+(collapsible fuelling panel on long-run day cards, alongside the existing routine
+panel), `frontend/src/components/workout-detail/WorkoutDetailView.tsx` + `.css`
+(fuelling card on race detail), `tests/test_nutrition.py` (new, 14 tests),
+`tests/test_ai_coach.py` (5 new tests), `tests/test_api_endpoints.py` (6 new tests).
 
 #### P2-2 · Post-race recovery & race-aware taper automation ✅ DONE (2026-07-01)
 **What:** Use the Garmin race calendar we already track (`GarminCalendarEvent`,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -204,6 +204,15 @@ export interface WorkoutStep {
   steps: WorkoutStep[] | null
 }
 
+export interface FuellingGuidance {
+  duration_sec: number
+  carbs_g_per_hour: number
+  fluid_ml_per_hour: number
+  total_carbs_g: number
+  total_fluid_ml: number
+  note: string
+}
+
 export interface CalendarEvent {
   id: number
   event_type: string | null
@@ -216,6 +225,7 @@ export interface CalendarEvent {
   workout_type: string | null
   workout_description: string | null
   workout_steps: WorkoutStep[] | null
+  fuelling_guidance: FuellingGuidance | null
 }
 
 export interface CalendarDay {
@@ -463,6 +473,7 @@ export interface TrainingPlanDay {
   notes: string | null
   week_theme: string | null
   routine: StrengthRoutine | null
+  fuelling_guidance: FuellingGuidance | null
 }
 
 export interface TrainingPlanWeek {

--- a/frontend/src/components/plan/PlanView.css
+++ b/frontend/src/components/plan/PlanView.css
@@ -521,3 +521,52 @@
   color: var(--text-muted);
   font-style: italic;
 }
+
+.plan-fuelling {
+  grid-column: 2;
+  margin-top: 4px;
+}
+
+.plan-fuelling-toggle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-long, #0984e3);
+  background: none;
+  border: 1px solid color-mix(in srgb, var(--color-long, #0984e3) 35%, transparent);
+  border-radius: var(--radius-sm);
+  padding: 4px 9px;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  transition: background 0.15s;
+}
+
+.plan-fuelling-toggle:hover {
+  background: color-mix(in srgb, var(--color-long, #0984e3) 10%, transparent);
+}
+
+.plan-fuelling-body {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  margin-top: 6px;
+  background: var(--bg-surface, var(--bg-card));
+}
+
+.plan-fuelling-note {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin: 0 0 8px;
+  line-height: 1.4;
+}
+
+.plan-fuelling-stats {
+  display: flex;
+  gap: 12px;
+  font-size: 0.78rem;
+  color: var(--text);
+  font-weight: 500;
+}

--- a/frontend/src/components/plan/PlanView.tsx
+++ b/frontend/src/components/plan/PlanView.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
-import { ClipboardList, RefreshCw, ChevronLeft, ChevronRight, AlertTriangle, Settings2, Watch, CheckCircle, ChevronDown, ChevronUp, Dumbbell } from 'lucide-react'
+import { ClipboardList, RefreshCw, ChevronLeft, ChevronRight, AlertTriangle, Settings2, Watch, CheckCircle, ChevronDown, ChevronUp, Dumbbell, Droplet } from 'lucide-react'
 import { useTrainingPlan, useGenerateTrainingPlan, useRealignmentStatus, useRealignPlan, usePushWorkoutToGarmin, useJobStatus } from '../../api/hooks'
-import type { StrengthRoutine, TrainingPlanDay, TrainingPlanWeek } from '../../api/types'
+import type { StrengthRoutine, FuellingGuidance, TrainingPlanDay, TrainingPlanWeek } from '../../api/types'
 import './PlanView.css'
 
 const WORKOUT_COLORS: Record<string, string> = {
@@ -108,6 +108,28 @@ function RoutinePanel({ routine }: { routine: StrengthRoutine }) {
   )
 }
 
+function FuellingPanel({ guidance }: { guidance: FuellingGuidance }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="plan-fuelling">
+      <button className="plan-fuelling-toggle" onClick={() => setOpen(o => !o)}>
+        <Droplet size={13} />
+        <span>Fuelling</span>
+        {open ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+      </button>
+      {open && (
+        <div className="plan-fuelling-body">
+          <p className="plan-fuelling-note">{guidance.note}</p>
+          <div className="plan-fuelling-stats">
+            <span>{guidance.total_carbs_g} g carbs total</span>
+            <span>{guidance.total_fluid_ml} ml fluid total</span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
 function DayCard({ day }: { day: TrainingPlanDay }) {
   const isToday = day.day_date === today()
   const isPast = day.day_date < today()
@@ -140,6 +162,7 @@ function DayCard({ day }: { day: TrainingPlanDay }) {
         <p className="plan-day-desc">{day.description}</p>
       )}
       {day.routine && <RoutinePanel routine={day.routine} />}
+      {day.fuelling_guidance && <FuellingPanel guidance={day.fuelling_guidance} />}
       {day.notes && (
         <p className="plan-day-notes">{day.notes}</p>
       )}

--- a/frontend/src/components/workout-detail/WorkoutDetailView.css
+++ b/frontend/src/components/workout-detail/WorkoutDetailView.css
@@ -33,3 +33,15 @@
   overflow: hidden;
   padding: 0;
 }
+
+.workout-detail-fuelling-note {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 0 12px;
+}
+
+.workout-detail-fuelling-stats {
+  display: flex;
+  gap: 24px;
+}

--- a/frontend/src/components/workout-detail/WorkoutDetailView.tsx
+++ b/frontend/src/components/workout-detail/WorkoutDetailView.tsx
@@ -69,6 +69,25 @@ export default function WorkoutDetailView() {
             </div>
           </section>
         ) : null}
+
+        {event.fuelling_guidance && (
+          <section className="detail-section">
+            <h3 className="section-title">Fuelling & Hydration</h3>
+            <div className="card workout-detail-fuelling">
+              <p className="workout-detail-fuelling-note">{event.fuelling_guidance.note}</p>
+              <div className="workout-detail-fuelling-stats">
+                <div>
+                  <div className="workout-detail-stat-value">{event.fuelling_guidance.total_carbs_g}g</div>
+                  <div className="workout-detail-stat-label">Total carbs</div>
+                </div>
+                <div>
+                  <div className="workout-detail-stat-value">{event.fuelling_guidance.total_fluid_ml}ml</div>
+                  <div className="workout-detail-stat-label">Total fluid</div>
+                </div>
+              </div>
+            </div>
+          </section>
+        )}
       </div>
     </div>
   )

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -196,6 +196,63 @@ def test_format_coach_memory_context_scoped_to_user(db):
     assert ai_coach._format_coach_memory_context(db, 1) == ""
 
 
+# --- recent_heat_stress ---
+
+def test_recent_heat_stress_true_for_hot_run(db):
+    db.add(Activity(
+        garmin_id=901, activity_type="running",
+        started_at=datetime(2026, 6, 15, 7, 0),
+        avg_pace_min_km=5.0,
+        weather_json=json.dumps({"temp": 73.4, "dewPoint": 64.4}),
+    ))
+    db.commit()
+    assert ai_coach.recent_heat_stress(db, date(2026, 6, 17)) is True
+
+
+def test_recent_heat_stress_false_when_no_weather(db):
+    db.add(Activity(
+        garmin_id=902, activity_type="running",
+        started_at=datetime(2026, 6, 15, 7, 0),
+        avg_pace_min_km=5.0,
+    ))
+    db.commit()
+    assert ai_coach.recent_heat_stress(db, date(2026, 6, 17)) is False
+
+
+def test_recent_heat_stress_false_outside_window(db):
+    db.add(Activity(
+        garmin_id=905, activity_type="running",
+        started_at=datetime(2026, 5, 1, 7, 0),
+        avg_pace_min_km=5.0,
+        weather_json=json.dumps({"temp": 73.4, "dewPoint": 64.4}),
+    ))
+    db.commit()
+    assert ai_coach.recent_heat_stress(db, date(2026, 6, 17)) is False
+
+
+def test_recent_heat_stress_scoped_to_user(db):
+    db.add(Activity(
+        user_id=2, garmin_id=903, activity_type="running",
+        started_at=datetime(2026, 6, 15, 7, 0),
+        avg_pace_min_km=5.0,
+        weather_json=json.dumps({"temp": 73.4, "dewPoint": 64.4}),
+    ))
+    db.commit()
+    assert ai_coach.recent_heat_stress(db, date(2026, 6, 17), user_id=1) is False
+
+
+def test_recent_heat_stress_note_reuses_same_data(db):
+    db.add(Activity(
+        garmin_id=904, activity_type="running",
+        started_at=datetime(2026, 6, 15, 7, 0),
+        avg_pace_min_km=5.0,
+        weather_json=json.dumps({"temp": 73.4, "dewPoint": 64.4}),
+    ))
+    db.commit()
+    assert ai_coach.recent_heat_stress(db, date(2026, 6, 17)) is True
+    assert "Recent heat stress" in ai_coach._recent_heat_stress_note(db, date(2026, 6, 17))
+
+
 # --- _extract_summary_and_category ---
 
 def test_extract_summary_from_marker():

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.models import (
     Activity,
+    AthleteProfile,
     ChatMessage,
     DailySummary,
     GarminCalendarEvent,
@@ -169,6 +170,49 @@ def test_calendar_event_detail(client, db):
 
 def test_calendar_event_detail_404(client):
     assert client.get("/api/v1/calendar-events/77").status_code == 404
+
+
+def test_calendar_event_race_includes_fuelling_guidance(client, db):
+    db.add(AthleteProfile(weight_kg=70))
+    e = GarminCalendarEvent(
+        garmin_id="r1", event_type="race", date=date(2026, 6, 20), title="City Half",
+        distance_m=21097.5, goal_time_sec=6300,  # 1h45m
+    )
+    db.add(e)
+    db.commit()
+    db.refresh(e)
+    resp = client.get(f"/api/v1/calendar-events/{e.id}")
+    assert resp.status_code == 200
+    guidance = resp.json()["fuelling_guidance"]
+    assert guidance is not None
+    assert guidance["carbs_g_per_hour"] > 0
+    assert guidance["fluid_ml_per_hour"] > 0
+
+
+def test_calendar_event_short_race_has_no_fuelling_guidance(client, db):
+    e = GarminCalendarEvent(
+        garmin_id="r2", event_type="race", date=date(2026, 6, 20), title="5K",
+        distance_m=5000, goal_time_sec=1200,  # 20 min
+    )
+    db.add(e)
+    db.commit()
+    db.refresh(e)
+    resp = client.get(f"/api/v1/calendar-events/{e.id}")
+    assert resp.status_code == 200
+    assert resp.json()["fuelling_guidance"] is None
+
+
+def test_calendar_event_workout_has_no_fuelling_guidance(client, db):
+    e = GarminCalendarEvent(
+        garmin_id="w2", event_type="workout", date=date(2026, 6, 20), title="Tempo",
+        distance_m=10000,
+    )
+    db.add(e)
+    db.commit()
+    db.refresh(e)
+    resp = client.get(f"/api/v1/calendar-events/{e.id}")
+    assert resp.status_code == 200
+    assert resp.json()["fuelling_guidance"] is None
 
 
 # --- /insights ---
@@ -737,6 +781,67 @@ def test_training_plan_day_no_routine_when_id_missing(client, db):
     body = resp.json()
     day = body["weeks"][0]["days"][0]
     assert day["routine"] is None
+    assert day["fuelling_guidance"] is None
+
+
+def test_training_plan_long_day_includes_fuelling_guidance(client, db):
+    from datetime import timezone
+    db.add(AthleteProfile(weight_kg=68))
+    plan = TrainingPlan(
+        generated_at=datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc),
+        week_start=date(2026, 6, 16),
+        plan_weeks=1,
+    )
+    db.add(plan)
+    db.flush()
+    db.add(TrainingPlanDay(
+        plan_id=plan.id,
+        day_date=date(2026, 6, 21),
+        day_of_week="Sunday",
+        week_number=1,
+        workout_type="long",
+        target_distance_m=25000,
+        target_pace_min_km=5.5,  # ~2h17m
+        description="Long run",
+    ))
+    db.commit()
+
+    resp = client.get("/api/v1/training-plan")
+    assert resp.status_code == 200
+    days = resp.json()["weeks"][0]["days"]
+    long_day = next(d for d in days if d["workout_type"] == "long")
+    guidance = long_day["fuelling_guidance"]
+    assert guidance is not None
+    assert guidance["carbs_g_per_hour"] > 0
+    assert guidance["fluid_ml_per_hour"] > 0
+
+
+def test_training_plan_short_long_day_has_no_fuelling_guidance(client, db):
+    from datetime import timezone
+    plan = TrainingPlan(
+        generated_at=datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc),
+        week_start=date(2026, 6, 16),
+        plan_weeks=1,
+    )
+    db.add(plan)
+    db.flush()
+    db.add(TrainingPlanDay(
+        plan_id=plan.id,
+        day_date=date(2026, 6, 21),
+        day_of_week="Sunday",
+        week_number=1,
+        workout_type="long",
+        target_distance_m=8000,
+        target_pace_min_km=5.5,  # ~44 min — under the 60 min threshold
+        description="Long run",
+    ))
+    db.commit()
+
+    resp = client.get("/api/v1/training-plan")
+    assert resp.status_code == 200
+    days = resp.json()["weeks"][0]["days"]
+    long_day = next(d for d in days if d["workout_type"] == "long")
+    assert long_day["fuelling_guidance"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nutrition.py
+++ b/tests/test_nutrition.py
@@ -1,0 +1,88 @@
+"""Tests for app/nutrition.py — fuelling/hydration guidance."""
+
+import pytest
+
+from app.nutrition import compute_fuelling_guidance
+
+
+# --- duration gating ---
+
+def test_no_guidance_under_one_hour():
+    assert compute_fuelling_guidance(duration_sec=3000) is None
+
+
+def test_guidance_at_exactly_one_hour():
+    guidance = compute_fuelling_guidance(duration_sec=3600)
+    assert guidance is not None
+
+
+def test_no_guidance_for_none_duration():
+    assert compute_fuelling_guidance(duration_sec=None) is None
+
+
+# --- carb tiers ---
+
+def test_carb_tier_short_long_run():
+    # 75 min, easy long run -> 30 g/hr tier
+    guidance = compute_fuelling_guidance(duration_sec=75 * 60, intensity="long")
+    assert guidance.carbs_g_per_hour == 30
+
+
+def test_carb_tier_mid_long_run():
+    # 2h, easy long run -> 60 g/hr tier
+    guidance = compute_fuelling_guidance(duration_sec=120 * 60, intensity="long")
+    assert guidance.carbs_g_per_hour == 60
+
+
+def test_carb_tier_long_ultra_effort():
+    # 3h, easy long run -> 90 g/hr tier
+    guidance = compute_fuelling_guidance(duration_sec=180 * 60, intensity="long")
+    assert guidance.carbs_g_per_hour == 90
+
+
+def test_race_intensity_bumps_carbs():
+    long_guidance = compute_fuelling_guidance(duration_sec=90 * 60, intensity="long")
+    race_guidance = compute_fuelling_guidance(duration_sec=90 * 60, intensity="race")
+    assert race_guidance.carbs_g_per_hour == long_guidance.carbs_g_per_hour + 15
+
+
+# --- fluid targets ---
+
+def test_fluid_scales_with_weight():
+    light = compute_fuelling_guidance(duration_sec=3600, weight_kg=50)
+    heavy = compute_fuelling_guidance(duration_sec=3600, weight_kg=90)
+    assert heavy.fluid_ml_per_hour > light.fluid_ml_per_hour
+
+
+def test_fluid_defaults_when_weight_missing():
+    guidance = compute_fuelling_guidance(duration_sec=3600, weight_kg=None)
+    assert guidance.fluid_ml_per_hour > 0
+
+
+def test_heat_stress_bumps_fluid():
+    neutral = compute_fuelling_guidance(duration_sec=3600, weight_kg=70, heat_stress=False)
+    hot = compute_fuelling_guidance(duration_sec=3600, weight_kg=70, heat_stress=True)
+    assert hot.fluid_ml_per_hour > neutral.fluid_ml_per_hour
+
+
+def test_heat_stress_reflected_in_note():
+    hot = compute_fuelling_guidance(duration_sec=3600, weight_kg=70, heat_stress=True)
+    assert "heat" in hot.note.lower()
+
+
+def test_no_heat_mention_when_neutral():
+    neutral = compute_fuelling_guidance(duration_sec=3600, weight_kg=70, heat_stress=False)
+    assert "heat" not in neutral.note.lower()
+
+
+# --- totals ---
+
+def test_totals_scale_with_duration():
+    guidance = compute_fuelling_guidance(duration_sec=7200, intensity="long", weight_kg=70)
+    assert guidance.total_carbs_g == pytest.approx(guidance.carbs_g_per_hour * 2, abs=1)
+    assert guidance.total_fluid_ml == pytest.approx(guidance.fluid_ml_per_hour * 2, abs=25)
+
+
+def test_note_contains_duration():
+    guidance = compute_fuelling_guidance(duration_sec=135 * 60, intensity="long")
+    assert "2h15m" in guidance.note


### PR DESCRIPTION
Deterministic carb-per-hour and fluid-per-hour targets scaled by duration,
intensity, athlete body weight, and recent heat exposure (reusing the P0-1
heat-stress signal). Surfaced on long-run plan days and race detail.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MzjptRq1sLwjCWCr7mjhfD