### PR TITLE
Add user-defined custom chart builder (P3-3)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -89,6 +89,10 @@ from app.schemas import (
     AerobicTrendsResponse,
     AIJobEnqueuedResponse,
     AIJobResponse,
+    CustomChartDataResponse,
+    CustomChartMetric,
+    CustomChartMetricsResponse,
+    CustomChartPoint,
 )
 from app.strength_routines import ROUTINE_LIBRARY, get_routine
 from app import training_load
@@ -1158,6 +1162,122 @@ def api_get_aerobic_trends(
         ],
         days=days,
     )
+
+
+# --- Custom Charts ---
+
+# Registry of chartable metrics, spanning the three stored time-series sources:
+# per-run Activity rows (aggregated to one point per day), DailySummary
+# wellness rows (already one row per day), and the CTL/ATL/TSB/ACWR series
+# (computed/cached by app.training_load).
+_CUSTOM_CHART_METRICS: dict[str, dict] = {
+    "distance_km": {"label": "Distance", "unit": "km", "group": "activity", "column": Activity.distance_m, "agg": "sum", "scale": 0.001},
+    "duration_min": {"label": "Duration", "unit": "min", "group": "activity", "column": Activity.duration_sec, "agg": "sum", "scale": 1 / 60},
+    "avg_pace": {"label": "Avg Pace", "unit": "min/km", "group": "activity", "column": Activity.avg_pace_min_km, "agg": "avg"},
+    "avg_hr": {"label": "Avg Heart Rate", "unit": "bpm", "group": "activity", "column": Activity.avg_hr, "agg": "avg"},
+    "avg_cadence": {"label": "Avg Cadence", "unit": "spm", "group": "activity", "column": Activity.avg_cadence, "agg": "avg"},
+    "elevation_gain": {"label": "Elevation Gain", "unit": "m", "group": "activity", "column": Activity.elevation_gain, "agg": "sum"},
+    "calories": {"label": "Calories", "unit": "kcal", "group": "activity", "column": Activity.calories, "agg": "sum"},
+    "vo2max": {"label": "VO2max", "unit": "ml/kg/min", "group": "activity", "column": Activity.vo2max, "agg": "avg"},
+    "training_stress_score": {"label": "Training Stress Score", "unit": "TSS", "group": "activity", "column": Activity.training_stress_score, "agg": "sum"},
+    "efficiency_factor": {"label": "Efficiency Factor", "unit": "", "group": "activity", "column": Activity.efficiency_factor, "agg": "avg"},
+    "decoupling_pct": {"label": "Aerobic Decoupling", "unit": "%", "group": "activity", "column": Activity.decoupling_pct, "agg": "avg"},
+    "resting_hr": {"label": "Resting Heart Rate", "unit": "bpm", "group": "wellness", "column": DailySummary.resting_hr},
+    "sleep_score": {"label": "Sleep Score", "unit": "", "group": "wellness", "column": DailySummary.sleep_score},
+    "stress_avg": {"label": "Stress", "unit": "", "group": "wellness", "column": DailySummary.stress_avg},
+    "body_battery_high": {"label": "Body Battery (high)", "unit": "", "group": "wellness", "column": DailySummary.body_battery_high},
+    "hrv_avg": {"label": "HRV", "unit": "ms", "group": "wellness", "column": DailySummary.hrv_avg},
+    "steps": {"label": "Steps", "unit": "", "group": "wellness", "column": DailySummary.steps},
+    "ctl": {"label": "Fitness (CTL)", "unit": "", "group": "load", "attr": "ctl"},
+    "atl": {"label": "Fatigue (ATL)", "unit": "", "group": "load", "attr": "atl"},
+    "tsb": {"label": "Form (TSB)", "unit": "", "group": "load", "attr": "tsb"},
+    "acwr": {"label": "ACWR", "unit": "", "group": "load", "attr": "acwr"},
+}
+
+_CUSTOM_CHART_RUN_TYPES = ("running", "trail_running", "treadmill_running", "indoor_running")
+
+
+@api_router.get("/custom-charts/metrics", response_model=CustomChartMetricsResponse)
+def api_custom_chart_metrics():
+    return CustomChartMetricsResponse(
+        metrics=[
+            CustomChartMetric(id=metric_id, label=m["label"], unit=m["unit"], group=m["group"])
+            for metric_id, m in _CUSTOM_CHART_METRICS.items()
+        ]
+    )
+
+
+@api_router.get("/custom-charts/data", response_model=CustomChartDataResponse)
+def api_custom_chart_data(
+    metrics: str = Query(..., description="Comma-separated metric ids"),
+    days: int = Query(90, ge=7, le=365),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Merge one or more registered metrics into a unified daily time series."""
+    metric_ids = [m.strip() for m in metrics.split(",") if m.strip()]
+    if not metric_ids:
+        raise HTTPException(status_code=400, detail="At least one metric is required")
+    unknown = [m for m in metric_ids if m not in _CUSTOM_CHART_METRICS]
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unknown metric id(s): {', '.join(unknown)}")
+
+    end_date = date.today()
+    start_date = end_date - timedelta(days=days - 1)
+    by_date: dict[str, dict[str, float | None]] = {}
+
+    def _set(d: date, metric_id: str, value) -> None:
+        by_date.setdefault(d.isoformat(), {})[metric_id] = round(value, 4) if value is not None else None
+
+    load_points_cache = None
+
+    for metric_id in metric_ids:
+        m = _CUSTOM_CHART_METRICS[metric_id]
+        if m["group"] == "activity":
+            date_col = func.date(Activity.started_at)
+            agg_fn = func.avg(m["column"]) if m["agg"] == "avg" else func.sum(m["column"])
+            rows = (
+                db.query(date_col.label("d"), agg_fn.label("v"))
+                .filter(
+                    Activity.user_id == current_user.id,
+                    Activity.started_at >= datetime.combine(start_date, datetime.min.time()),
+                    Activity.started_at < datetime.combine(end_date + timedelta(days=1), datetime.min.time()),
+                    func.lower(Activity.activity_type).in_(_CUSTOM_CHART_RUN_TYPES),
+                    m["column"].isnot(None),
+                )
+                .group_by(date_col)
+                .all()
+            )
+            scale = m.get("scale", 1.0)
+            for r in rows:
+                d = r.d if isinstance(r.d, date) else datetime.strptime(str(r.d)[:10], "%Y-%m-%d").date()
+                _set(d, metric_id, r.v * scale if r.v is not None else None)
+        elif m["group"] == "wellness":
+            rows = (
+                db.query(DailySummary.date.label("d"), m["column"].label("v"))
+                .filter(
+                    DailySummary.user_id == current_user.id,
+                    DailySummary.date >= start_date,
+                    DailySummary.date <= end_date,
+                    m["column"].isnot(None),
+                )
+                .all()
+            )
+            for r in rows:
+                _set(r.d, metric_id, r.v)
+        else:  # load
+            if load_points_cache is None:
+                load_points_cache = training_load.compute_load_series(
+                    db, end_date=end_date, days=days, user_id=current_user.id
+                )
+            for p in load_points_cache:
+                _set(p.date, metric_id, getattr(p, m["attr"]))
+
+    result_points = [
+        CustomChartPoint(date=d, values={mid: by_date[d].get(mid) for mid in metric_ids})
+        for d in sorted(by_date.keys())
+    ]
+    return CustomChartDataResponse(points=result_points, days=days)
 
 
 # --- Training Plan ---

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -589,6 +589,27 @@ class AerobicTrendsResponse(BaseModel):
     days: int
 
 
+class CustomChartMetric(BaseModel):
+    id: str
+    label: str
+    unit: str
+    group: str  # "activity" | "wellness" | "load"
+
+
+class CustomChartMetricsResponse(BaseModel):
+    metrics: list[CustomChartMetric] = []
+
+
+class CustomChartPoint(BaseModel):
+    date: str
+    values: dict[str, float | None] = {}
+
+
+class CustomChartDataResponse(BaseModel):
+    points: list[CustomChartPoint] = []
+    days: int
+
+
 class StrengthExercise(BaseModel):
     name: str
     sets: int

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -290,9 +290,21 @@ badges replace the old client-side duplicate banding, plus a recommendation line
   TrainingPeaks are adding progressive load and demo videos. Add per-week progression
   and optional exercise demo links. **S–M.** Files: `app/strength_routines.py`,
   `frontend/src/components/workout-detail/*`.
-- **P3-3 · User-defined custom charts.** Carryover from v3 — an Intervals.icu-style
-  custom chart/metric builder over the stored series. **L.** Files: `app/api.py`,
-  `frontend/src/components/trends/*` + hooks/types.
+- **P3-3 · User-defined custom charts** ✅ DONE (2026-07-01). Carryover from v3 — an
+  Intervals.icu-style custom chart/metric builder over the stored series. A registry
+  of ~20 chartable metrics spans the three stored time-series sources (per-run
+  `Activity` rows aggregated to one point per day, `DailySummary` wellness rows, and
+  the cached CTL/ATL/TSB/ACWR series), merged into a unified daily series by two new
+  endpoints. A new "Custom" tab in Trends lets the athlete pick up to 4 metrics across
+  groups, choose a date range, and plot them on a multi-axis Recharts line chart;
+  selection and named presets persist client-side (`localStorage`), so no new backend
+  model/migration was needed. **L.** Files: `app/schemas.py` (`CustomChartMetric`,
+  `CustomChartMetricsResponse`, `CustomChartPoint`, `CustomChartDataResponse`),
+  `app/api.py` (`_CUSTOM_CHART_METRICS` registry, `GET /custom-charts/metrics`,
+  `GET /custom-charts/data`), `frontend/src/api/types.ts`, `frontend/src/api/hooks.ts`
+  (`useCustomChartMetrics`, `useCustomChartData`),
+  `frontend/src/components/trends/CustomChartsView.tsx` + `.css` (new), `TrendsView.tsx`
+  (new "Custom" tab), `tests/test_custom_charts.py` (new, 9 tests).
 - **P3-4 · Security default hardening.** The startup guard *warns* on an
   unauthenticated non-loopback bind but still starts; consider **refusing** to start in
   that configuration (opt-out env for trusted private networks). **S.** Files:

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -38,6 +38,8 @@ import type {
   ThresholdEstimateResponse,
   ThresholdApplyRequest,
   AerobicTrendsResponse,
+  CustomChartMetricsResponse,
+  CustomChartDataResponse,
 } from './types'
 
 export function useMe() {
@@ -369,6 +371,22 @@ export function useAerobicTrends(days = 90) {
   return useQuery({
     queryKey: ['aerobic-trends', days],
     queryFn: () => apiGet<AerobicTrendsResponse>(`/aerobic-trends?days=${days}`),
+  })
+}
+
+export function useCustomChartMetrics() {
+  return useQuery({
+    queryKey: ['custom-chart-metrics'],
+    queryFn: () => apiGet<CustomChartMetricsResponse>('/custom-charts/metrics'),
+    staleTime: Infinity,
+  })
+}
+
+export function useCustomChartData(metricIds: string[], days: number) {
+  return useQuery({
+    queryKey: ['custom-chart-data', metricIds, days],
+    queryFn: () => apiGet<CustomChartDataResponse>(`/custom-charts/data?metrics=${metricIds.join(',')}&days=${days}`),
+    enabled: metricIds.length > 0,
   })
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -561,6 +561,29 @@ export interface AerobicTrendsResponse {
   days: number
 }
 
+export type CustomChartMetricGroup = 'activity' | 'wellness' | 'load'
+
+export interface CustomChartMetric {
+  id: string
+  label: string
+  unit: string
+  group: CustomChartMetricGroup
+}
+
+export interface CustomChartMetricsResponse {
+  metrics: CustomChartMetric[]
+}
+
+export interface CustomChartPoint {
+  date: string
+  values: Record<string, number | null>
+}
+
+export interface CustomChartDataResponse {
+  points: CustomChartPoint[]
+  days: number
+}
+
 export interface PushWorkoutResponse {
   workout_name: string
   garmin_workout_id: number | string

--- a/frontend/src/components/trends/CustomChartsView.css
+++ b/frontend/src/components/trends/CustomChartsView.css
@@ -1,0 +1,154 @@
+.custom-chart-view {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 24px;
+}
+
+.custom-chart-view .trends-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.custom-chart-view .trends-range-tabs {
+  display: flex;
+  gap: 4px;
+}
+
+.custom-chart-view .range-tab {
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+
+.custom-chart-view .range-tab.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.custom-chart-view .range-tab:hover:not(.active) {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+.custom-chart-metric-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.custom-chart-metric-group {
+  min-width: 140px;
+}
+
+.custom-chart-group-label {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 6px;
+}
+
+.custom-chart-checkbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.custom-chart-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.custom-chart-checkbox.disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.custom-chart-presets {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.custom-chart-save-btn {
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.custom-chart-save-btn:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+.custom-chart-save-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.custom-chart-preset-chip {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  font-size: 0.75rem;
+}
+
+.custom-chart-preset-chip button {
+  background: transparent;
+  border: none;
+  color: var(--text);
+  padding: 4px 8px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.75rem;
+}
+
+.custom-chart-preset-remove {
+  color: var(--text-muted);
+  border-left: 1px solid var(--border) !important;
+  padding: 4px 6px !important;
+}
+
+.custom-chart-preset-remove:hover {
+  color: var(--text);
+}
+
+.custom-chart-card {
+  padding: 16px;
+}
+
+.custom-chart-empty {
+  padding: 48px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}

--- a/frontend/src/components/trends/CustomChartsView.tsx
+++ b/frontend/src/components/trends/CustomChartsView.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ComposedChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+import { useCustomChartMetrics, useCustomChartData } from '../../api/hooks'
+import { useTheme } from '../../App'
+import { getChartTickColor, getChartTooltipStyle } from '../../utils/theme'
+import type { CustomChartMetric, CustomChartMetricGroup } from '../../api/types'
+import './CustomChartsView.css'
+
+type Days = 30 | 90 | 180 | 365
+
+const DAY_OPTIONS: { label: string; value: Days }[] = [
+  { label: '30d', value: 30 },
+  { label: '90d', value: 90 },
+  { label: '180d', value: 180 },
+  { label: '365d', value: 365 },
+]
+
+const GROUP_LABELS: Record<CustomChartMetricGroup, string> = {
+  activity: 'Activity',
+  wellness: 'Wellness',
+  load: 'Training Load',
+}
+
+const GROUP_ORDER: CustomChartMetricGroup[] = ['activity', 'wellness', 'load']
+
+const SERIES_COLORS = ['#6c5ce7', '#00b894', '#e17055', '#0984e3']
+
+const MAX_METRICS = 4
+const CONFIG_KEY = 'runningCoach.customChart.config'
+const PRESETS_KEY = 'runningCoach.customChart.presets'
+
+interface ChartConfig {
+  metricIds: string[]
+  days: Days
+}
+
+interface ChartPreset extends ChartConfig {
+  name: string
+}
+
+function loadConfig(): ChartConfig {
+  try {
+    const raw = localStorage.getItem(CONFIG_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed.metricIds) && typeof parsed.days === 'number') {
+        return { metricIds: parsed.metricIds, days: parsed.days }
+      }
+    }
+  } catch {
+    // ignore malformed localStorage state
+  }
+  return { metricIds: ['avg_pace', 'avg_hr'], days: 90 }
+}
+
+function loadPresets(): ChartPreset[] {
+  try {
+    const raw = localStorage.getItem(PRESETS_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) return parsed
+    }
+  } catch {
+    // ignore malformed localStorage state
+  }
+  return []
+}
+
+function formatDate(iso: string) {
+  const d = new Date(iso + 'T00:00:00')
+  return `${d.getMonth() + 1}/${d.getDate()}`
+}
+
+export default function CustomChartsView() {
+  const { data: metricsData, isLoading: metricsLoading } = useCustomChartMetrics()
+  const [config, setConfig] = useState<ChartConfig>(loadConfig)
+  const [presets, setPresets] = useState<ChartPreset[]>(loadPresets)
+  const { theme } = useTheme()
+  const tickColor = getChartTickColor(theme)
+  const tooltipStyle = getChartTooltipStyle(theme)
+
+  const { metricIds, days } = config
+  const { data: chartData, isLoading: dataLoading } = useCustomChartData(metricIds, days)
+
+  useEffect(() => {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify(config))
+  }, [config])
+
+  const metricsById = useMemo(() => {
+    const map = new Map<string, CustomChartMetric>()
+    for (const m of metricsData?.metrics ?? []) map.set(m.id, m)
+    return map
+  }, [metricsData])
+
+  const groupedMetrics = useMemo(() => {
+    const groups: Record<CustomChartMetricGroup, CustomChartMetric[]> = { activity: [], wellness: [], load: [] }
+    for (const m of metricsData?.metrics ?? []) groups[m.group].push(m)
+    return groups
+  }, [metricsData])
+
+  function toggleMetric(id: string) {
+    setConfig(prev => {
+      const selected = prev.metricIds.includes(id)
+      if (selected) return { ...prev, metricIds: prev.metricIds.filter(m => m !== id) }
+      if (prev.metricIds.length >= MAX_METRICS) return prev
+      return { ...prev, metricIds: [...prev.metricIds, id] }
+    })
+  }
+
+  function setDays(days: Days) {
+    setConfig(prev => ({ ...prev, days }))
+  }
+
+  function savePreset() {
+    const name = window.prompt('Name this chart:')
+    if (!name) return
+    const next = [...presets.filter(p => p.name !== name), { name, metricIds, days }]
+    setPresets(next)
+    localStorage.setItem(PRESETS_KEY, JSON.stringify(next))
+  }
+
+  function loadPreset(name: string) {
+    const preset = presets.find(p => p.name === name)
+    if (preset) setConfig({ metricIds: preset.metricIds, days: preset.days })
+  }
+
+  function deletePreset(name: string) {
+    const next = presets.filter(p => p.name !== name)
+    setPresets(next)
+    localStorage.setItem(PRESETS_KEY, JSON.stringify(next))
+  }
+
+  const rows = useMemo(() => {
+    return (chartData?.points ?? []).map(p => ({
+      label: formatDate(p.date),
+      ...p.values,
+    }))
+  }, [chartData])
+
+  if (metricsLoading) {
+    return <div className="custom-chart-empty">Loading metrics…</div>
+  }
+
+  return (
+    <div className="custom-chart-view">
+      <div className="trends-header">
+        <h2 style={{ margin: 0, fontSize: '1.1rem', fontWeight: 700 }}>Custom Chart</h2>
+        <div className="trends-range-tabs">
+          {DAY_OPTIONS.map(o => (
+            <button
+              key={o.value}
+              className={`range-tab ${days === o.value ? 'active' : ''}`}
+              onClick={() => setDays(o.value)}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="custom-chart-metric-picker">
+        {GROUP_ORDER.map(group => (
+          <div key={group} className="custom-chart-metric-group">
+            <div className="custom-chart-group-label">{GROUP_LABELS[group]}</div>
+            <div className="custom-chart-checkbox-list">
+              {groupedMetrics[group].map(m => {
+                const checked = metricIds.includes(m.id)
+                const disabled = !checked && metricIds.length >= MAX_METRICS
+                return (
+                  <label key={m.id} className={`custom-chart-checkbox ${disabled ? 'disabled' : ''}`}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={disabled}
+                      onChange={() => toggleMetric(m.id)}
+                    />
+                    {m.label}
+                  </label>
+                )
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="custom-chart-presets">
+        <button className="custom-chart-save-btn" onClick={savePreset} disabled={metricIds.length === 0}>
+          Save as preset
+        </button>
+        {presets.map(p => (
+          <span key={p.name} className="custom-chart-preset-chip">
+            <button onClick={() => loadPreset(p.name)}>{p.name}</button>
+            <button className="custom-chart-preset-remove" onClick={() => deletePreset(p.name)} aria-label={`Delete ${p.name}`}>
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+
+      {metricIds.length === 0 ? (
+        <div className="custom-chart-empty">Select at least one metric to build a chart.</div>
+      ) : dataLoading ? (
+        <div className="custom-chart-empty">Loading chart…</div>
+      ) : rows.length === 0 ? (
+        <div className="custom-chart-empty">No data available for the selected metrics and range.</div>
+      ) : (
+        <div className="card custom-chart-card">
+          <ResponsiveContainer width="100%" height={320}>
+            <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+              <XAxis dataKey="label" tick={{ fontSize: 11, fill: tickColor }} tickLine={false} axisLine={false} />
+              {metricIds.map((id, i) => (
+                <YAxis
+                  key={id}
+                  yAxisId={id}
+                  orientation={i % 2 === 0 ? 'left' : 'right'}
+                  hide={i >= 2}
+                  tick={{ fontSize: 11, fill: SERIES_COLORS[i % SERIES_COLORS.length] }}
+                  tickLine={false}
+                  axisLine={false}
+                  width={40}
+                />
+              ))}
+              <Tooltip
+                contentStyle={tooltipStyle}
+                formatter={(value: number, name: string, item: any) => {
+                  const m = metricsById.get(item.dataKey as string)
+                  return [`${value}${m?.unit ? ' ' + m.unit : ''}`, name]
+                }}
+              />
+              <Legend wrapperStyle={{ fontSize: 11, paddingTop: 8 }} />
+              {metricIds.map((id, i) => (
+                <Line
+                  key={id}
+                  dataKey={id}
+                  yAxisId={id}
+                  stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
+                  strokeWidth={2}
+                  dot={false}
+                  connectNulls
+                  name={metricsById.get(id)?.label ?? id}
+                />
+              ))}
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/trends/TrendsView.tsx
+++ b/frontend/src/components/trends/TrendsView.tsx
@@ -3,14 +3,16 @@ import WellnessTrendsView from './WellnessTrendsView'
 import PerformanceCurveView from './PerformanceCurveView'
 import IntensityTrendsView from './IntensityTrendsView'
 import AerobicTrendsView from './AerobicTrendsView'
+import CustomChartsView from './CustomChartsView'
 
-type Tab = 'wellness' | 'intensity' | 'performance' | 'aerobic'
+type Tab = 'wellness' | 'intensity' | 'performance' | 'aerobic' | 'custom'
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'wellness', label: 'Wellness' },
   { id: 'intensity', label: 'Intensity' },
   { id: 'performance', label: 'Performance' },
   { id: 'aerobic', label: 'Aerobic' },
+  { id: 'custom', label: 'Custom' },
 ]
 
 export default function TrendsView() {
@@ -51,6 +53,7 @@ export default function TrendsView() {
       {tab === 'intensity' && <IntensityTrendsView />}
       {tab === 'performance' && <PerformanceCurveView />}
       {tab === 'aerobic' && <AerobicTrendsView />}
+      {tab === 'custom' && <CustomChartsView />}
     </div>
   )
 }

--- a/tests/test_custom_charts.py
+++ b/tests/test_custom_charts.py
@@ -1,0 +1,109 @@
+"""Tests for the P3-3 custom chart builder endpoints."""
+from datetime import date, datetime, timedelta
+
+from app.models import Activity, DailySummary
+
+
+def _add_activity(db, started_at, *, distance_m=10000.0, avg_hr=150, user_id=1):
+    db.add(Activity(
+        user_id=user_id,
+        garmin_id=int(started_at.timestamp()),
+        activity_type="running",
+        name="Run",
+        started_at=started_at,
+        distance_m=distance_m,
+        avg_hr=avg_hr,
+        duration_sec=3000,
+    ))
+    db.commit()
+
+
+def _add_daily_summary(db, day, *, sleep_score=80.0, user_id=1):
+    db.add(DailySummary(user_id=user_id, date=day, sleep_score=sleep_score))
+    db.commit()
+
+
+def test_metrics_endpoint_lists_known_metrics(client, db):
+    resp = client.get("/api/v1/custom-charts/metrics")
+    assert resp.status_code == 200
+    by_id = {m["id"]: m for m in resp.json()["metrics"]}
+    assert by_id["avg_hr"]["group"] == "activity"
+    assert by_id["sleep_score"]["group"] == "wellness"
+    assert by_id["ctl"]["group"] == "load"
+    assert by_id["distance_km"]["unit"] == "km"
+
+
+def test_data_endpoint_rejects_unknown_metric(client, db):
+    resp = client.get("/api/v1/custom-charts/data?metrics=not_a_real_metric&days=30")
+    assert resp.status_code == 400
+
+
+def test_data_endpoint_requires_metrics_param(client, db):
+    resp = client.get("/api/v1/custom-charts/data?days=30")
+    assert resp.status_code == 422
+
+
+def test_data_endpoint_rejects_days_out_of_bounds(client, db):
+    assert client.get("/api/v1/custom-charts/data?metrics=avg_hr&days=1").status_code == 422
+    assert client.get("/api/v1/custom-charts/data?metrics=avg_hr&days=1000").status_code == 422
+
+
+def test_data_endpoint_aggregates_activity_metrics_per_day(client, db):
+    day = datetime(2026, 6, 10, 7, 0)
+    _add_activity(db, day, distance_m=8000.0, avg_hr=140)
+    _add_activity(db, day + timedelta(hours=8), distance_m=2000.0, avg_hr=160)
+
+    resp = client.get("/api/v1/custom-charts/data?metrics=distance_km,avg_hr&days=30")
+    assert resp.status_code == 200
+    points = resp.json()["points"]
+    point = next(p for p in points if p["date"] == "2026-06-10")
+    assert point["values"]["distance_km"] == 10.0  # summed
+    assert point["values"]["avg_hr"] == 150.0       # averaged
+
+
+def test_data_endpoint_wellness_passthrough(client, db):
+    _add_daily_summary(db, date(2026, 6, 11), sleep_score=87.5)
+    resp = client.get("/api/v1/custom-charts/data?metrics=sleep_score&days=30")
+    assert resp.status_code == 200
+    points = resp.json()["points"]
+    point = next(p for p in points if p["date"] == "2026-06-11")
+    assert point["values"]["sleep_score"] == 87.5
+
+
+def test_data_endpoint_merges_multiple_sources_by_date_with_nulls(client, db):
+    day = date(2026, 6, 12)
+    _add_activity(db, datetime.combine(day, datetime.min.time()).replace(hour=7), distance_m=5000.0)
+    # No DailySummary row for this date.
+
+    resp = client.get("/api/v1/custom-charts/data?metrics=distance_km,sleep_score&days=30")
+    assert resp.status_code == 200
+    point = next(p for p in resp.json()["points"] if p["date"] == "2026-06-12")
+    assert point["values"]["distance_km"] == 5.0
+    assert point["values"]["sleep_score"] is None
+
+
+def test_data_endpoint_load_metrics_present(client, db):
+    base = datetime(2026, 6, 1, 7, 0)
+    for i in range(10):
+        _add_activity(db, base + timedelta(days=i), distance_m=10000.0)
+        db.query(Activity).filter(Activity.started_at == base + timedelta(days=i)).update(
+            {"training_stress_score": 70.0}
+        )
+        db.commit()
+
+    resp = client.get("/api/v1/custom-charts/data?metrics=ctl,tsb&days=30")
+    assert resp.status_code == 200
+    points = resp.json()["points"]
+    assert len(points) > 0
+    last = points[-1]
+    assert last["values"]["ctl"] is not None
+    assert last["values"]["tsb"] is not None
+
+
+def test_data_endpoint_scopes_to_current_user(client, db):
+    day = datetime(2026, 6, 13, 7, 0)
+    _add_activity(db, day, distance_m=5000.0, user_id=2)  # other user
+    resp = client.get("/api/v1/custom-charts/data?metrics=distance_km&days=30")
+    assert resp.status_code == 200
+    dates = [p["date"] for p in resp.json()["points"]]
+    assert "2026-06-13" not in dates


### PR DESCRIPTION
Adds a registry of ~20 chartable metrics spanning Activity, DailySummary,
and the CTL/ATL/TSB/ACWR series, merged by date into a unified series via
two new endpoints (GET /custom-charts/metrics, GET /custom-charts/data).
A new "Custom" tab in Trends lets the athlete pick up to 4 metrics and a
date range, rendered as a multi-axis line chart; selection and named
presets persist client-side, so no new backend model was needed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018LbgjKcaqDsWYWZfc62zzL