### PR TITLE
Add per-week strength progression and exercise demo links (P3-2)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -94,7 +94,7 @@ from app.schemas import (
     CustomChartMetricsResponse,
     CustomChartPoint,
 )
-from app.strength_routines import ROUTINE_LIBRARY, get_routine
+from app.strength_routines import ROUTINE_LIBRARY, get_routine, get_routine_for_week
 from app import training_load
 from app import plan_adaptation as plan_adaptation_mod
 from app import threshold as threshold_mod
@@ -1290,7 +1290,7 @@ def _day_to_response(
     """Convert a TrainingPlanDay ORM row to its response schema, hydrating routine."""
     resp = TrainingPlanDayResponse.model_validate(d)
     if d.routine_id:
-        raw = get_routine(d.routine_id)
+        raw = get_routine_for_week(d.routine_id, d.week_number)
         if raw:
             resp.routine = StrengthRoutine.model_validate(raw)
     if d.workout_type == "long" and d.target_distance_m and d.target_pace_min_km:
@@ -1355,7 +1355,7 @@ def _build_plan_response(plan: TrainingPlan, db: Session) -> TrainingPlanRespons
 @api_router.get("/strength-routines", response_model=list[StrengthRoutine])
 def api_get_strength_routines():
     """Return the full catalog of strength & mobility routines."""
-    return [StrengthRoutine.model_validate(r) for r in ROUTINE_LIBRARY.values()]
+    return [StrengthRoutine.model_validate(get_routine(rid)) for rid in ROUTINE_LIBRARY]
 
 
 @api_router.get("/training-plan", response_model=TrainingPlanResponse | None)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -615,6 +615,7 @@ class StrengthExercise(BaseModel):
     sets: int
     reps: str
     note: str | None = None
+    demo_url: str | None = None
 
 
 class StrengthRoutine(BaseModel):

--- a/app/strength_routines.py
+++ b/app/strength_routines.py
@@ -5,7 +5,8 @@ the ID is stored on TrainingPlanDay.routine_id and hydrated at response time.
 """
 
 from __future__ import annotations
-from typing import TypedDict
+from typing import NotRequired, TypedDict
+from urllib.parse import quote_plus
 
 
 class Exercise(TypedDict):
@@ -13,6 +14,7 @@ class Exercise(TypedDict):
     sets: int
     reps: str          # e.g. "12", "45 sec", "10 each side"
     note: str | None   # optional cue / substitution
+    demo_url: NotRequired[str]  # hydrated on lookup, not part of the static literal
 
 
 class Routine(TypedDict):
@@ -113,8 +115,60 @@ ROUTINE_LIBRARY: dict[str, Routine] = {
 ROUTINE_IDS = list(ROUTINE_LIBRARY.keys())
 
 
+def exercise_demo_url(name: str) -> str:
+    """YouTube search link for a form demonstration of this exercise.
+
+    A search URL (not a specific guessed video) so it's always valid.
+    """
+    return f"https://www.youtube.com/results?search_query={quote_plus(name + ' exercise proper form')}"
+
+
+def _hydrate(routine: Routine) -> Routine:
+    return {
+        **routine,
+        "exercises": [
+            {**ex, "demo_url": exercise_demo_url(ex["name"])}
+            for ex in routine["exercises"]
+        ],
+    }
+
+
 def get_routine(routine_id: str) -> Routine | None:
-    return ROUTINE_LIBRARY.get(routine_id)
+    raw = ROUTINE_LIBRARY.get(routine_id)
+    return _hydrate(raw) if raw else None
+
+
+def _progression_sets(week_number: int) -> int:
+    """Extra sets per exercise: +1 every 2 weeks from week 3, capped at +2."""
+    if week_number < 3:
+        return 0
+    return min((week_number - 1) // 2, 2)
+
+
+def _apply_progression(routine: Routine, week_number: int) -> Routine:
+    added = _progression_sets(week_number)
+    if added == 0:
+        return routine
+    suffix = f"Progression: +{added} set{'s' if added != 1 else ''} this week"
+    return {
+        **routine,
+        "exercises": [
+            {
+                **ex,
+                "sets": ex["sets"] + added,
+                "note": f"{ex['note']}; {suffix}" if ex["note"] else suffix,
+            }
+            for ex in routine["exercises"]
+        ],
+    }
+
+
+def get_routine_for_week(routine_id: str, week_number: int) -> Routine | None:
+    """Look up a routine hydrated with demo links and scaled for progressive load."""
+    routine = get_routine(routine_id)
+    if routine is None:
+        return None
+    return _apply_progression(routine, week_number)
 
 
 def catalog_summary() -> str:

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -286,10 +286,19 @@ badges replace the old client-side duplicate banding, plus a recommendation line
   targets. Add a longer-horizon plan skeleton (phase blocks to the goal race) that the
   4-week generator fills in. **L.** Files: `app/ai_coach.py`, `app/models.py` + Alembic,
   `frontend/src/components/plan/*`.
-- **P3-2 · Strength progression & demos.** The routine library is static; Garmin/
-  TrainingPeaks are adding progressive load and demo videos. Add per-week progression
-  and optional exercise demo links. **S–M.** Files: `app/strength_routines.py`,
-  `frontend/src/components/workout-detail/*`.
+- **P3-2 · Strength progression & demos** ✅ DONE (2026-07-01). The routine library
+  was static; Garmin/TrainingPeaks are adding progressive load and demo videos. Each
+  routine now scales with the plan day's `week_number` — `get_routine_for_week` adds
+  +1 set per exercise every 2 weeks from week 3, capped at +2, with a "Progression:
+  +N set(s) this week" note appended — and every exercise carries a `demo_url` (a
+  YouTube search link built from the exercise name, not a guessed specific video) for
+  a form demo. **S–M.** Files: `app/strength_routines.py` (`exercise_demo_url`,
+  `get_routine_for_week`, `_apply_progression`), `app/schemas.py`
+  (`StrengthExercise.demo_url`), `app/api.py` (`_day_to_response` and
+  `/strength-routines` hydrate via `get_routine`/`get_routine_for_week`),
+  `frontend/src/api/types.ts`, `frontend/src/components/plan/PlanView.tsx` + `.css`
+  (demo-link icon per exercise), `tests/test_strength_routines.py` (new, 11 tests),
+  `tests/test_api_endpoints.py` (2 new/updated tests).
 - **P3-3 · User-defined custom charts** ✅ DONE (2026-07-01). Carryover from v3 — an
   Intervals.icu-style custom chart/metric builder over the stored series. A registry
   of ~20 chartable metrics spans the three stored time-series sources (per-run

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -449,6 +449,7 @@ export interface StrengthExercise {
   sets: number
   reps: string
   note: string | null
+  demo_url: string | null
 }
 
 export interface StrengthRoutine {

--- a/frontend/src/components/plan/PlanView.css
+++ b/frontend/src/components/plan/PlanView.css
@@ -504,6 +504,19 @@
   grid-row: 1;
   color: var(--text);
   font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.plan-routine-ex-demo {
+  display: inline-flex;
+  color: var(--text-muted);
+  line-height: 0;
+}
+
+.plan-routine-ex-demo:hover {
+  color: var(--accent-light);
 }
 
 .plan-routine-ex-sets {

--- a/frontend/src/components/plan/PlanView.tsx
+++ b/frontend/src/components/plan/PlanView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
-import { ClipboardList, RefreshCw, ChevronLeft, ChevronRight, AlertTriangle, Settings2, Watch, CheckCircle, ChevronDown, ChevronUp, Dumbbell, Droplet } from 'lucide-react'
+import { ClipboardList, RefreshCw, ChevronLeft, ChevronRight, AlertTriangle, Settings2, Watch, CheckCircle, ChevronDown, ChevronUp, Dumbbell, Droplet, PlayCircle } from 'lucide-react'
 import { useTrainingPlan, useGenerateTrainingPlan, useRealignmentStatus, useRealignPlan, usePushWorkoutToGarmin, useJobStatus } from '../../api/hooks'
 import type { StrengthRoutine, FuellingGuidance, TrainingPlanDay, TrainingPlanWeek } from '../../api/types'
 import './PlanView.css'
@@ -96,7 +96,21 @@ function RoutinePanel({ routine }: { routine: StrengthRoutine }) {
           <ol className="plan-routine-exercises">
             {routine.exercises.map((ex, i) => (
               <li key={i} className="plan-routine-exercise">
-                <span className="plan-routine-ex-name">{ex.name}</span>
+                <span className="plan-routine-ex-name">
+                  {ex.name}
+                  {ex.demo_url && (
+                    <a
+                      className="plan-routine-ex-demo"
+                      href={ex.demo_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title="Watch a form demo"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <PlayCircle size={12} />
+                    </a>
+                  )}
+                </span>
                 <span className="plan-routine-ex-sets">{ex.sets}×{ex.reps}</span>
                 {ex.note && <span className="plan-routine-ex-note">{ex.note}</span>}
               </li>

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -723,6 +723,7 @@ def test_strength_routines_returns_catalog(client):
             assert "name" in ex
             assert "sets" in ex
             assert "reps" in ex
+            assert ex["demo_url"].startswith("https://www.youtube.com/results?search_query=")
 
 
 def test_training_plan_day_includes_routine(client, db):
@@ -754,6 +755,40 @@ def test_training_plan_day_includes_routine(client, db):
     assert strength_day["routine"] is not None
     assert strength_day["routine"]["id"] == "running-base"
     assert len(strength_day["routine"]["exercises"]) > 0
+
+
+def test_training_plan_day_routine_reflects_week_progression(client, db):
+    """A week-3 strength day gets progressively loaded sets via get_routine_for_week."""
+    from datetime import timezone
+    plan = TrainingPlan(
+        generated_at=datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc),
+        week_start=date(2026, 6, 16),
+        plan_weeks=3,
+    )
+    db.add(plan)
+    db.flush()
+    db.add(TrainingPlanDay(
+        plan_id=plan.id,
+        day_date=date(2026, 6, 30),
+        day_of_week="Tuesday",
+        week_number=3,
+        workout_type="strength",
+        description="Strength session",
+        routine_id="running-base",
+    ))
+    db.commit()
+
+    from app.strength_routines import get_routine
+    base_sets = get_routine("running-base")["exercises"][0]["sets"]
+
+    resp = client.get("/api/v1/training-plan")
+    assert resp.status_code == 200
+    body = resp.json()
+    days = body["weeks"][0]["days"]
+    strength_day = next(d for d in days if d["workout_type"] == "strength")
+    ex = strength_day["routine"]["exercises"][0]
+    assert ex["sets"] == base_sets + 1
+    assert "Progression" in ex["note"]
 
 
 def test_training_plan_day_no_routine_when_id_missing(client, db):

--- a/tests/test_strength_routines.py
+++ b/tests/test_strength_routines.py
@@ -1,0 +1,84 @@
+"""Tests for app/strength_routines.py — routine catalog, progression, and demo links."""
+
+from app.strength_routines import (
+    ROUTINE_IDS,
+    exercise_demo_url,
+    get_routine,
+    get_routine_for_week,
+)
+
+
+# --- demo links ---
+
+def test_exercise_demo_url_is_youtube_search():
+    url = exercise_demo_url("Single-leg squat")
+    assert url.startswith("https://www.youtube.com/results?search_query=")
+    assert "Single-leg+squat" in url
+
+
+def test_get_routine_hydrates_demo_url_on_every_exercise():
+    routine = get_routine("running-base")
+    assert routine is not None
+    for ex in routine["exercises"]:
+        assert ex["demo_url"].startswith("https://www.youtube.com/results?search_query=")
+
+
+def test_get_routine_unknown_id_returns_none():
+    assert get_routine("does-not-exist") is None
+
+
+# --- progression ---
+
+def test_progression_unchanged_weeks_1_and_2():
+    base = get_routine("running-base")
+    for week in (1, 2):
+        progressed = get_routine_for_week("running-base", week)
+        assert progressed["exercises"] == base["exercises"]
+
+
+def test_progression_adds_one_set_from_week_3():
+    base = get_routine("running-base")
+    progressed = get_routine_for_week("running-base", 3)
+    for base_ex, prog_ex in zip(base["exercises"], progressed["exercises"]):
+        assert prog_ex["sets"] == base_ex["sets"] + 1
+        assert "Progression: +1 set this week" in prog_ex["note"]
+
+
+def test_progression_caps_at_plus_two_sets():
+    base = get_routine("running-base")
+    progressed = get_routine_for_week("running-base", 9)
+    for base_ex, prog_ex in zip(base["exercises"], progressed["exercises"]):
+        assert prog_ex["sets"] == base_ex["sets"] + 2
+        assert "+2 sets this week" in prog_ex["note"]
+
+
+def test_progression_preserves_existing_note():
+    progressed = get_routine_for_week("running-base", 3)
+    single_leg_squat = next(ex for ex in progressed["exercises"] if ex["name"] == "Single-leg squat")
+    assert "Keep knee tracking over toes" in single_leg_squat["note"]
+    assert "Progression" in single_leg_squat["note"]
+
+
+def test_progression_sets_note_when_original_has_none():
+    # "Fire hydrant" in hip-glute has note=None at baseline.
+    progressed = get_routine_for_week("hip-glute", 3)
+    fire_hydrant = next(ex for ex in progressed["exercises"] if ex["name"] == "Fire hydrant")
+    assert fire_hydrant["note"] == "Progression: +1 set this week"
+
+
+def test_get_routine_for_week_unknown_id_returns_none():
+    assert get_routine_for_week("does-not-exist", 3) is None
+
+
+def test_get_routine_for_week_does_not_mutate_library():
+    """Progression must not leak into the static ROUTINE_LIBRARY or later lookups."""
+    get_routine_for_week("running-base", 9)
+    fresh = get_routine("running-base")
+    baseline_squat = next(ex for ex in fresh["exercises"] if ex["name"] == "Single-leg squat")
+    assert baseline_squat["sets"] == 3
+
+
+def test_all_routine_ids_progress_without_error():
+    for routine_id in ROUTINE_IDS:
+        for week in (1, 3, 5, 8):
+            assert get_routine_for_week(routine_id, week) is not None


### PR DESCRIPTION
Routines hydrated onto a plan day now scale with week_number via
get_routine_for_week (+1 set per exercise every 2 weeks from week 3,
capped at +2) and every exercise carries a demo_url (YouTube search
link) for a form demo, surfaced in the plan routine panel.