### PR TITLE
Refuse startup on unauthenticated public bind (P3-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,15 @@ All settings come from environment variables (see `app/config.py`):
 | `CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD` | — | Required when auth is enabled |
 | `ENCRYPTION_KEY` | — | Fernet key for per-user Garmin passwords |
 | `BIND_HOST` | `127.0.0.1` | Interface uvicorn listens on (must match `--host`); used by the security guard |
+| `ALLOW_INSECURE_BIND` | `false` | Opt out of the startup refusal below (e.g. trusted, firewalled private network) |
 
 > **Safe-default rule:** `AUTH_ENABLED=false` is fine for local development
 > (`BIND_HOST=127.0.0.1`, the default).  If you expose the app on any
 > non-loopback interface — including Docker's `0.0.0.0` — you **must** set
 > `AUTH_ENABLED=true` and configure Cloudflare Access.  The app logs a
-> `CRITICAL` warning at startup when it detects the unsafe combination.
+> `CRITICAL` warning and **refuses to start** when it detects the unsafe
+> combination; set `ALLOW_INSECURE_BIND=true` only if you understand the risk
+> and still want to run that way (e.g. a trusted, firewalled private network).
 
 Generate an encryption key once and keep it stable:
 

--- a/app/config.py
+++ b/app/config.py
@@ -42,6 +42,10 @@ class Settings(BaseSettings):
     # Network binding — used by the startup security guard to detect public exposure
     # without auth.  Must match the --host value passed to uvicorn.
     bind_host: str = "127.0.0.1"
+    # Explicit opt-out for the startup security guard below — set this only if
+    # you understand the risk (e.g. a trusted, firewalled private network) and
+    # still want to run with auth disabled on a non-loopback bind.
+    allow_insecure_bind: bool = False
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/app/main.py
+++ b/app/main.py
@@ -30,13 +30,15 @@ _LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
 
 
 def _check_security_config() -> None:
-    """Warn loudly when auth is disabled on a non-loopback bind address.
+    """Refuse to start when auth is disabled on a non-loopback bind address.
 
     Auth-disabled mode trusts a synthetic dev user for every request — anyone
     who can reach the socket gets full data access.  That is fine on loopback
     (only local processes can connect) but catastrophic on 0.0.0.0 or any
-    public interface.  This guard fires once at startup so the warning appears
-    prominently in logs and container output.
+    public interface.  This guard fires once at startup so the unsafe
+    combination is caught before the app ever accepts a request; set
+    ALLOW_INSECURE_BIND=true to explicitly opt out (e.g. a trusted, firewalled
+    private network) and downgrade this back to a warning.
     """
     if not settings.auth_enabled and settings.bind_host not in _LOOPBACK_HOSTS:
         logger.critical(
@@ -47,9 +49,16 @@ def _check_security_config() -> None:
             "  All user data is publicly readable and writable.\n"
             "  Set AUTH_ENABLED=true (with Cloudflare Access) or restrict\n"
             "  BIND_HOST to 127.0.0.1 before exposing this instance.\n"
+            "  Refusing to start. Set ALLOW_INSECURE_BIND=true to override.\n"
             "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
             settings.bind_host,
         )
+        if not settings.allow_insecure_bind:
+            raise RuntimeError(
+                f"Refusing to start: auth_enabled=False and bind_host={settings.bind_host!r} "
+                "(non-loopback). Set AUTH_ENABLED=true or BIND_HOST=127.0.0.1, or set "
+                "ALLOW_INSECURE_BIND=true to override."
+            )
 
 _libc = None
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -241,9 +241,10 @@ Mobile-first SPA with bottom navigation and an expandable calendar. Routes:
   falls back to a synthetic dev user, so local runs and the test suite work
   without Cloudflare.
 - A **startup security guard** (`_check_security_config` in `app/main.py`) logs a
-  prominent `CRITICAL` warning when `auth_enabled=False` and `bind_host` is not a
-  loopback address — the case where an unauthenticated instance would be publicly
-  readable/writable.
+  prominent `CRITICAL` warning and **refuses to start** when `auth_enabled=False`
+  and `bind_host` is not a loopback address — the case where an unauthenticated
+  instance would be publicly readable/writable. `ALLOW_INSECURE_BIND=true` opts
+  out of the refusal (warning still logs) for trusted, firewalled networks.
 - All API queries and compute paths are scoped by `user_id`; `DEFAULT_USER_ID = 1`
   is the bootstrap account that unscoped/test writes default to. The scheduler
   fans each job out across all Garmin-connected users, isolating per-user
@@ -341,11 +342,10 @@ intentionally absent.
 
 ### Single Bootstrap Tenant in Practice
 The multi-user plumbing (auth, per-user scoping, per-user Garmin credentials) is
-in place, and a startup guard now warns on unauthenticated public binds, but the
-common deployment is still single-tenant (env `GARMIN_EMAIL/PASSWORD` seeds user
-#1, and `auth_enabled` defaults to `False`). The guard *warns* rather than refuses
-to start, so a misconfigured public instance with auth disabled would still leak
-all data.
+in place, and a startup guard now refuses to start on unauthenticated public
+binds (opt-out via `ALLOW_INSECURE_BIND=true`), but the common deployment is
+still single-tenant (env `GARMIN_EMAIL/PASSWORD` seeds user #1, and
+`auth_enabled` defaults to `False`).
 
 ### AI Output Still Model-Dependent
 Plan generation now uses structured output with a fence-stripping fallback, and the

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -329,10 +329,16 @@ badges replace the old client-side duplicate banding, plus a recommendation line
   (`useCustomChartMetrics`, `useCustomChartData`),
   `frontend/src/components/trends/CustomChartsView.tsx` + `.css` (new), `TrendsView.tsx`
   (new "Custom" tab), `tests/test_custom_charts.py` (new, 9 tests).
-- **P3-4 · Security default hardening.** The startup guard *warns* on an
-  unauthenticated non-loopback bind but still starts; consider **refusing** to start in
-  that configuration (opt-out env for trusted private networks). **S.** Files:
-  `app/main.py`, `app/config.py`, docs.
+- **P3-4 · Security default hardening** ✅ DONE (2026-07-01). The startup guard
+  *warned* on an unauthenticated non-loopback bind but still started; it now
+  **refuses to start** in that configuration (`RuntimeError` raised from
+  `_check_security_config`, surfaced through the FastAPI `lifespan` before any
+  request is served), with a new `ALLOW_INSECURE_BIND` opt-out env var for
+  trusted private networks that still logs the `CRITICAL` warning but lets the
+  app continue. **S.** Files: `app/config.py` (`Settings.allow_insecure_bind`),
+  `app/main.py` (`_check_security_config` raises unless overridden),
+  `tests/test_main.py` (refusal + opt-out coverage), `README.md`,
+  `docs/CURRENT_STATE.md`.
 - **P3-5 · Keep the suite green.** New surfaces (chat tool-use, weather, daily
   adaptation, GPX) need contract/edge tests; preserve the 80% coverage gate (~551
   backend tests today). **Throughout.** Files: `tests/`.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -179,12 +179,15 @@ def test_spa_catch_all_rejects_api_paths():
 
 # --- _check_security_config ------------------------------------------------
 
-def test_security_guard_warns_when_auth_disabled_on_public_host(monkeypatch, caplog):
+def test_security_guard_refuses_when_auth_disabled_on_public_host(monkeypatch, caplog):
     import logging
+    import pytest
     monkeypatch.setattr(main.settings, "auth_enabled", False)
     monkeypatch.setattr(main.settings, "bind_host", "0.0.0.0")
+    monkeypatch.setattr(main.settings, "allow_insecure_bind", False)
     with caplog.at_level(logging.CRITICAL, logger="app.main"):
-        main._check_security_config()
+        with pytest.raises(RuntimeError, match="Refusing to start"):
+            main._check_security_config()
     assert any("SECURITY WARNING" in r.message for r in caplog.records)
     assert any(r.levelno == logging.CRITICAL for r in caplog.records)
 
@@ -192,6 +195,7 @@ def test_security_guard_warns_when_auth_disabled_on_public_host(monkeypatch, cap
 def test_security_guard_silent_when_auth_disabled_on_loopback(monkeypatch, caplog):
     import logging
     monkeypatch.setattr(main.settings, "auth_enabled", False)
+    monkeypatch.setattr(main.settings, "allow_insecure_bind", False)
     for host in ("127.0.0.1", "::1", "localhost"):
         caplog.clear()
         monkeypatch.setattr(main.settings, "bind_host", host)
@@ -206,6 +210,18 @@ def test_security_guard_silent_when_auth_enabled_on_public_host(monkeypatch, cap
     import logging
     monkeypatch.setattr(main.settings, "auth_enabled", True)
     monkeypatch.setattr(main.settings, "bind_host", "0.0.0.0")
+    monkeypatch.setattr(main.settings, "allow_insecure_bind", False)
     with caplog.at_level(logging.CRITICAL, logger="app.main"):
         main._check_security_config()
     assert not any(r.levelno == logging.CRITICAL for r in caplog.records)
+
+
+def test_security_guard_warns_but_continues_when_insecure_bind_allowed(monkeypatch, caplog):
+    import logging
+    monkeypatch.setattr(main.settings, "auth_enabled", False)
+    monkeypatch.setattr(main.settings, "bind_host", "0.0.0.0")
+    monkeypatch.setattr(main.settings, "allow_insecure_bind", True)
+    with caplog.at_level(logging.CRITICAL, logger="app.main"):
+        main._check_security_config()  # must not raise
+    assert any("SECURITY WARNING" in r.message for r in caplog.records)
+    assert any(r.levelno == logging.CRITICAL for r in caplog.records)


### PR DESCRIPTION
The security guard previously only warned when auth_enabled=False and
bind_host was non-loopback, letting a misconfigured public instance leak
all data. It now raises during startup unless ALLOW_INSECURE_BIND=true is
set for trusted, firewalled deployments that accept the risk.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YRaSdhuycJ78EGJtyyWH2c