### PR TITLE
Implement P0-2: personal records & peak performances

### DIFF
--- a/alembic/versions/n7o8p9q0r1s2_add_personal_records.py
+++ b/alembic/versions/n7o8p9q0r1s2_add_personal_records.py
@@ -1,0 +1,52 @@
+"""add personal_records table
+
+Revision ID: n7o8p9q0r1s2
+Revises: m6n7o8p9q0r1
+Create Date: 2026-07-04
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision: str = "n7o8p9q0r1s2"
+down_revision: Union[str, None] = "m6n7o8p9q0r1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    insp = inspect(op.get_bind())
+    existing = insp.get_table_names()
+
+    if "personal_records" not in existing:
+        op.create_table(
+            "personal_records",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("user_id", sa.Integer(), nullable=False, default=1),
+            sa.Column("record_type", sa.String(20), nullable=False),
+            sa.Column("metric", sa.String(20), nullable=True),
+            sa.Column("duration_sec", sa.Integer(), nullable=True),
+            sa.Column("distance_label", sa.Text(), nullable=True),
+            sa.Column("value", sa.Float(), nullable=False),
+            sa.Column("previous_value", sa.Float(), nullable=True),
+            sa.Column("activity_id", sa.Integer(), nullable=False),
+            sa.Column("achieved_at", sa.DateTime(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+        )
+        op.create_index("ix_personal_records_user_id", "personal_records", ["user_id"])
+        op.create_index("ix_personal_records_record_type", "personal_records", ["record_type"])
+        op.create_index("ix_personal_records_activity_id", "personal_records", ["activity_id"])
+        op.create_index("ix_personal_records_achieved_at", "personal_records", ["achieved_at"])
+        op.create_index("ix_personal_records_created_at", "personal_records", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_personal_records_created_at", "personal_records")
+    op.drop_index("ix_personal_records_achieved_at", "personal_records")
+    op.drop_index("ix_personal_records_activity_id", "personal_records")
+    op.drop_index("ix_personal_records_record_type", "personal_records")
+    op.drop_index("ix_personal_records_user_id", "personal_records")
+    op.drop_table("personal_records")

--- a/app/coach/chat.py
+++ b/app/coach/chat.py
@@ -104,6 +104,7 @@ def _build_chat_context(
                 zc["pace"],
                 zc["threshold_hr"],
                 zc["threshold_pace"],
+                db=db,
             )
             trigger_data = (
                 f"The athlete is asking about a specific activity:\n\n{activity_context}"

--- a/app/coach/context.py
+++ b/app/coach/context.py
@@ -13,6 +13,7 @@ from sqlalchemy import func
 from app import training_load
 from app import threshold as threshold_mod
 from app import intensity as intensity_mod
+from app import records as records_mod
 from app import weather as weather_mod
 from app.models import (
     DEFAULT_USER_ID,
@@ -97,6 +98,7 @@ def _format_activity_context(
     pace_zone_configs: list[ZoneConfig] | None = None,
     threshold_hr: int | None = None,
     threshold_pace: float | None = None,
+    db: Session | None = None,
 ) -> str:
     parts = [
         f"**{activity.name}** ({activity.activity_type})",
@@ -269,6 +271,17 @@ def _format_activity_context(
             )
             if wx_desc:
                 parts.append(f"Weather: {wx_desc}")
+        except Exception:
+            pass
+
+    # Personal records set by this activity (app.records)
+    if db is not None and activity.id:
+        try:
+            pr_context = records_mod.format_activity_pr_context(
+                db, activity.id, user_id=activity.user_id or DEFAULT_USER_ID
+            )
+            if pr_context:
+                parts.append(pr_context)
         except Exception:
             pass
 

--- a/app/coach/jobs.py
+++ b/app/coach/jobs.py
@@ -123,6 +123,7 @@ def analyze_activity(activity: Activity):
                 activity, zones_by_metric,
                 hr_zone_configs=zc["hr"], pace_zone_configs=zc["pace"],
                 threshold_hr=zc["threshold_hr"], threshold_pace=zc["threshold_pace"],
+                db=db,
             )
 
             # Append workout adherence section if a workout was scheduled for this date
@@ -227,6 +228,7 @@ def analyze_activity_force(activity_id: int):
                 activity, zones_by_metric,
                 hr_zone_configs=zc["hr"], pace_zone_configs=zc["pace"],
                 threshold_hr=zc["threshold_hr"], threshold_pace=zc["threshold_pace"],
+                db=db,
             )
             full_context = _build_context(
                 db, "activity", activity_context, reference_date=activity_date, user_id=user_id

--- a/app/coach/plans.py
+++ b/app/coach/plans.py
@@ -899,6 +899,7 @@ def weekly_review(user_id: int = DEFAULT_USER_ID):
                     a, zones_by_metric,
                     hr_zone_configs=zc["hr"], pace_zone_configs=zc["pace"],
                     threshold_hr=zc["threshold_hr"], threshold_pace=zc["threshold_pace"],
+                    db=db,
                 )
                 for a in week_activities
             )

--- a/app/garmin_sync.py
+++ b/app/garmin_sync.py
@@ -9,7 +9,7 @@ from datetime import datetime, date, timedelta, timezone
 from garminconnect import Garmin
 from sqlalchemy.orm import Session
 
-from app import crypto, streams
+from app import crypto, records, streams
 from app.config import settings
 from app.database import db_session
 from app.models import (
@@ -627,6 +627,10 @@ def sync_activities(user: User | None = None) -> list[Activity]:
                 )
                 if activity:
                     new_activities.append(activity)
+                    try:
+                        records.detect_new_records_for_activity(db, activity, user_id=uid)
+                    except Exception:
+                        logger.exception("Personal-record detection failed for activity %s", activity.id)
 
             _set_sync_status(
                 db, "last_activity_sync", datetime.now(timezone.utc).isoformat(), user_id=uid
@@ -936,6 +940,15 @@ def backfill_activities():
 
             _set_sync_status(db, "backfill_activities", "complete", user_id=uid)
             logger.info("Activity backfill complete")
+
+            # Backfill pages arrive newest-first, so per-activity PR detection
+            # during the loop above would compare each activity against an
+            # incomplete history. Rebuild the full record history in one
+            # chronological pass now that every activity is stored.
+            try:
+                records.rebuild_personal_records(db, user_id=uid)
+            except Exception:
+                logger.exception("Personal-record rebuild failed after backfill")
 
         except Exception:
             logger.exception("Activity backfill failed")

--- a/app/models.py
+++ b/app/models.py
@@ -458,6 +458,32 @@ class DailyLoadSeries(Base):
     computed_at = Column(DateTime, default=_utcnow)
 
 
+class PersonalRecord(Base):
+    """A detected all-time best, appended whenever an activity beats prior history.
+
+    Two kinds share the table: duration-based bests (power/gap_speed mean-max at
+    a standard duration, e.g. "5-min power") and distance-based race bests (best
+    time over a standard race distance, e.g. "5K"). Append-only — each broken
+    record is a new row referencing the value it beat — so both "current bests"
+    (latest row per key) and a recent-history feed ("last 90 days") come from the
+    same table.
+    """
+
+    __tablename__ = "personal_records"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
+    record_type = Column(String(20), nullable=False, index=True)   # "duration" | "distance"
+    metric = Column(String(20), nullable=True)                      # "power" | "gap_speed" (duration only)
+    duration_sec = Column(Integer, nullable=True)                   # duration key (duration records only)
+    distance_label = Column(Text, nullable=True)                    # "5K" etc. (distance records only)
+    value = Column(Float, nullable=False)                           # W, m/s, or seconds (distance records)
+    previous_value = Column(Float, nullable=True)
+    activity_id = Column(Integer, nullable=False, index=True)       # → Activity.id
+    achieved_at = Column(DateTime, nullable=False, index=True)      # activity.started_at
+    created_at = Column(DateTime, default=_utcnow, index=True)
+
+
 class TrainingPlanDay(Base):
     """One scheduled day within a TrainingPlan."""
 

--- a/app/records.py
+++ b/app/records.py
@@ -1,0 +1,326 @@
+"""Personal records / peak-performance detection.
+
+Detects when a synced activity sets a new all-time best against the athlete's
+own history, using data already computed elsewhere: the per-activity
+mean-maximal curve (see :mod:`app.streams`, stored on ``Activity.mean_max_json``)
+for duration-based bests (best sustained power / grade-adjusted pace at each
+standard duration), and ``Activity.distance_m``/``duration_sec`` for
+race-distance bests (best time over a standard race distance). Pure detection
+over stored data — no new sync.
+
+Two entry points:
+
+- :func:`detect_new_records_for_activity` — incremental, called right after a
+  single new activity is stored during live sync. Compares only against
+  activities that happened *before* it (by ``started_at``), so a late-arriving
+  activity for a past date can't be mistaken for a new best.
+- :func:`rebuild_personal_records` — full replay in chronological order, used
+  once after a historical backfill completes. Backfill pages arrive
+  newest-first, so per-activity incremental detection during backfill would
+  compare each activity against an incomplete history.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.models import DEFAULT_USER_ID, Activity, PersonalRecord
+
+logger = logging.getLogger(__name__)
+
+DURATION_METRICS = ("power", "gap_speed")
+
+RACE_DISTANCES = [
+    ("5K", 5000.0),
+    ("10K", 10000.0),
+    ("Half Marathon", 21097.5),
+    ("Marathon", 42195.0),
+]
+# An activity's distance within +/-2% of a standard race distance counts as an
+# effort at that distance (GPS/course measurement noise), same tolerance style
+# used elsewhere in the codebase for matching against nominal distances.
+RACE_DISTANCE_TOLERANCE = 0.02
+
+
+def _is_run(activity_type: str | None) -> bool:
+    if not activity_type:
+        return False
+    t = activity_type.lower()
+    return "run" in t or "treadmill" in t
+
+
+def _duration_curve(activity: Activity, metric: str) -> dict[int, float]:
+    if not activity.mean_max_json:
+        return {}
+    try:
+        curve = json.loads(activity.mean_max_json)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    sub = curve.get(metric) or {}
+    out: dict[int, float] = {}
+    for dur_str, val in sub.items():
+        try:
+            out[int(dur_str)] = float(val)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def _race_distance_match(distance_m: float | None) -> str | None:
+    """Standard race-distance label this activity's distance matches, if any."""
+    if not distance_m:
+        return None
+    for label, dist_m in RACE_DISTANCES:
+        if abs(distance_m - dist_m) <= dist_m * RACE_DISTANCE_TOLERANCE:
+            return label
+    return None
+
+
+@dataclass
+class _BestState:
+    """Running best-so-far, keyed by (metric, duration) and by distance label."""
+
+    duration_best: dict[tuple[str, int], float] = field(default_factory=dict)
+    distance_best: dict[str, float] = field(default_factory=dict)
+
+
+def _accumulate(state: _BestState, activity: Activity) -> None:
+    """Fold ``activity`` into ``state`` without generating any records."""
+    if not _is_run(activity.activity_type) or not activity.started_at:
+        return
+    for metric in DURATION_METRICS:
+        for duration, value in _duration_curve(activity, metric).items():
+            key = (metric, duration)
+            if value > state.duration_best.get(key, float("-inf")):
+                state.duration_best[key] = value
+    label = _race_distance_match(activity.distance_m)
+    if label and activity.duration_sec:
+        if activity.duration_sec < state.distance_best.get(label, float("inf")):
+            state.distance_best[label] = activity.duration_sec
+
+
+def _check_and_record(
+    activity: Activity, state: _BestState, user_id: int
+) -> list[PersonalRecord]:
+    """Compare ``activity`` against ``state``, returning new records and advancing ``state``."""
+    if not _is_run(activity.activity_type) or not activity.started_at:
+        return []
+
+    records: list[PersonalRecord] = []
+
+    for metric in DURATION_METRICS:
+        for duration, value in _duration_curve(activity, metric).items():
+            key = (metric, duration)
+            prior_best = state.duration_best.get(key)
+            if prior_best is None or value > prior_best:
+                records.append(PersonalRecord(
+                    user_id=user_id,
+                    record_type="duration",
+                    metric=metric,
+                    duration_sec=duration,
+                    value=value,
+                    previous_value=prior_best,
+                    activity_id=activity.id,
+                    achieved_at=activity.started_at,
+                ))
+                state.duration_best[key] = value
+
+    label = _race_distance_match(activity.distance_m)
+    if label and activity.duration_sec:
+        prior_best = state.distance_best.get(label)
+        if prior_best is None or activity.duration_sec < prior_best:
+            records.append(PersonalRecord(
+                user_id=user_id,
+                record_type="distance",
+                distance_label=label,
+                value=activity.duration_sec,
+                previous_value=prior_best,
+                activity_id=activity.id,
+                achieved_at=activity.started_at,
+            ))
+            state.distance_best[label] = activity.duration_sec
+
+    return records
+
+
+def detect_new_records_for_activity(
+    db: Session, activity: Activity, user_id: int = DEFAULT_USER_ID
+) -> list[PersonalRecord]:
+    """Detect and persist any new bests set by a single newly-synced activity.
+
+    Compares only against activities that started strictly before this one, so
+    it stays correct regardless of what order activities are synced in.
+    """
+    if not activity.started_at:
+        return []
+    prior = (
+        db.query(Activity)
+        .filter(
+            Activity.user_id == user_id,
+            Activity.id != activity.id,
+            Activity.started_at.isnot(None),
+            Activity.started_at < activity.started_at,
+        )
+        .all()
+    )
+    state = _BestState()
+    for a in prior:
+        _accumulate(state, a)
+
+    new_records = _check_and_record(activity, state, user_id)
+    if new_records:
+        db.add_all(new_records)
+        db.commit()
+        for r in new_records:
+            db.refresh(r)
+    return new_records
+
+
+def rebuild_personal_records(db: Session, user_id: int = DEFAULT_USER_ID) -> int:
+    """Recompute the full personal-record history in chronological order.
+
+    Clears existing records for the user and replays every activity oldest to
+    newest, so each is checked only against what truly preceded it. Used once
+    after a historical backfill (whose activities land newest-page-first, so
+    per-activity incremental detection during backfill would be unreliable).
+    """
+    db.query(PersonalRecord).filter(PersonalRecord.user_id == user_id).delete()
+
+    activities = (
+        db.query(Activity)
+        .filter(Activity.user_id == user_id, Activity.started_at.isnot(None))
+        .order_by(Activity.started_at.asc())
+        .all()
+    )
+
+    state = _BestState()
+    created = 0
+    for activity in activities:
+        new_records = _check_and_record(activity, state, user_id)
+        if new_records:
+            db.add_all(new_records)
+            created += len(new_records)
+
+    db.commit()
+    logger.info("Rebuilt personal records for user %s: %d records", user_id, created)
+    return created
+
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+def get_current_bests(db: Session, user_id: int = DEFAULT_USER_ID) -> list[PersonalRecord]:
+    """The current (latest) record per duration/distance key — the all-time bests."""
+    all_records = (
+        db.query(PersonalRecord)
+        .filter(PersonalRecord.user_id == user_id)
+        .order_by(PersonalRecord.achieved_at.asc())
+        .all()
+    )
+    latest: dict[tuple, PersonalRecord] = {}
+    for r in all_records:
+        key = (r.record_type, r.metric, r.duration_sec, r.distance_label)
+        latest[key] = r  # ascending order => the last write per key is the current best
+    return list(latest.values())
+
+
+def get_recent_records(
+    db: Session, user_id: int = DEFAULT_USER_ID, days: int = 90
+) -> list[PersonalRecord]:
+    """Records achieved within the last ``days`` days, most recent first."""
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    return (
+        db.query(PersonalRecord)
+        .filter(PersonalRecord.user_id == user_id, PersonalRecord.achieved_at >= cutoff)
+        .order_by(PersonalRecord.achieved_at.desc())
+        .all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+def _format_duration_label(duration_sec: int) -> str:
+    if duration_sec < 60:
+        return f"{duration_sec}-sec"
+    mins = duration_sec / 60
+    return f"{int(mins)}-min" if mins == int(mins) else f"{mins:.1f}-min"
+
+
+def _format_pace_from_speed(speed_ms: float | None) -> str:
+    if not speed_ms or speed_ms <= 0:
+        return "n/a"
+    pace_min_km = (1000.0 / speed_ms) / 60.0
+    m = int(pace_min_km)
+    s = int(round((pace_min_km - m) * 60))
+    if s == 60:
+        m += 1
+        s = 0
+    return f"{m}:{s:02d}/km"
+
+
+def _format_race_time(seconds: float | None) -> str:
+    if seconds is None:
+        return "n/a"
+    seconds = int(round(seconds))
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
+def _format_duration_value(metric: str, value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.0f} W" if metric == "power" else _format_pace_from_speed(value)
+
+
+def record_label(record: PersonalRecord) -> str:
+    """Short human-readable label for a record, e.g. '20-min power' or 'Half Marathon'."""
+    if record.record_type == "duration":
+        metric_label = "power" if record.metric == "power" else "GAP-pace"
+        return f"{_format_duration_label(record.duration_sec)} {metric_label}"
+    return record.distance_label or ""
+
+
+def record_display_value(record: PersonalRecord) -> str:
+    """Formatted value for a record, e.g. '320 W' or '1:32:10'."""
+    if record.record_type == "duration":
+        return _format_duration_value(record.metric, record.value)
+    return _format_race_time(record.value)
+
+
+def format_record_line(record: PersonalRecord) -> str:
+    """One human-readable line describing a single PersonalRecord."""
+    if record.record_type == "duration":
+        label = _format_duration_label(record.duration_sec)
+        metric_label = "power" if record.metric == "power" else "GAP-pace"
+        line = f"New {label} {metric_label} best: {_format_duration_value(record.metric, record.value)}"
+        if record.previous_value is not None:
+            line += f" (previous: {_format_duration_value(record.metric, record.previous_value)})"
+        return line
+    line = f"New {record.distance_label} best: {_format_race_time(record.value)}"
+    if record.previous_value is not None:
+        line += f" (previous: {_format_race_time(record.previous_value)})"
+    return line
+
+
+def format_activity_pr_context(
+    db: Session, activity_id: int, user_id: int = DEFAULT_USER_ID
+) -> str:
+    """Markdown block summarizing PRs set by one activity, for the AI context."""
+    records = (
+        db.query(PersonalRecord)
+        .filter(PersonalRecord.user_id == user_id, PersonalRecord.activity_id == activity_id)
+        .all()
+    )
+    if not records:
+        return ""
+    lines = "\n".join(f"- {format_record_line(r)}" for r in records)
+    return "**Personal Records set in this activity — clear fitness signal:**\n" + lines

--- a/app/records.py
+++ b/app/records.py
@@ -211,6 +211,36 @@ def rebuild_personal_records(db: Session, user_id: int = DEFAULT_USER_ID) -> int
     return created
 
 
+def ensure_records_backfilled(db: Session, user_id: int = DEFAULT_USER_ID) -> None:
+    """Lazily mine full history the first time records are requested.
+
+    ``rebuild_personal_records`` normally runs once, right after a historical
+    Garmin backfill completes. Accounts that finished their backfill before
+    this feature existed never got that call, so their pre-existing activities
+    would otherwise never be checked. Mirrors the self-healing pattern used
+    elsewhere in this module (e.g. ``streams.backfill_missing_curves``): the
+    first request pays the one-time cost of a full chronological pass; every
+    request after that sees records already exist and is a single indexed
+    lookup.
+    """
+    has_records = (
+        db.query(PersonalRecord.id).filter(PersonalRecord.user_id == user_id).first()
+    )
+    if has_records is not None:
+        return
+    has_history = (
+        db.query(Activity.id)
+        .filter(Activity.user_id == user_id, Activity.started_at.isnot(None))
+        .first()
+    )
+    if has_history is None:
+        return
+    try:
+        rebuild_personal_records(db, user_id=user_id)
+    except Exception:
+        logger.exception("Lazy personal-record backfill failed for user %s", user_id)
+
+
 # ---------------------------------------------------------------------------
 # Queries
 # ---------------------------------------------------------------------------

--- a/app/records.py
+++ b/app/records.py
@@ -4,9 +4,11 @@ Detects when a synced activity sets a new all-time best against the athlete's
 own history, using data already computed elsewhere: the per-activity
 mean-maximal curve (see :mod:`app.streams`, stored on ``Activity.mean_max_json``)
 for duration-based bests (best sustained power / grade-adjusted pace at each
-standard duration), and ``Activity.distance_m``/``duration_sec`` for
-race-distance bests (best time over a standard race distance). Pure detection
-over stored data — no new sync.
+standard duration) and Strava-style "Best Efforts" (fastest time to cover each
+standard race distance anywhere within the activity, also in ``mean_max_json``
+as ``distance_efforts`` — so a half marathon race yields a 5K and 10K best
+effort too, not just a Half Marathon one). Pure detection over stored data —
+no new sync.
 
 Two entry points:
 
@@ -25,26 +27,24 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
-from app.models import DEFAULT_USER_ID, Activity, PersonalRecord
+from app import streams
+from app.models import DEFAULT_USER_ID, Activity, PersonalRecord, SyncStatus
 
 logger = logging.getLogger(__name__)
 
 DURATION_METRICS = ("power", "gap_speed")
 
-RACE_DISTANCES = [
-    ("5K", 5000.0),
-    ("10K", 10000.0),
-    ("Half Marathon", 21097.5),
-    ("Marathon", 42195.0),
-]
-# An activity's distance within +/-2% of a standard race distance counts as an
-# effort at that distance (GPS/course measurement noise), same tolerance style
-# used elsewhere in the codebase for matching against nominal distances.
-RACE_DISTANCE_TOLERANCE = 0.02
+# Canonical chip order for the UI — Strava's "Best Efforts" distance set.
+RACE_DISTANCE_LABELS = [label for label, _ in streams.RACE_DISTANCES_M]
+
+# Bumped whenever the record-detection logic changes in a way that requires
+# re-mining existing history (see ensure_records_backfilled).
+_BACKFILL_STATUS_KEY = "personal_records_backfill_version"
+_BACKFILL_VERSION = 2  # v2: Strava-style rolling-window distance-effort bests
 
 
 def _is_run(activity_type: str | None) -> bool:
@@ -71,14 +71,20 @@ def _duration_curve(activity: Activity, metric: str) -> dict[int, float]:
     return out
 
 
-def _race_distance_match(distance_m: float | None) -> str | None:
-    """Standard race-distance label this activity's distance matches, if any."""
-    if not distance_m:
-        return None
-    for label, dist_m in RACE_DISTANCES:
-        if abs(distance_m - dist_m) <= dist_m * RACE_DISTANCE_TOLERANCE:
-            return label
-    return None
+def _distance_efforts(activity: Activity) -> dict[str, float]:
+    """This activity's fastest time at each standard race distance, if any."""
+    if not activity.mean_max_json:
+        return {}
+    try:
+        curve = json.loads(activity.mean_max_json)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    efforts = curve.get("distance_efforts") or {}
+    return {
+        label: float(seconds)
+        for label, seconds in efforts.items()
+        if isinstance(seconds, (int, float))
+    }
 
 
 @dataclass
@@ -98,10 +104,9 @@ def _accumulate(state: _BestState, activity: Activity) -> None:
             key = (metric, duration)
             if value > state.duration_best.get(key, float("-inf")):
                 state.duration_best[key] = value
-    label = _race_distance_match(activity.distance_m)
-    if label and activity.duration_sec:
-        if activity.duration_sec < state.distance_best.get(label, float("inf")):
-            state.distance_best[label] = activity.duration_sec
+    for label, seconds in _distance_efforts(activity).items():
+        if seconds < state.distance_best.get(label, float("inf")):
+            state.distance_best[label] = seconds
 
 
 def _check_and_record(
@@ -130,20 +135,19 @@ def _check_and_record(
                 ))
                 state.duration_best[key] = value
 
-    label = _race_distance_match(activity.distance_m)
-    if label and activity.duration_sec:
+    for label, seconds in _distance_efforts(activity).items():
         prior_best = state.distance_best.get(label)
-        if prior_best is None or activity.duration_sec < prior_best:
+        if prior_best is None or seconds < prior_best:
             records.append(PersonalRecord(
                 user_id=user_id,
                 record_type="distance",
                 distance_label=label,
-                value=activity.duration_sec,
+                value=seconds,
                 previous_value=prior_best,
                 activity_id=activity.id,
                 achieved_at=activity.started_at,
             ))
-            state.distance_best[label] = activity.duration_sec
+            state.distance_best[label] = seconds
 
     return records
 
@@ -212,33 +216,50 @@ def rebuild_personal_records(db: Session, user_id: int = DEFAULT_USER_ID) -> int
 
 
 def ensure_records_backfilled(db: Session, user_id: int = DEFAULT_USER_ID) -> None:
-    """Lazily mine full history the first time records are requested.
+    """Lazily (re)mine full history when the detection logic version advances.
 
     ``rebuild_personal_records`` normally runs once, right after a historical
     Garmin backfill completes. Accounts that finished their backfill before
-    this feature existed never got that call, so their pre-existing activities
-    would otherwise never be checked. Mirrors the self-healing pattern used
-    elsewhere in this module (e.g. ``streams.backfill_missing_curves``): the
-    first request pays the one-time cost of a full chronological pass; every
-    request after that sees records already exist and is a single indexed
-    lookup.
+    this feature existed (or before a later change to how records are
+    detected) never got that call, so their pre-existing activities would
+    otherwise never be (re)checked. A ``SyncStatus`` row tracks the backfill
+    version this user's records were last built with; a mismatch triggers a
+    one-time re-mine: recompute any activity curves missing distance-effort
+    data, then replay full history in chronological order. Mirrors the
+    self-healing pattern used elsewhere (e.g. ``streams.backfill_missing_curves``)
+    — the first request after a version bump pays the one-time cost; every
+    request after that is a single indexed lookup.
     """
-    has_records = (
-        db.query(PersonalRecord.id).filter(PersonalRecord.user_id == user_id).first()
+    status = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == user_id, SyncStatus.key == _BACKFILL_STATUS_KEY)
+        .first()
     )
-    if has_records is not None:
+    current_version = int(status.value) if status and status.value else 0
+    if current_version >= _BACKFILL_VERSION:
         return
     has_history = (
         db.query(Activity.id)
         .filter(Activity.user_id == user_id, Activity.started_at.isnot(None))
         .first()
     )
-    if has_history is None:
-        return
-    try:
-        rebuild_personal_records(db, user_id=user_id)
-    except Exception:
-        logger.exception("Lazy personal-record backfill failed for user %s", user_id)
+    if has_history is not None:
+        try:
+            streams.backfill_missing_distance_efforts(db, user_id=user_id)
+            rebuild_personal_records(db, user_id=user_id)
+        except Exception:
+            logger.exception("Lazy personal-record backfill failed for user %s", user_id)
+            return  # leave the version stale so the next request retries
+
+    if status:
+        status.value = str(_BACKFILL_VERSION)
+        status.updated_at = datetime.now(timezone.utc)
+    else:
+        db.add(SyncStatus(
+            user_id=user_id, key=_BACKFILL_STATUS_KEY, value=str(_BACKFILL_VERSION),
+            updated_at=datetime.now(timezone.utc),
+        ))
+    db.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -271,6 +292,32 @@ def get_recent_records(
         .order_by(PersonalRecord.achieved_at.desc())
         .all()
     )
+
+
+def get_distance_top_n(
+    db: Session, user_id: int = DEFAULT_USER_ID, top_n: int = 3
+) -> dict[str, list[PersonalRecord]]:
+    """Top-``top_n`` historical bests per race distance, fastest first.
+
+    ``PersonalRecord`` is append-only and a row is only created when a time
+    actually beats the prior best for that distance, so the sequence of rows
+    for a given distance label is already strictly improving over time — the
+    most-recently-achieved row is the fastest, the one before it is the
+    second-fastest, and so on. Sorting by ``achieved_at`` descending therefore
+    gives the fastest-first rank directly, with no separate ranking query.
+    """
+    all_records = (
+        db.query(PersonalRecord)
+        .filter(PersonalRecord.user_id == user_id, PersonalRecord.record_type == "distance")
+        .order_by(PersonalRecord.achieved_at.desc())
+        .all()
+    )
+    out: dict[str, list[PersonalRecord]] = {}
+    for r in all_records:
+        bucket = out.setdefault(r.distance_label, [])
+        if len(bucket) < top_n:
+            bucket.append(r)
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/app/records.py
+++ b/app/records.py
@@ -29,7 +29,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, load_only
 
 from app import streams
 from app.models import DEFAULT_USER_ID, Activity, PersonalRecord, SyncStatus
@@ -45,6 +45,19 @@ RACE_DISTANCE_LABELS = [label for label, _ in streams.RACE_DISTANCES_M]
 # re-mining existing history (see ensure_records_backfilled).
 _BACKFILL_STATUS_KEY = "personal_records_backfill_version"
 _BACKFILL_VERSION = 2  # v2: Strava-style rolling-window distance-effort bests
+
+
+def _essentials_only():
+    """Column-defer everything a record-detection scan doesn't need.
+
+    Detection only ever reads ``activity_type``, ``started_at``, and
+    ``mean_max_json``. A plain ``db.query(Activity)`` loads the *entire* row —
+    including ``laps_json``/``raw_json``/etc., each of which can run multiple
+    MB per activity — so a full-history scan (``rebuild_personal_records``, or
+    the prior-activities lookup below) would multiply that cost across
+    thousands of rows for no reason.
+    """
+    return load_only(Activity.activity_type, Activity.started_at, Activity.mean_max_json)
 
 
 def _is_run(activity_type: str | None) -> bool:
@@ -164,6 +177,7 @@ def detect_new_records_for_activity(
         return []
     prior = (
         db.query(Activity)
+        .options(_essentials_only())
         .filter(
             Activity.user_id == user_id,
             Activity.id != activity.id,
@@ -197,6 +211,7 @@ def rebuild_personal_records(db: Session, user_id: int = DEFAULT_USER_ID) -> int
 
     activities = (
         db.query(Activity)
+        .options(_essentials_only())
         .filter(Activity.user_id == user_id, Activity.started_at.isnot(None))
         .order_by(Activity.started_at.asc())
         .all()
@@ -225,10 +240,20 @@ def ensure_records_backfilled(db: Session, user_id: int = DEFAULT_USER_ID) -> No
     otherwise never be (re)checked. A ``SyncStatus`` row tracks the backfill
     version this user's records were last built with; a mismatch triggers a
     one-time re-mine: recompute any activity curves missing distance-effort
-    data, then replay full history in chronological order. Mirrors the
-    self-healing pattern used elsewhere (e.g. ``streams.backfill_missing_curves``)
-    — the first request after a version bump pays the one-time cost; every
-    request after that is a single indexed lookup.
+    data, then replay full history in chronological order.
+
+    The curve recompute is done in bounded chunks
+    (``streams.DISTANCE_EFFORTS_BACKFILL_CHUNK``), not all at once: unlike most
+    self-healing backfills in this codebase, this one's target set on first
+    rollout is an account's *entire* history, and each recompute re-parses
+    that activity's full detail stream — doing that for thousands of
+    activities in a single request is what spiked memory and hung a request
+    in production. So each call processes one chunk; if a full chunk was
+    processed there's likely more left, and this returns without advancing
+    the version, so the next request (e.g. reloading the page) picks up where
+    this one left off. Only once a call catches up (processes less than a
+    full chunk) does the chronological replay run and the version get
+    recorded — from then on this is a single indexed lookup.
     """
     status = (
         db.query(SyncStatus)
@@ -245,7 +270,9 @@ def ensure_records_backfilled(db: Session, user_id: int = DEFAULT_USER_ID) -> No
     )
     if has_history is not None:
         try:
-            streams.backfill_missing_distance_efforts(db, user_id=user_id)
+            updated = streams.backfill_missing_distance_efforts(db, user_id=user_id)
+            if updated >= streams.DISTANCE_EFFORTS_BACKFILL_CHUNK:
+                return  # more activities likely still need recomputing
             rebuild_personal_records(db, user_id=user_id)
         except Exception:
             logger.exception("Lazy personal-record backfill failed for user %s", user_id)

--- a/app/routers/_shared.py
+++ b/app/routers/_shared.py
@@ -2,8 +2,9 @@
 from datetime import date, datetime
 
 from app import adherence as adherence_mod
-from app.models import GarminCalendarEvent
-from app.schemas import CalendarEventResponse
+from app import records as records_mod
+from app.models import GarminCalendarEvent, PersonalRecord
+from app.schemas import CalendarEventResponse, PersonalRecordResponse
 
 
 def _parse_date(s: str | None) -> date:
@@ -23,3 +24,20 @@ def _enrich_event_with_steps(event: GarminCalendarEvent) -> CalendarEventRespons
         if steps:
             resp.workout_steps = steps
     return resp
+
+
+def _to_pr_response(r: PersonalRecord) -> PersonalRecordResponse:
+    """Convert a PersonalRecord row to its API response, filling in display fields."""
+    return PersonalRecordResponse(
+        id=r.id,
+        record_type=r.record_type,
+        metric=r.metric,
+        duration_sec=r.duration_sec,
+        distance_label=r.distance_label,
+        value=r.value,
+        previous_value=r.previous_value,
+        activity_id=r.activity_id,
+        achieved_at=r.achieved_at,
+        label=records_mod.record_label(r),
+        display_value=records_mod.record_display_value(r),
+    )

--- a/app/routers/activities.py
+++ b/app/routers/activities.py
@@ -17,6 +17,7 @@ from app.schemas import (
     MetricZoneResponse,
 )
 from app import adherence as adherence_mod
+from app import records as records_mod
 from app import streams as streams_mod
 from app import weather as weather_mod
 from app.utils import safe_json_loads, parse_activity_charts, parse_activity_route
@@ -148,6 +149,7 @@ def api_activity_detail(
         weather, activity.avg_pace_min_km
     )
 
+    records_mod.ensure_records_backfilled(db, user_id=current_user.id)
     personal_records = (
         db.query(PersonalRecord)
         .filter(PersonalRecord.user_id == current_user.id, PersonalRecord.activity_id == activity.id)

--- a/app/routers/activities.py
+++ b/app/routers/activities.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.auth import get_current_user
 from app.database import get_db
-from app.models import Activity, GarminCalendarEvent, Insight, MetricZone, User
+from app.models import Activity, GarminCalendarEvent, Insight, MetricZone, PersonalRecord, User
 from app.schemas import (
     AIJobEnqueuedResponse,
     ActivityDetail,
@@ -20,7 +20,7 @@ from app import adherence as adherence_mod
 from app import streams as streams_mod
 from app import weather as weather_mod
 from app.utils import safe_json_loads, parse_activity_charts, parse_activity_route
-from app.routers._shared import _enrich_event_with_steps
+from app.routers._shared import _enrich_event_with_steps, _to_pr_response
 
 import logging
 
@@ -148,6 +148,12 @@ def api_activity_detail(
         weather, activity.avg_pace_min_km
     )
 
+    personal_records = (
+        db.query(PersonalRecord)
+        .filter(PersonalRecord.user_id == current_user.id, PersonalRecord.activity_id == activity.id)
+        .all()
+    )
+
     result = ActivityDetail.model_validate(activity)
     result.splits = splits
     result.hr_zones = hr_zones
@@ -163,6 +169,7 @@ def api_activity_detail(
     result.weather_adjusted_pace_min_km = wx_adjusted_pace
     result.weather_penalty_sec_per_km = wx_penalty_sec
     result.weather_description = wx_description
+    result.personal_records = [_to_pr_response(r) for r in personal_records] or None
     return result
 
 

--- a/app/routers/trends.py
+++ b/app/routers/trends.py
@@ -144,6 +144,7 @@ def api_personal_records(
     records_mod.ensure_records_backfilled(db, user_id=current_user.id)
     current_bests = records_mod.get_current_bests(db, user_id=current_user.id)
     recent = records_mod.get_recent_records(db, user_id=current_user.id, days=days)
+    distance_top_n = records_mod.get_distance_top_n(db, user_id=current_user.id)
     return PersonalRecordsResponse(
         current_bests=sorted(
             [_to_pr_response(r) for r in current_bests],
@@ -151,6 +152,11 @@ def api_personal_records(
         ),
         recent=[_to_pr_response(r) for r in recent],
         recent_days=days,
+        distance_bests={
+            label: [_to_pr_response(r) for r in recs]
+            for label, recs in distance_top_n.items()
+        },
+        distance_labels=records_mod.RACE_DISTANCE_LABELS,
     )
 
 

--- a/app/routers/trends.py
+++ b/app/routers/trends.py
@@ -141,6 +141,7 @@ def api_personal_records(
     current_user: User = Depends(get_current_user),
 ):
     """All-time bests plus a recent-history feed, for the Peak Performances panel."""
+    records_mod.ensure_records_backfilled(db, user_id=current_user.id)
     current_bests = records_mod.get_current_bests(db, user_id=current_user.id)
     recent = records_mod.get_recent_records(db, user_id=current_user.id, days=days)
     return PersonalRecordsResponse(

--- a/app/routers/trends.py
+++ b/app/routers/trends.py
@@ -20,6 +20,8 @@ from app.schemas import (
     IntensityWeek,
     PerformanceCurvePoint,
     PerformanceCurveResponse,
+    PersonalRecordResponse,
+    PersonalRecordsResponse,
     RacePrediction,
     TrainingLoadResponse,
 )
@@ -27,7 +29,8 @@ from app import training_load
 from app import threshold as threshold_mod
 from app import intensity as intensity_mod
 from app import streams as streams_mod
-from app.routers._shared import _parse_date
+from app import records as records_mod
+from app.routers._shared import _parse_date, _to_pr_response
 
 router = APIRouter()
 
@@ -126,6 +129,27 @@ def api_get_performance_curve(
         ],
         lookback_days=data.lookback_days,
         activities_analyzed=data.activities_analyzed,
+    )
+
+
+# --- Personal Records / Peak Performances ---
+
+@router.get("/personal-records", response_model=PersonalRecordsResponse)
+def api_personal_records(
+    days: int = Query(90, ge=1, le=3650),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """All-time bests plus a recent-history feed, for the Peak Performances panel."""
+    current_bests = records_mod.get_current_bests(db, user_id=current_user.id)
+    recent = records_mod.get_recent_records(db, user_id=current_user.id, days=days)
+    return PersonalRecordsResponse(
+        current_bests=sorted(
+            [_to_pr_response(r) for r in current_bests],
+            key=lambda r: (r.record_type, r.duration_sec or 0, r.distance_label or ""),
+        ),
+        recent=[_to_pr_response(r) for r in recent],
+        recent_days=days,
     )
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -600,6 +600,10 @@ class PersonalRecordsResponse(BaseModel):
     current_bests: list[PersonalRecordResponse] = []
     recent: list[PersonalRecordResponse] = []
     recent_days: int
+    # Race-distance "Best Efforts": label -> top-3 historical bests, fastest first.
+    distance_bests: dict[str, list[PersonalRecordResponse]] = {}
+    # Canonical distance chip order (Strava's set), including labels with no data yet.
+    distance_labels: list[str] = []
 
 
 class AerobicTrendPoint(BaseModel):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -188,6 +188,9 @@ class ActivityDetail(BaseModel):
     # Workout adherence comparison (planned vs actual)
     adherence: "WorkoutAdherence | None" = None
 
+    # Personal records set by this specific activity, if any
+    personal_records: list["PersonalRecordResponse"] | None = None
+
     @field_validator('feedback_tags', mode='before')
     @classmethod
     def parse_feedback_tags(cls, v: Any) -> list[str] | None:
@@ -574,6 +577,29 @@ class PerformanceCurveResponse(BaseModel):
     race_predictions: list[RacePrediction] = []
     lookback_days: int
     activities_analyzed: int
+
+
+class PersonalRecordResponse(BaseModel):
+    id: int
+    record_type: str                        # "duration" | "distance"
+    metric: str | None = None               # "power" | "gap_speed" (duration records only)
+    duration_sec: int | None = None
+    distance_label: str | None = None       # "5K" etc. (distance records only)
+    value: float                            # W, m/s, or seconds (distance records)
+    previous_value: float | None = None
+    activity_id: int
+    achieved_at: datetime
+    label: str                              # human-readable, e.g. "20-min power" or "Half Marathon"
+    display_value: str                      # formatted value, e.g. "320 W" or "1:32:10"
+
+    class Config:
+        from_attributes = True
+
+
+class PersonalRecordsResponse(BaseModel):
+    current_bests: list[PersonalRecordResponse] = []
+    recent: list[PersonalRecordResponse] = []
+    recent_days: int
 
 
 class AerobicTrendPoint(BaseModel):

--- a/app/streams.py
+++ b/app/streams.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import logging
 
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,27 @@ logger = logging.getLogger(__name__)
 STANDARD_DURATIONS: list[int] = [
     5, 15, 30, 60, 120, 180, 300, 480, 600, 720,
     1200, 1800, 2400, 3000, 3600, 5400,
+]
+
+# Standard race distances (meters) at which we look for the fastest contiguous
+# effort anywhere within an activity — Strava's "Best Efforts" set. Unlike the
+# duration-keyed mean-max curve above, this is windowed by *distance*: a half
+# marathon race yields a 5K and 10K best effort too, from whichever contiguous
+# stretch of it was fastest, not just the whole-activity time.
+RACE_DISTANCES_M: list[tuple[str, float]] = [
+    ("400m", 400.0),
+    ("1/2 mile", 804.672),
+    ("1K", 1000.0),
+    ("1 mile", 1609.344),
+    ("2 mile", 3218.688),
+    ("5K", 5000.0),
+    ("10K", 10000.0),
+    ("15K", 15000.0),
+    ("10 mile", 16093.44),
+    ("20K", 20000.0),
+    ("Half Marathon", 21097.5),
+    ("30K", 30000.0),
+    ("Marathon", 42195.0),
 ]
 
 # Spike-rejection caps — anything beyond these is a sensor/GPS glitch for running.
@@ -315,14 +337,94 @@ def _is_treadmill(activity_type: str | None) -> bool:
     return bool(activity_type) and "treadmill" in activity_type.lower()
 
 
+def _best_time_for_distance(
+    time: list[float | None], distance: list[float | None], target_m: float
+) -> float | None:
+    """Minimum elapsed time to cover any contiguous window of ``target_m`` meters.
+
+    Mirrors ``_best_mean``'s two-pointer sweep but keyed on distance instead of
+    duration: as the window start advances, both the cumulative distance and
+    the target end-distance only increase, so the end pointer never needs to
+    move backwards. The exact crossing time is linearly interpolated between
+    the two samples that bracket it, so the result isn't quantized to sample
+    spacing. Returns ``None`` if the stream never covers ``target_m``.
+    """
+    pts = [
+        (t, d)
+        for t, d in zip(time, distance)
+        if isinstance(t, (int, float)) and isinstance(d, (int, float))
+    ]
+    pts.sort(key=lambda p: p[0])
+    # Enforce non-decreasing distance, dropping samples where GPS/footpod noise
+    # made cumulative distance regress (a real reset — e.g. a paused/restarted
+    # recording — would show up as a large gap rather than a small regression).
+    cleaned: list[tuple[float, float]] = []
+    running_max = None
+    for t, d in pts:
+        if running_max is None or d >= running_max:
+            running_max = d
+            cleaned.append((t, d))
+    n = len(cleaned)
+    if n < 2:
+        return None
+    times = [p[0] for p in cleaned]
+    dists = [p[1] for p in cleaned]
+    if dists[-1] - dists[0] < target_m:
+        return None
+
+    best: float | None = None
+    j = 0
+    for i in range(n):
+        if j < i:
+            j = i
+        target_dist = dists[i] + target_m
+        while j < n and dists[j] < target_dist:
+            j += 1
+        if j >= n:
+            break
+        if j == i:
+            continue
+        d0, d1 = dists[j - 1], dists[j]
+        t0, t1 = times[j - 1], times[j]
+        t_at_target = t1 if d1 == d0 else t0 + (target_dist - d0) / (d1 - d0) * (t1 - t0)
+        elapsed = t_at_target - times[i]
+        if elapsed > 0 and (best is None or elapsed < best):
+            best = elapsed
+    return best
+
+
+def compute_distance_efforts(
+    streams: dict[str, list[float | None]], activity_type: str | None = None
+) -> dict[str, float]:
+    """Best (fastest) time to cover each standard race distance, anywhere in the activity.
+
+    Skipped for treadmill activities: footpod/treadmill-belt cumulative distance
+    isn't reliable enough for a race-distance best effort (the same reason
+    GAP-pace frontiers exclude treadmill runs in app.threshold).
+    """
+    if _is_treadmill(activity_type):
+        return {}
+    time = streams.get("time", [])
+    distance = streams.get("distance", [])
+    out: dict[str, float] = {}
+    for label, target_m in RACE_DISTANCES_M:
+        best = _best_time_for_distance(time, distance, target_m)
+        if best is not None:
+            out[label] = round(best, 1)
+    return out
+
+
 def compute_curves_from_details(
     details: dict | None, activity_type: str | None = None
 ) -> dict | None:
     """Compute the mean-maximal curves for one activity from its detail streams.
 
     Returns ``{"power": {dur: w}, "gap_speed": {dur: m/s}, "speed": {...},
-    "hr": {dur: bpm}, "is_treadmill": bool, "duration": seconds}`` or ``None``
-    when streams can't be parsed.
+    "hr": {dur: bpm}, "is_treadmill": bool, "duration": seconds,
+    "distance_efforts": {label: seconds}}`` or ``None`` when streams can't be
+    parsed. ``distance_efforts`` is the fastest time anywhere in the activity
+    covering each standard race distance (Strava's "Best Efforts"), independent
+    of the activity's total distance.
     """
     streams = parse_streams(details)
     if streams is None:
@@ -336,6 +438,7 @@ def compute_curves_from_details(
         "gap_speed": {str(k): v for k, v in mean_max_curve(time, gap).items()},
         "hr": {str(k): v for k, v in mean_max_curve(time, streams["hr"]).items()},
         "is_treadmill": _is_treadmill(activity_type),
+        "distance_efforts": compute_distance_efforts(streams, activity_type),
     }
     valid_times = [t for t in time if isinstance(t, (int, float))]
     result["duration"] = round(max(valid_times) - min(valid_times), 1) if valid_times else 0.0
@@ -576,4 +679,42 @@ def backfill_missing_curves(db: Session, limit: int = 500, user_id: int | None =
     if updated:
         db.commit()
         logger.info("Backfilled mean-max curves for %d activities", updated)
+    return updated
+
+
+def backfill_missing_distance_efforts(db: Session, limit: int = 100_000, user_id: int | None = None) -> int:
+    """Recompute ``mean_max_json`` for activities whose curves predate distance efforts.
+
+    Self-heals databases whose curves were computed before Strava-style
+    rolling-window race-distance bests existed (``distance_efforts`` wasn't a
+    key in ``compute_curves_from_details``'s output yet). Detected by a cheap
+    substring check rather than parsing every row up front. When ``user_id`` is
+    given, only that user's activities are processed.
+    """
+    from app.models import Activity
+
+    query = db.query(Activity).filter(
+        Activity.laps_json.isnot(None),
+        or_(
+            Activity.mean_max_json.is_(None),
+            ~Activity.mean_max_json.like("%distance_efforts%"),
+        ),
+    )
+    if user_id is not None:
+        query = query.filter(Activity.user_id == user_id)
+    rows = query.order_by(Activity.started_at.desc()).limit(limit).all()
+
+    updated = 0
+    for act in rows:
+        try:
+            details = json.loads(act.laps_json)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        curves = compute_curves_from_details(details, act.activity_type)
+        if curves:
+            act.mean_max_json = json.dumps(curves)
+            updated += 1
+    if updated:
+        db.commit()
+        logger.info("Backfilled distance efforts for %d activities", updated)
     return updated

--- a/app/streams.py
+++ b/app/streams.py
@@ -23,7 +23,7 @@ import json
 import logging
 
 from sqlalchemy import or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, load_only
 
 logger = logging.getLogger(__name__)
 
@@ -656,8 +656,14 @@ def backfill_missing_curves(db: Session, limit: int = 500, user_id: int | None =
     """
     from app.models import Activity
 
-    query = db.query(Activity).filter(
-        Activity.mean_max_json.is_(None), Activity.laps_json.isnot(None)
+    query = (
+        db.query(Activity)
+        # Defer every other column: raw_json/splits_json/weather_json/etc. can
+        # each be substantial, and loading them for rows we only need
+        # activity_type + laps_json + mean_max_json from multiplies memory use
+        # across a whole-history scan for nothing.
+        .options(load_only(Activity.activity_type, Activity.laps_json, Activity.mean_max_json))
+        .filter(Activity.mean_max_json.is_(None), Activity.laps_json.isnot(None))
     )
     if user_id is not None:
         query = query.filter(Activity.user_id == user_id)
@@ -682,23 +688,42 @@ def backfill_missing_curves(db: Session, limit: int = 500, user_id: int | None =
     return updated
 
 
-def backfill_missing_distance_efforts(db: Session, limit: int = 100_000, user_id: int | None = None) -> int:
+# Kept small on purpose: unlike backfill_missing_curves (whose target set is
+# normally a handful of stragglers from before curve computation existed),
+# the first rollout of distance efforts matches an account's *entire* activity
+# history at once, and each recompute re-parses that activity's full detail
+# stream (laps_json, which can run multiple MB for a long run with dense
+# chart/GPS sampling). A large batch of those loaded and parsed at once is
+# exactly what spiked memory into the GBs and hung a request in production —
+# this bounds peak memory per call; ensure_records_backfilled spreads the
+# remaining work across subsequent requests instead of forcing it into one.
+DISTANCE_EFFORTS_BACKFILL_CHUNK = 200
+
+
+def backfill_missing_distance_efforts(
+    db: Session, limit: int = DISTANCE_EFFORTS_BACKFILL_CHUNK, user_id: int | None = None
+) -> int:
     """Recompute ``mean_max_json`` for activities whose curves predate distance efforts.
 
     Self-heals databases whose curves were computed before Strava-style
     rolling-window race-distance bests existed (``distance_efforts`` wasn't a
     key in ``compute_curves_from_details``'s output yet). Detected by a cheap
     substring check rather than parsing every row up front. When ``user_id`` is
-    given, only that user's activities are processed.
+    given, only that user's activities are processed. Bounded by ``limit`` per
+    call — see ``DISTANCE_EFFORTS_BACKFILL_CHUNK``.
     """
     from app.models import Activity
 
-    query = db.query(Activity).filter(
-        Activity.laps_json.isnot(None),
-        or_(
-            Activity.mean_max_json.is_(None),
-            ~Activity.mean_max_json.like("%distance_efforts%"),
-        ),
+    query = (
+        db.query(Activity)
+        .options(load_only(Activity.activity_type, Activity.laps_json, Activity.mean_max_json))
+        .filter(
+            Activity.laps_json.isnot(None),
+            or_(
+                Activity.mean_max_json.is_(None),
+                ~Activity.mean_max_json.like("%distance_efforts%"),
+            ),
+        )
     )
     if user_id is not None:
         query = query.filter(Activity.user_id == user_id)

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -138,7 +138,7 @@ adaptation-suggestion + race-week pushes), `static/sw.js` (push handlers),
 `frontend/src/api/{types,hooks,client}.ts`, `requirements.txt` (`pywebpush`),
 `tests/test_notifications.py` (new), `tests/test_api_endpoints.py`.
 
-#### P0-2 · Personal records & peak performances
+#### P0-2 · Personal records & peak performances ✅ Done.
 **What:** Detect and celebrate bests from data we already compute. After
 `compute_curves_from_details` stores an activity's mean-max curve, compare each
 standard duration against the athlete's historical frontier (and race-distance
@@ -162,6 +162,19 @@ curve computation), `app/ai_coach.py` (`_format_activity_context` PR line),
 `app/schemas.py`, `frontend/src/components/trends/PeakPerformancesView.tsx` +
 `.css` (new), `frontend/src/components/activity-detail/ActivityDetailView.tsx`
 (badge), `frontend/src/api/{types,hooks}.ts`, `tests/test_records.py` (new).
+_Implemented as described, scoped to P0-2 only (no push — that's P0-1, not yet
+built). Duration-based bests (power/GAP-speed per standard mean-max duration)
+and race-distance bests (time at 5K/10K/half/marathon, matched within ±2% of
+nominal distance) are both append-only `PersonalRecord` rows, detected
+incrementally after each live-synced activity (`garmin_sync.sync_activities`)
+by comparing only against activities with an earlier `started_at` — order-
+independent by date, not by sync order. Because `backfill_activities` imports
+pages newest-first, per-activity detection is skipped there and a single
+chronological `rebuild_personal_records` pass runs once backfill completes.
+Surfaced via `GET /personal-records` (Trends → Records tab, all-time bests +
+recent-window feed) and a `personal_records` field on `ActivityDetail` (New PB
+badge); the AI activity-analysis context gets a one-line PR mention when
+applicable. All new/existing tests pass (backend + frontend)._
 
 ### P1 — Ask the athlete, plan the real race
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -164,17 +164,27 @@ curve computation), `app/ai_coach.py` (`_format_activity_context` PR line),
 (badge), `frontend/src/api/{types,hooks}.ts`, `tests/test_records.py` (new).
 _Implemented as described, scoped to P0-2 only (no push — that's P0-1, not yet
 built). Duration-based bests (power/GAP-speed per standard mean-max duration)
-and race-distance bests (time at 5K/10K/half/marathon, matched within ±2% of
-nominal distance) are both append-only `PersonalRecord` rows, detected
-incrementally after each live-synced activity (`garmin_sync.sync_activities`)
-by comparing only against activities with an earlier `started_at` — order-
-independent by date, not by sync order. Because `backfill_activities` imports
-pages newest-first, per-activity detection is skipped there and a single
-chronological `rebuild_personal_records` pass runs once backfill completes.
-Surfaced via `GET /personal-records` (Trends → Records tab, all-time bests +
-recent-window feed) and a `personal_records` field on `ActivityDetail` (New PB
-badge); the AI activity-analysis context gets a one-line PR mention when
-applicable. All new/existing tests pass (backend + frontend)._
+and race-distance "Best Efforts" (Strava's 400m/1-2mi/5K.../Marathon set) are
+both append-only `PersonalRecord` rows, detected incrementally after each
+live-synced activity (`garmin_sync.sync_activities`) by comparing only against
+activities with an earlier `started_at` — order-independent by date, not by
+sync order. Because `backfill_activities` imports pages newest-first,
+per-activity detection is skipped there and a single chronological
+`rebuild_personal_records` pass runs once backfill completes; a versioned
+`SyncStatus` flag (`ensure_records_backfilled`) also lazily re-mines full
+history on the first request after any detection-logic change, so accounts
+whose backfill predates this feature (or a later revision of it) aren't stuck
+with an empty panel. Race-distance bests are **rolling-window best efforts**,
+not whole-activity distance matching: `app.streams.compute_distance_efforts`
+finds the fastest contiguous stretch of each standard distance anywhere within
+an activity's distance/time stream (two-pointer sweep, linearly interpolated
+crossing time), so a half marathon race correctly yields a 5K and 10K best
+effort too, exactly like Strava. Surfaced via `GET /personal-records`
+(Trends → Records tab: a Strava-style distance-chip picker showing the top-3
+historical bests per distance, a Duration Bests grid, and a recent-window
+feed) and a `personal_records` field on `ActivityDetail` (New PB badge); the
+AI activity-analysis context gets a one-line PR mention when applicable. All
+new/existing tests pass (backend + frontend)._
 
 ### P1 — Ask the athlete, plan the real race
 

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -19,6 +19,7 @@ import type {
   PacingStrategyResponse,
   PacingPushRequest,
   PerformanceCurveResponse,
+  PersonalRecordsResponse,
   PlanRealignmentStatus,
   PushWorkoutResponse,
   SettingsResponse,
@@ -372,6 +373,13 @@ export function usePerformanceCurve(days = 90) {
   return useQuery({
     queryKey: ['performance-curve', days],
     queryFn: () => apiGet<PerformanceCurveResponse>(`/performance-curve?days=${days}`),
+  })
+}
+
+export function usePersonalRecords(days = 90) {
+  return useQuery({
+    queryKey: ['personal-records', days],
+    queryFn: () => apiGet<PersonalRecordsResponse>(`/personal-records?days=${days}`),
   })
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -139,6 +139,7 @@ export interface ActivityDetail extends ActivitySummary {
   insight: InsightResponse | null
   scheduled_workout: CalendarEvent | null
   adherence: WorkoutAdherence | null
+  personal_records: PersonalRecordResponse[] | null
 }
 
 export interface ChartSeries {
@@ -551,6 +552,26 @@ export interface PerformanceCurveResponse {
   race_predictions: RacePrediction[]
   lookback_days: number
   activities_analyzed: number
+}
+
+export interface PersonalRecordResponse {
+  id: number
+  record_type: 'duration' | 'distance'
+  metric: 'power' | 'gap_speed' | null
+  duration_sec: number | null
+  distance_label: string | null
+  value: number
+  previous_value: number | null
+  activity_id: number
+  achieved_at: string
+  label: string
+  display_value: string
+}
+
+export interface PersonalRecordsResponse {
+  current_bests: PersonalRecordResponse[]
+  recent: PersonalRecordResponse[]
+  recent_days: number
 }
 
 export interface IntensityWeek {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -572,6 +572,8 @@ export interface PersonalRecordsResponse {
   current_bests: PersonalRecordResponse[]
   recent: PersonalRecordResponse[]
   recent_days: number
+  distance_bests: Record<string, PersonalRecordResponse[]>  // label -> top 3, fastest first
+  distance_labels: string[]  // canonical chip order (Strava's distance set)
 }
 
 export interface IntensityWeek {

--- a/frontend/src/components/activity-detail/ActivityDetailView.css
+++ b/frontend/src/components/activity-detail/ActivityDetailView.css
@@ -42,6 +42,15 @@
   margin: 6px 0 4px;
 }
 
+.pr-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 6px;
+  background: #f0a50022;
+  color: #f0a500;
+}
+
 .detail-date {
   font-size: 0.78rem;
   color: var(--text-muted);

--- a/frontend/src/components/activity-detail/ActivityDetailView.tsx
+++ b/frontend/src/components/activity-detail/ActivityDetailView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, RotateCcw, Loader } from 'lucide-react'
+import { ArrowLeft, RotateCcw, Loader, Trophy } from 'lucide-react'
 import { useActivity, useTriggerAnalysis, useJobStatus } from '../../api/hooks'
 import { getActivityColor, colorMap } from '../../utils/colors'
 import { formatDistance, formatDuration, formatPace } from '../../utils/formatting'
@@ -108,6 +108,14 @@ export default function ActivityDetailView() {
         </button>
         <div className="detail-header-info">
           <span className="badge" style={{ background: `${color}22`, color }}>{typeLabel}</span>
+          {activity.personal_records && activity.personal_records.length > 0 && (
+            <span
+              className="badge pr-badge"
+              title={activity.personal_records.map(r => `${r.label}: ${r.display_value}`).join(', ')}
+            >
+              <Trophy size={11} /> New PB
+            </span>
+          )}
           <h1 className="detail-title">{activity.name || 'Workout'}</h1>
           {activity.started_at && (
             <span className="detail-date">{format(parseISO(activity.started_at), 'EEEE, d MMMM yyyy, HH:mm')}</span>

--- a/frontend/src/components/trends/PeakPerformancesView.css
+++ b/frontend/src/components/trends/PeakPerformancesView.css
@@ -172,3 +172,135 @@
   color: var(--text-muted);
   font-size: 0.82rem;
 }
+
+/* Best Efforts (Strava-style distance chips) */
+
+.pr-chip-row {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  margin-bottom: 12px;
+  scrollbar-width: thin;
+}
+
+.pr-chip {
+  flex-shrink: 0;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+.pr-chip.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.pr-chip.empty:not(.active) {
+  color: var(--text-muted);
+  opacity: 0.55;
+}
+
+.pr-chip:hover:not(.active) {
+  border-color: var(--text-muted);
+}
+
+.pr-effort-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.pr-effort-row {
+  border-bottom: 1px solid var(--border);
+}
+
+.pr-effort-row:last-child {
+  border-bottom: none;
+}
+
+.pr-effort-row-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--text-muted);
+}
+
+.pr-effort-medal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  font-size: 0.78rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  color: #fff;
+}
+
+.pr-effort-medal-1 { background: #f0a500; }
+.pr-effort-medal-2 { background: #9aa1ac; }
+.pr-effort-medal-3 { background: #c17a4a; }
+
+.pr-effort-values {
+  flex: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  text-align: left;
+}
+
+.pr-effort-time {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.pr-effort-rank-1 .pr-effort-time {
+  font-size: 1.3rem;
+}
+
+.pr-effort-pace {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.pr-effort-detail {
+  display: block;
+  padding: 0 0 12px 38px;
+  text-decoration: none;
+}
+
+.pr-effort-detail-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.pr-effort-detail-stats {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.pr-effort-detail-date {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}

--- a/frontend/src/components/trends/PeakPerformancesView.css
+++ b/frontend/src/components/trends/PeakPerformancesView.css
@@ -1,0 +1,174 @@
+.pr-view {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 24px;
+}
+
+.pr-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.pr-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.pr-card {
+  background: var(--surface);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 12px 16px;
+}
+
+.pr-card-title {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 10px;
+}
+
+.pr-card-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.pr-card-title-row .pr-card-title {
+  margin-bottom: 0;
+}
+
+.pr-tab-strip {
+  display: flex;
+  gap: 4px;
+}
+
+.pr-tab {
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+
+.pr-tab.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.pr-tab:hover:not(.active) {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+.pr-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.pr-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  text-decoration: none;
+  transition: border-color 0.15s;
+}
+
+.pr-tile:hover {
+  border-color: var(--accent);
+}
+
+.pr-tile-label {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.pr-tile-value {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.pr-tile-date {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+
+.pr-recent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pr-recent-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+  text-decoration: none;
+  color: var(--text);
+}
+
+.pr-recent-list li:last-child .pr-recent-row {
+  border-bottom: none;
+}
+
+.pr-recent-icon {
+  color: #f0a500;
+  flex-shrink: 0;
+}
+
+.pr-recent-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.pr-recent-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.pr-recent-meta {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.pr-empty,
+.pr-loading {
+  padding: 48px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.pr-empty-inline {
+  padding: 16px 0;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}

--- a/frontend/src/components/trends/PeakPerformancesView.tsx
+++ b/frontend/src/components/trends/PeakPerformancesView.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Trophy } from 'lucide-react'
-import { usePersonalRecords } from '../../api/hooks'
+import { ChevronDown, ChevronUp, Trophy } from 'lucide-react'
+import { usePersonalRecords, useActivity } from '../../api/hooks'
+import { formatDistance, formatDuration } from '../../utils/formatting'
+import { format, parseISO } from '../../utils/date'
 import type { PersonalRecordResponse } from '../../api/types'
 import './PeakPerformancesView.css'
 
@@ -13,6 +15,24 @@ const DAY_OPTIONS: { label: string; value: Days }[] = [
   { label: '1y', value: 365 },
 ]
 
+// Mirrors app.streams.RACE_DISTANCES_M — the API returns effort *time* only,
+// so pace is derived client-side from each label's known nominal distance.
+const DISTANCE_METERS: Record<string, number> = {
+  '400m': 400,
+  '1/2 mile': 804.672,
+  '1K': 1000,
+  '1 mile': 1609.344,
+  '2 mile': 3218.688,
+  '5K': 5000,
+  '10K': 10000,
+  '15K': 15000,
+  '10 mile': 16093.44,
+  '20K': 20000,
+  'Half Marathon': 21097.5,
+  '30K': 30000,
+  Marathon: 42195,
+}
+
 function formatRaceTime(seconds: number): string {
   const s = Math.round(seconds)
   const h = Math.floor(s / 3600)
@@ -23,32 +43,81 @@ function formatRaceTime(seconds: number): string {
     : `${m}:${String(sec).padStart(2, '0')}`
 }
 
-function formatPreviousValue(r: PersonalRecordResponse): string | null {
-  if (r.previous_value == null) return null
-  if (r.record_type === 'distance') return formatRaceTime(r.previous_value)
-  if (r.metric === 'power') return `${r.previous_value.toFixed(0)} W`
-  const paceMinKm = (1000 / r.previous_value) / 60
+function formatPaceForLabel(label: string, seconds: number): string | null {
+  const meters = DISTANCE_METERS[label]
+  if (!meters) return null
+  const paceMinKm = seconds / (meters / 1000) / 60
   const m = Math.floor(paceMinKm)
-  const sec = Math.round((paceMinKm - m) * 60)
-  return `${m}:${String(sec).padStart(2, '0')}/km`
+  const s = Math.round((paceMinKm - m) * 60)
+  return `${m}:${String(s).padStart(2, '0')} /km`
 }
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+  return format(parseISO(iso), 'MMMM d, yyyy')
+}
+
+function BestEffortDetail({ record }: { record: PersonalRecordResponse }) {
+  const { data: activity, isLoading } = useActivity(record.activity_id)
+  return (
+    <Link to={`/activities/${record.activity_id}`} className="pr-effort-detail">
+      <div className="pr-effort-detail-name">
+        {isLoading ? 'Loading…' : activity?.name || `Activity #${record.activity_id}`}
+      </div>
+      {activity && (
+        <div className="pr-effort-detail-stats">
+          {formatDistance(activity.distance_m)} km · {formatDuration(activity.duration_sec)}
+        </div>
+      )}
+      <div className="pr-effort-detail-date">{formatDate(record.achieved_at)}</div>
+    </Link>
+  )
+}
+
+function BestEffortRow({ record, rank }: { record: PersonalRecordResponse; rank: number }) {
+  const [open, setOpen] = useState(rank === 1)
+  const pace = formatPaceForLabel(record.distance_label ?? '', record.value)
+
+  return (
+    <div className="pr-effort-row">
+      <button
+        type="button"
+        className={`pr-effort-row-header pr-effort-rank-${rank}`}
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+      >
+        <span className={`pr-effort-medal pr-effort-medal-${rank}`}>
+          {rank === 1 ? <Trophy size={15} /> : rank}
+        </span>
+        <span className="pr-effort-values">
+          <span className="pr-effort-time">{formatRaceTime(record.value)}</span>
+          {pace && <span className="pr-effort-pace">{pace}</span>}
+        </span>
+        {open ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+      </button>
+      {open && <BestEffortDetail record={record} />}
+    </div>
+  )
 }
 
 export default function PeakPerformancesView() {
-  const [days, setDays] = useState<Days>(90)
-  const { data, isLoading } = usePersonalRecords(days)
+  const [recentDays, setRecentDays] = useState<Days>(90)
+  const { data, isLoading } = usePersonalRecords(recentDays)
+  const [selectedLabel, setSelectedLabel] = useState<string | null>(null)
 
   if (isLoading) return <div className="pr-loading">Loading personal records…</div>
 
+  const labels = data?.distance_labels ?? []
+  const distanceBests = data?.distance_bests ?? {}
   const currentBests = data?.current_bests ?? []
   const recent = data?.recent ?? []
-  const distanceBests = currentBests.filter(r => r.record_type === 'distance')
   const durationBests = currentBests.filter(r => r.record_type === 'duration')
 
-  if (currentBests.length === 0) {
+  const hasAnyDistanceData = labels.some(l => (distanceBests[l]?.length ?? 0) > 0)
+  const effectiveSelected =
+    selectedLabel ?? labels.find(l => (distanceBests[l]?.length ?? 0) > 0) ?? labels[0]
+  const selectedRecords = distanceBests[effectiveSelected] ?? []
+
+  if (currentBests.length === 0 && !hasAnyDistanceData) {
     return (
       <div className="pr-view">
         <div className="pr-header">
@@ -68,20 +137,33 @@ export default function PeakPerformancesView() {
         <span className="pr-title">Peak Performances</span>
       </div>
 
-      {distanceBests.length > 0 && (
-        <div className="pr-card">
-          <div className="pr-card-title">Race Distance Bests</div>
-          <div className="pr-grid">
-            {distanceBests.map(r => (
-              <Link key={r.id} to={`/activities/${r.activity_id}`} className="pr-tile">
-                <div className="pr-tile-label">{r.label}</div>
-                <div className="pr-tile-value">{r.display_value}</div>
-                <div className="pr-tile-date">{formatDate(r.achieved_at)}</div>
-              </Link>
+      <div className="pr-card">
+        <div className="pr-card-title">Best Efforts</div>
+        <div className="pr-chip-row">
+          {labels.map(label => (
+            <button
+              key={label}
+              className={[
+                'pr-chip',
+                effectiveSelected === label ? 'active' : '',
+                (distanceBests[label]?.length ?? 0) === 0 ? 'empty' : '',
+              ].join(' ').trim()}
+              onClick={() => setSelectedLabel(label)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        {selectedRecords.length === 0 ? (
+          <div className="pr-empty-inline">No {effectiveSelected} effort recorded yet.</div>
+        ) : (
+          <div className="pr-effort-list">
+            {selectedRecords.map((r, i) => (
+              <BestEffortRow key={r.id} record={r} rank={i + 1} />
             ))}
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
       {durationBests.length > 0 && (
         <div className="pr-card">
@@ -105,32 +187,27 @@ export default function PeakPerformancesView() {
             {DAY_OPTIONS.map(o => (
               <button
                 key={o.value}
-                className={`pr-tab ${days === o.value ? 'active' : ''}`}
-                onClick={() => setDays(o.value)}
+                className={`pr-tab ${recentDays === o.value ? 'active' : ''}`}
+                onClick={() => setRecentDays(o.value)}
               >{o.label}</button>
             ))}
           </div>
         </div>
         {recent.length === 0 ? (
-          <div className="pr-empty-inline">No new records in the last {days} days.</div>
+          <div className="pr-empty-inline">No new records in the last {recentDays} days.</div>
         ) : (
           <ul className="pr-recent-list">
-            {recent.map(r => {
-              const prev = formatPreviousValue(r)
-              return (
-                <li key={r.id}>
-                  <Link to={`/activities/${r.activity_id}`} className="pr-recent-row">
-                    <Trophy size={14} className="pr-recent-icon" />
-                    <div className="pr-recent-text">
-                      <div className="pr-recent-label">New {r.label} best: {r.display_value}</div>
-                      <div className="pr-recent-meta">
-                        {formatDate(r.achieved_at)}{prev ? ` · previous: ${prev}` : ''}
-                      </div>
-                    </div>
-                  </Link>
-                </li>
-              )
-            })}
+            {recent.map(r => (
+              <li key={r.id}>
+                <Link to={`/activities/${r.activity_id}`} className="pr-recent-row">
+                  <Trophy size={14} className="pr-recent-icon" />
+                  <div className="pr-recent-text">
+                    <div className="pr-recent-label">New {r.label} best: {r.display_value}</div>
+                    <div className="pr-recent-meta">{formatDate(r.achieved_at)}</div>
+                  </div>
+                </Link>
+              </li>
+            ))}
           </ul>
         )}
       </div>

--- a/frontend/src/components/trends/PeakPerformancesView.tsx
+++ b/frontend/src/components/trends/PeakPerformancesView.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Trophy } from 'lucide-react'
+import { usePersonalRecords } from '../../api/hooks'
+import type { PersonalRecordResponse } from '../../api/types'
+import './PeakPerformancesView.css'
+
+type Days = 30 | 90 | 365
+
+const DAY_OPTIONS: { label: string; value: Days }[] = [
+  { label: '30d', value: 30 },
+  { label: '90d', value: 90 },
+  { label: '1y', value: 365 },
+]
+
+function formatRaceTime(seconds: number): string {
+  const s = Math.round(seconds)
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const sec = s % 60
+  return h > 0
+    ? `${h}:${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`
+    : `${m}:${String(sec).padStart(2, '0')}`
+}
+
+function formatPreviousValue(r: PersonalRecordResponse): string | null {
+  if (r.previous_value == null) return null
+  if (r.record_type === 'distance') return formatRaceTime(r.previous_value)
+  if (r.metric === 'power') return `${r.previous_value.toFixed(0)} W`
+  const paceMinKm = (1000 / r.previous_value) / 60
+  const m = Math.floor(paceMinKm)
+  const sec = Math.round((paceMinKm - m) * 60)
+  return `${m}:${String(sec).padStart(2, '0')}/km`
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+export default function PeakPerformancesView() {
+  const [days, setDays] = useState<Days>(90)
+  const { data, isLoading } = usePersonalRecords(days)
+
+  if (isLoading) return <div className="pr-loading">Loading personal records…</div>
+
+  const currentBests = data?.current_bests ?? []
+  const recent = data?.recent ?? []
+  const distanceBests = currentBests.filter(r => r.record_type === 'distance')
+  const durationBests = currentBests.filter(r => r.record_type === 'duration')
+
+  if (currentBests.length === 0) {
+    return (
+      <div className="pr-view">
+        <div className="pr-header">
+          <span className="pr-title">Peak Performances</span>
+        </div>
+        <div className="pr-empty">
+          No personal records yet. Bests are detected automatically as you sync activities with
+          power or GPS data.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="pr-view">
+      <div className="pr-header">
+        <span className="pr-title">Peak Performances</span>
+      </div>
+
+      {distanceBests.length > 0 && (
+        <div className="pr-card">
+          <div className="pr-card-title">Race Distance Bests</div>
+          <div className="pr-grid">
+            {distanceBests.map(r => (
+              <Link key={r.id} to={`/activities/${r.activity_id}`} className="pr-tile">
+                <div className="pr-tile-label">{r.label}</div>
+                <div className="pr-tile-value">{r.display_value}</div>
+                <div className="pr-tile-date">{formatDate(r.achieved_at)}</div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {durationBests.length > 0 && (
+        <div className="pr-card">
+          <div className="pr-card-title">Duration Bests</div>
+          <div className="pr-grid">
+            {durationBests.map(r => (
+              <Link key={r.id} to={`/activities/${r.activity_id}`} className="pr-tile">
+                <div className="pr-tile-label">{r.label}</div>
+                <div className="pr-tile-value">{r.display_value}</div>
+                <div className="pr-tile-date">{formatDate(r.achieved_at)}</div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="pr-card">
+        <div className="pr-card-title-row">
+          <div className="pr-card-title">Recent Records</div>
+          <div className="pr-tab-strip">
+            {DAY_OPTIONS.map(o => (
+              <button
+                key={o.value}
+                className={`pr-tab ${days === o.value ? 'active' : ''}`}
+                onClick={() => setDays(o.value)}
+              >{o.label}</button>
+            ))}
+          </div>
+        </div>
+        {recent.length === 0 ? (
+          <div className="pr-empty-inline">No new records in the last {days} days.</div>
+        ) : (
+          <ul className="pr-recent-list">
+            {recent.map(r => {
+              const prev = formatPreviousValue(r)
+              return (
+                <li key={r.id}>
+                  <Link to={`/activities/${r.activity_id}`} className="pr-recent-row">
+                    <Trophy size={14} className="pr-recent-icon" />
+                    <div className="pr-recent-text">
+                      <div className="pr-recent-label">New {r.label} best: {r.display_value}</div>
+                      <div className="pr-recent-meta">
+                        {formatDate(r.achieved_at)}{prev ? ` · previous: ${prev}` : ''}
+                      </div>
+                    </div>
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/trends/TrendsView.tsx
+++ b/frontend/src/components/trends/TrendsView.tsx
@@ -4,13 +4,15 @@ import PerformanceCurveView from './PerformanceCurveView'
 import IntensityTrendsView from './IntensityTrendsView'
 import AerobicTrendsView from './AerobicTrendsView'
 import CustomChartsView from './CustomChartsView'
+import PeakPerformancesView from './PeakPerformancesView'
 
-type Tab = 'wellness' | 'intensity' | 'performance' | 'aerobic' | 'custom'
+type Tab = 'wellness' | 'intensity' | 'performance' | 'records' | 'aerobic' | 'custom'
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'wellness', label: 'Wellness' },
   { id: 'intensity', label: 'Intensity' },
   { id: 'performance', label: 'Performance' },
+  { id: 'records', label: 'Records' },
   { id: 'aerobic', label: 'Aerobic' },
   { id: 'custom', label: 'Custom' },
 ]
@@ -52,6 +54,7 @@ export default function TrendsView() {
       {tab === 'wellness' && <WellnessTrendsView />}
       {tab === 'intensity' && <IntensityTrendsView />}
       {tab === 'performance' && <PerformanceCurveView />}
+      {tab === 'records' && <PeakPerformancesView />}
       {tab === 'aerobic' && <AerobicTrendsView />}
       {tab === 'custom' && <CustomChartsView />}
     </div>

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from app import garmin_sync
-from app.models import Activity, AthleteProfile, DailySummary, GarminCalendarEvent, SyncStatus, User
+from app.models import Activity, AthleteProfile, DailySummary, GarminCalendarEvent, PersonalRecord, SyncStatus, User
 
 
 # --- _parse_garmin_ts ---
@@ -489,6 +489,58 @@ def test_backfill_activities_walks_pages(db, patch_db_session, monkeypatch):
     garmin_sync.backfill_activities()
     assert db.query(Activity).filter(Activity.garmin_id == 3001).count() == 1
     assert garmin_sync._get_sync_status(db, "backfill_activities") == "complete"
+
+
+def test_sync_activities_detects_personal_record(db, patch_db_session, monkeypatch):
+    """A newly-synced activity with a mean-max curve triggers PR detection."""
+    patch_db_session(garmin_sync)
+    monkeypatch.setattr(garmin_sync.time, "sleep", lambda *a, **k: None)
+
+    fake_client = MagicMock()
+    fake_client.get_activities.return_value = [
+        {"activityId": 4001, "activityType": {"typeKey": "running"},
+         "activityName": "Run", "startTimeLocal": "2026-06-10 07:00:00",
+         "duration": 1800, "distance": 5000},
+    ]
+    fake_client.get_activity_details.return_value = {"metricDescriptors": [], "activityDetailMetrics": [1]}
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: fake_client)
+    monkeypatch.setattr(garmin_sync, "_fetch_activity_details", lambda c, gid: {})
+    monkeypatch.setattr(
+        garmin_sync.streams, "compute_curves_from_details",
+        lambda details, activity_type: {"power": {"300": 300}, "gap_speed": {}, "speed": {}, "hr": {}, "is_treadmill": False},
+    )
+
+    new = garmin_sync.sync_activities()
+    assert len(new) == 1
+    stored = db.query(Activity).filter(Activity.garmin_id == 4001).first()
+    pr = db.query(PersonalRecord).filter(PersonalRecord.activity_id == stored.id).first()
+    assert pr is not None
+    assert pr.record_type == "duration"
+    assert pr.value == 300
+
+
+def test_backfill_activities_rebuilds_personal_records_once_complete(db, patch_db_session, monkeypatch):
+    patch_db_session(garmin_sync)
+    monkeypatch.setattr(garmin_sync.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(garmin_sync, "_fetch_activity_details", lambda c, gid: {})
+
+    fake_client = MagicMock()
+    fake_client.get_activities.side_effect = [
+        [{"activityId": 5001, "activityType": {"typeKey": "running"},
+          "activityName": "Run", "startTimeLocal": "2026-06-10 07:00:00",
+          "duration": 1800, "distance": 5000}],
+    ]
+    fake_client.get_activity_details.return_value = {"metricDescriptors": []}
+    monkeypatch.setattr(garmin_sync, "get_garmin_client", lambda *a, **k: fake_client)
+
+    rebuild_calls = []
+    monkeypatch.setattr(
+        garmin_sync.records, "rebuild_personal_records",
+        lambda db_, user_id=1: rebuild_calls.append(user_id),
+    )
+
+    garmin_sync.backfill_activities()
+    assert rebuild_calls == [garmin_sync.DEFAULT_USER_ID]
 
 
 def test_backfill_activities_skips_when_complete(db, patch_db_session, monkeypatch):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -280,6 +280,33 @@ def test_ensure_records_backfilled_records_version_and_is_a_noop_after(db, monke
     assert called == []
 
 
+def test_ensure_records_backfilled_defers_rebuild_when_more_curves_remain(db, monkeypatch):
+    """Reproduces the production hang: with a large activity history, curve
+    recomputation must happen in bounded chunks, not all at once in a single
+    request. If backfill_missing_distance_efforts reports a full chunk
+    processed, rebuild_personal_records must NOT run yet (there's likely more
+    left), and the version must NOT be recorded (so the next request retries
+    and makes further progress instead of getting stuck)."""
+    _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}))
+
+    monkeypatch.setattr(
+        records.streams, "backfill_missing_distance_efforts",
+        lambda *a, **k: records.streams.DISTANCE_EFFORTS_BACKFILL_CHUNK,
+    )
+    rebuild_called = []
+    monkeypatch.setattr(records, "rebuild_personal_records", lambda *a, **k: rebuild_called.append(1))
+
+    records.ensure_records_backfilled(db)
+
+    assert rebuild_called == []
+    status = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == DEFAULT_USER_ID, SyncStatus.key == "personal_records_backfill_version")
+        .first()
+    )
+    assert status is None  # not yet recorded -> next request will retry
+
+
 def test_ensure_records_backfilled_is_a_noop_with_no_history(db, monkeypatch):
     called = []
     monkeypatch.setattr(records, "rebuild_personal_records", lambda *a, **k: called.append(1))

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,286 @@
+import json
+from datetime import datetime, timedelta
+
+from app import records
+from app.models import Activity, PersonalRecord
+
+DEFAULT_USER_ID = 1
+
+
+def _curve_json(*, power=None, gap_speed=None):
+    return json.dumps({
+        "power": power or {},
+        "speed": {},
+        "gap_speed": gap_speed or {},
+        "hr": {},
+        "is_treadmill": False,
+        "duration": 1800.0,
+    })
+
+
+def _add_activity(db, *, days_ago, activity_type="running", mean_max=None,
+                   distance_m=None, duration_sec=None, user_id=DEFAULT_USER_ID):
+    started = datetime.utcnow() - timedelta(days=days_ago)
+    act = Activity(
+        garmin_id=int(started.timestamp() * 1000) + days_ago,
+        user_id=user_id,
+        activity_type=activity_type,
+        name="Run",
+        started_at=started,
+        distance_m=distance_m,
+        duration_sec=duration_sec,
+        mean_max_json=mean_max,
+    )
+    db.add(act)
+    db.commit()
+    db.refresh(act)
+    return act
+
+
+# --- duration-based bests ---
+
+def test_first_activity_sets_a_record_with_no_previous(db):
+    act = _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}))
+    created = records.detect_new_records_for_activity(db, act)
+    assert len(created) == 1
+    assert created[0].record_type == "duration"
+    assert created[0].metric == "power"
+    assert created[0].duration_sec == 300
+    assert created[0].value == 300
+    assert created[0].previous_value is None
+
+
+def test_beating_prior_best_creates_record_with_previous_value(db):
+    _add_activity(db, days_ago=10, mean_max=_curve_json(power={"300": 280}))
+    _add_activity(db, days_ago=5, mean_max=_curve_json(power={"300": 280}))  # ties, no PR
+    newer = _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}))
+
+    created = records.detect_new_records_for_activity(db, newer)
+    assert len(created) == 1
+    assert created[0].value == 300
+    assert created[0].previous_value == 280
+
+
+def test_not_beating_prior_best_creates_no_record(db):
+    _add_activity(db, days_ago=10, mean_max=_curve_json(power={"300": 320}))
+    newer = _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}))
+
+    created = records.detect_new_records_for_activity(db, newer)
+    assert created == []
+
+
+def test_gap_speed_and_power_tracked_independently(db):
+    _add_activity(db, days_ago=10, mean_max=_curve_json(power={"600": 250}, gap_speed={"600": 3.0}))
+    newer = _add_activity(
+        db, days_ago=1,
+        mean_max=_curve_json(power={"600": 240}, gap_speed={"600": 3.2}),
+    )
+    created = records.detect_new_records_for_activity(db, newer)
+    assert len(created) == 1
+    assert created[0].metric == "gap_speed"
+    assert created[0].value == 3.2
+
+
+def test_non_running_activity_produces_no_records(db):
+    act = _add_activity(db, days_ago=1, activity_type="cycling", mean_max=_curve_json(power={"300": 400}))
+    created = records.detect_new_records_for_activity(db, act)
+    assert created == []
+
+
+# --- distance-based race bests ---
+
+def test_race_distance_within_tolerance_creates_distance_record(db):
+    # 5000m nominal; 5080m is within +2%
+    act = _add_activity(db, days_ago=1, distance_m=5080, duration_sec=1200)
+    created = records.detect_new_records_for_activity(db, act)
+    assert len(created) == 1
+    assert created[0].record_type == "distance"
+    assert created[0].distance_label == "5K"
+    assert created[0].value == 1200
+
+
+def test_race_distance_outside_tolerance_is_not_matched(db):
+    act = _add_activity(db, days_ago=1, distance_m=5500, duration_sec=1200)
+    created = records.detect_new_records_for_activity(db, act)
+    assert created == []
+
+
+def test_faster_time_at_same_distance_beats_prior(db):
+    _add_activity(db, days_ago=10, distance_m=5000, duration_sec=1300)
+    newer = _add_activity(db, days_ago=1, distance_m=5000, duration_sec=1200)
+
+    created = records.detect_new_records_for_activity(db, newer)
+    assert len(created) == 1
+    assert created[0].distance_label == "5K"
+    assert created[0].value == 1200
+    assert created[0].previous_value == 1300
+
+
+def test_slower_time_at_same_distance_creates_no_record(db):
+    _add_activity(db, days_ago=10, distance_m=5000, duration_sec=1200)
+    newer = _add_activity(db, days_ago=1, distance_m=5000, duration_sec=1300)
+
+    created = records.detect_new_records_for_activity(db, newer)
+    assert created == []
+
+
+# --- chronological correctness (backfill ordering) ---
+
+def test_incremental_detection_is_order_sensitive_by_insertion(db):
+    """Out-of-order insertion (as in backfill's newest-first pages) can produce a
+    stale PR for a later-inserted-but-earlier activity — this is exactly why
+    rebuild_personal_records exists."""
+    newer = _add_activity(db, days_ago=2, distance_m=5000, duration_sec=1200)  # 20:00 5K
+    created_newer = records.detect_new_records_for_activity(db, newer)
+    assert len(created_newer) == 1 and created_newer[0].previous_value is None
+
+    # A faster, older run inserted afterwards (simulating backfill order).
+    older = _add_activity(db, days_ago=10, distance_m=5000, duration_sec=1100)  # 18:20 5K
+    created_older = records.detect_new_records_for_activity(db, older)
+    # Nothing precedes `older` chronologically yet (in the DB), so it also looks
+    # like a fresh PR from the incremental function's point of view.
+    assert len(created_older) == 1 and created_older[0].previous_value is None
+
+    assert (
+        db.query(PersonalRecord).filter(PersonalRecord.distance_label == "5K").count() == 2
+    )
+
+
+def test_rebuild_fixes_chronological_ordering(db):
+    newer = _add_activity(db, days_ago=2, distance_m=5000, duration_sec=1200)
+    records.detect_new_records_for_activity(db, newer)
+    older = _add_activity(db, days_ago=10, distance_m=5000, duration_sec=1100)
+    records.detect_new_records_for_activity(db, older)
+
+    created = records.rebuild_personal_records(db)
+    assert created == 1  # only the older (faster, and chronologically first) run is a real PR
+
+    remaining = db.query(PersonalRecord).filter(PersonalRecord.distance_label == "5K").all()
+    assert len(remaining) == 1
+    assert remaining[0].activity_id == older.id
+    assert remaining[0].value == 1100
+
+
+def test_rebuild_replays_duration_bests_in_order(db):
+    _add_activity(db, days_ago=20, mean_max=_curve_json(power={"300": 260}))
+    _add_activity(db, days_ago=10, mean_max=_curve_json(power={"300": 300}))
+    _add_activity(db, days_ago=5, mean_max=_curve_json(power={"300": 280}))  # not a PR
+
+    created = records.rebuild_personal_records(db)
+    assert created == 2  # day-20 (first) and day-10 (beats it); day-5 doesn't beat 300
+
+    bests = records.get_current_bests(db)
+    assert len(bests) == 1
+    assert bests[0].value == 300
+
+
+def test_rebuild_scopes_to_user(db):
+    _add_activity(db, days_ago=5, mean_max=_curve_json(power={"300": 300}), user_id=1)
+    _add_activity(db, days_ago=5, mean_max=_curve_json(power={"300": 999}), user_id=2)
+
+    created = records.rebuild_personal_records(db, user_id=1)
+    assert created == 1
+    assert db.query(PersonalRecord).filter(PersonalRecord.user_id == 2).count() == 0
+
+
+# --- queries ---
+
+def test_get_current_bests_returns_latest_per_key(db):
+    _add_activity(db, days_ago=20, mean_max=_curve_json(power={"300": 260}))
+    latest = _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 310}))
+    records.rebuild_personal_records(db)
+
+    bests = records.get_current_bests(db)
+    assert len(bests) == 1
+    assert bests[0].activity_id == latest.id
+    assert bests[0].value == 310
+
+
+def test_get_recent_records_filters_by_window(db):
+    _add_activity(db, days_ago=200, mean_max=_curve_json(power={"300": 260}))
+    recent_act = _add_activity(db, days_ago=5, mean_max=_curve_json(power={"300": 310}))
+    records.rebuild_personal_records(db)
+
+    recent = records.get_recent_records(db, days=90)
+    assert len(recent) == 1
+    assert recent[0].activity_id == recent_act.id
+
+
+# --- formatting ---
+
+def test_format_activity_pr_context_includes_new_and_previous_values(db):
+    _add_activity(db, days_ago=10, mean_max=_curve_json(power={"300": 280}))
+    newer = _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}))
+    records.detect_new_records_for_activity(db, newer)
+
+    context = records.format_activity_pr_context(db, newer.id)
+    assert "300 W" in context
+    assert "280 W" in context
+    assert "5-min power" in context
+
+
+def test_format_activity_pr_context_empty_when_no_records(db):
+    act = _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 100}))
+    _add_activity(db, days_ago=5, mean_max=_curve_json(power={"300": 500}))
+    # act doesn't beat anything, so no PR was ever created for it.
+    assert records.format_activity_pr_context(db, act.id) == ""
+
+
+def test_record_label_and_display_value_for_distance():
+    r = PersonalRecord(
+        user_id=1, record_type="distance", distance_label="Half Marathon",
+        value=5530.0, activity_id=1, achieved_at=datetime.utcnow(),
+    )
+    assert records.record_label(r) == "Half Marathon"
+    assert records.record_display_value(r) == "1:32:10"
+
+
+def test_record_label_and_display_value_for_duration_pace():
+    r = PersonalRecord(
+        user_id=1, record_type="duration", metric="gap_speed", duration_sec=1200,
+        value=1000.0 / (4 * 60) / 1.0 * 1.0,  # placeholder, overwritten below
+        activity_id=1, achieved_at=datetime.utcnow(),
+    )
+    r.value = 1000 / (4.0 * 60)  # 4:00/km pace -> speed in m/s
+    assert records.record_label(r) == "20-min GAP-pace"
+    assert records.record_display_value(r) == "4:00/km"
+
+
+# --- API ---
+
+def test_personal_records_endpoint_returns_current_and_recent(client, session_factory):
+    db = session_factory()
+    _add_activity(db, days_ago=200, mean_max=_curve_json(power={"300": 260}))
+    _add_activity(db, days_ago=5, mean_max=_curve_json(power={"300": 310}))
+    records.rebuild_personal_records(db)
+    db.close()
+
+    resp = client.get("/api/v1/personal-records")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["recent_days"] == 90
+    assert len(body["current_bests"]) == 1
+    assert body["current_bests"][0]["value"] == 310
+    assert body["current_bests"][0]["label"] == "5-min power"
+    assert body["current_bests"][0]["display_value"] == "310 W"
+    assert len(body["recent"]) == 1  # only the day-5 activity falls in the 90-day window
+
+
+def test_activity_detail_includes_personal_records(client, session_factory):
+    db = session_factory()
+    older = _add_activity(db, days_ago=10, mean_max=_curve_json(power={"300": 280}))
+    newer = _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}))
+    records.detect_new_records_for_activity(db, newer)
+    newer_id, older_id = newer.id, older.id
+    db.close()
+
+    resp = client.get(f"/api/v1/activities/{newer_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["personal_records"] is not None
+    assert len(body["personal_records"]) == 1
+    assert body["personal_records"][0]["value"] == 300
+    assert body["personal_records"][0]["previous_value"] == 280
+
+    resp2 = client.get(f"/api/v1/activities/{older_id}")
+    assert resp2.json()["personal_records"] is None

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -206,6 +206,59 @@ def test_get_recent_records_filters_by_window(db):
     assert recent[0].activity_id == recent_act.id
 
 
+# --- lazy backfill (pre-existing history synced before this feature shipped) ---
+
+def test_ensure_records_backfilled_mines_pre_existing_history(db):
+    """Simulates an account whose Garmin backfill completed long before this
+    feature existed: activities exist, but no PersonalRecord rows do, and
+    rebuild_personal_records was never triggered (only fires at the end of a
+    fresh backfill). The lazy check should mine that history on first call."""
+    _add_activity(db, days_ago=20, mean_max=_curve_json(power={"300": 260}))
+    newer = _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}))
+
+    assert db.query(PersonalRecord).count() == 0
+    records.ensure_records_backfilled(db)
+
+    bests = records.get_current_bests(db)
+    assert len(bests) == 1
+    assert bests[0].activity_id == newer.id
+    assert bests[0].value == 300
+
+
+def test_ensure_records_backfilled_is_a_noop_once_records_exist(db, monkeypatch):
+    _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}))
+    records.rebuild_personal_records(db)
+    assert db.query(PersonalRecord).count() == 1
+
+    called = []
+    monkeypatch.setattr(records, "rebuild_personal_records", lambda *a, **k: called.append(1))
+    records.ensure_records_backfilled(db)
+    assert called == []
+
+
+def test_ensure_records_backfilled_is_a_noop_with_no_history(db, monkeypatch):
+    called = []
+    monkeypatch.setattr(records, "rebuild_personal_records", lambda *a, **k: called.append(1))
+    records.ensure_records_backfilled(db)
+    assert called == []
+
+
+def test_personal_records_endpoint_backfills_pre_existing_activities(client, session_factory):
+    """Reproduces the reported bug: activities synced before this feature
+    existed should still surface on the Peak Performances panel, not just
+    activities synced after it."""
+    db = session_factory()
+    _add_activity(db, days_ago=200, mean_max=_curve_json(power={"300": 260}))
+    _add_activity(db, days_ago=100, mean_max=_curve_json(power={"300": 310}))
+    db.close()
+
+    resp = client.get("/api/v1/personal-records")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["current_bests"]) == 1
+    assert body["current_bests"][0]["value"] == 310
+
+
 # --- formatting ---
 
 def test_format_activity_pr_context_includes_new_and_previous_values(db):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -2,19 +2,20 @@ import json
 from datetime import datetime, timedelta
 
 from app import records
-from app.models import Activity, PersonalRecord
+from app.models import Activity, PersonalRecord, SyncStatus
 
 DEFAULT_USER_ID = 1
 
 
-def _curve_json(*, power=None, gap_speed=None):
+def _curve_json(*, power=None, gap_speed=None, distance_efforts=None, is_treadmill=False):
     return json.dumps({
         "power": power or {},
         "speed": {},
         "gap_speed": gap_speed or {},
         "hr": {},
-        "is_treadmill": False,
+        "is_treadmill": is_treadmill,
         "duration": 1800.0,
+        "distance_efforts": distance_efforts or {},
     })
 
 
@@ -87,27 +88,32 @@ def test_non_running_activity_produces_no_records(db):
     assert created == []
 
 
-# --- distance-based race bests ---
+# --- distance-based "Best Efforts" (rolling-window, not whole-activity) ---
 
-def test_race_distance_within_tolerance_creates_distance_record(db):
-    # 5000m nominal; 5080m is within +2%
-    act = _add_activity(db, days_ago=1, distance_m=5080, duration_sec=1200)
+def test_distance_effort_creates_record_with_no_previous(db):
+    act = _add_activity(db, days_ago=1, mean_max=_curve_json(distance_efforts={"10K": 3000}))
     created = records.detect_new_records_for_activity(db, act)
     assert len(created) == 1
     assert created[0].record_type == "distance"
-    assert created[0].distance_label == "5K"
-    assert created[0].value == 1200
+    assert created[0].distance_label == "10K"
+    assert created[0].value == 3000
+    assert created[0].previous_value is None
 
 
-def test_race_distance_outside_tolerance_is_not_matched(db):
-    act = _add_activity(db, days_ago=1, distance_m=5500, duration_sec=1200)
+def test_half_marathon_activity_also_yields_a_10k_and_5k_effort(db):
+    """The whole point of Strava-style Best Efforts: a half marathon race
+    contains a 5K and 10K sub-effort, not just a Half Marathon one."""
+    act = _add_activity(db, days_ago=1, mean_max=_curve_json(distance_efforts={
+        "5K": 1450, "10K": 2950, "Half Marathon": 6480,
+    }))
     created = records.detect_new_records_for_activity(db, act)
-    assert created == []
+    labels = {r.distance_label for r in created}
+    assert labels == {"5K", "10K", "Half Marathon"}
 
 
-def test_faster_time_at_same_distance_beats_prior(db):
-    _add_activity(db, days_ago=10, distance_m=5000, duration_sec=1300)
-    newer = _add_activity(db, days_ago=1, distance_m=5000, duration_sec=1200)
+def test_faster_effort_beats_prior_at_same_distance(db):
+    _add_activity(db, days_ago=10, mean_max=_curve_json(distance_efforts={"5K": 1300}))
+    newer = _add_activity(db, days_ago=1, mean_max=_curve_json(distance_efforts={"5K": 1200}))
 
     created = records.detect_new_records_for_activity(db, newer)
     assert len(created) == 1
@@ -116,12 +122,23 @@ def test_faster_time_at_same_distance_beats_prior(db):
     assert created[0].previous_value == 1300
 
 
-def test_slower_time_at_same_distance_creates_no_record(db):
-    _add_activity(db, days_ago=10, distance_m=5000, duration_sec=1200)
-    newer = _add_activity(db, days_ago=1, distance_m=5000, duration_sec=1300)
+def test_slower_effort_at_same_distance_creates_no_record(db):
+    _add_activity(db, days_ago=10, mean_max=_curve_json(distance_efforts={"5K": 1200}))
+    newer = _add_activity(db, days_ago=1, mean_max=_curve_json(distance_efforts={"5K": 1300}))
 
     created = records.detect_new_records_for_activity(db, newer)
     assert created == []
+
+
+def test_distance_labels_are_tracked_independently(db):
+    _add_activity(db, days_ago=10, mean_max=_curve_json(distance_efforts={"5K": 1300, "10K": 2700}))
+    newer = _add_activity(
+        db, days_ago=1,
+        mean_max=_curve_json(distance_efforts={"5K": 1250, "10K": 2800}),  # 5K PR, 10K not
+    )
+    created = records.detect_new_records_for_activity(db, newer)
+    assert len(created) == 1
+    assert created[0].distance_label == "5K"
 
 
 # --- chronological correctness (backfill ordering) ---
@@ -130,12 +147,12 @@ def test_incremental_detection_is_order_sensitive_by_insertion(db):
     """Out-of-order insertion (as in backfill's newest-first pages) can produce a
     stale PR for a later-inserted-but-earlier activity — this is exactly why
     rebuild_personal_records exists."""
-    newer = _add_activity(db, days_ago=2, distance_m=5000, duration_sec=1200)  # 20:00 5K
+    newer = _add_activity(db, days_ago=2, mean_max=_curve_json(distance_efforts={"5K": 1200}))
     created_newer = records.detect_new_records_for_activity(db, newer)
     assert len(created_newer) == 1 and created_newer[0].previous_value is None
 
     # A faster, older run inserted afterwards (simulating backfill order).
-    older = _add_activity(db, days_ago=10, distance_m=5000, duration_sec=1100)  # 18:20 5K
+    older = _add_activity(db, days_ago=10, mean_max=_curve_json(distance_efforts={"5K": 1100}))
     created_older = records.detect_new_records_for_activity(db, older)
     # Nothing precedes `older` chronologically yet (in the DB), so it also looks
     # like a fresh PR from the incremental function's point of view.
@@ -147,9 +164,9 @@ def test_incremental_detection_is_order_sensitive_by_insertion(db):
 
 
 def test_rebuild_fixes_chronological_ordering(db):
-    newer = _add_activity(db, days_ago=2, distance_m=5000, duration_sec=1200)
+    newer = _add_activity(db, days_ago=2, mean_max=_curve_json(distance_efforts={"5K": 1200}))
     records.detect_new_records_for_activity(db, newer)
-    older = _add_activity(db, days_ago=10, distance_m=5000, duration_sec=1100)
+    older = _add_activity(db, days_ago=10, mean_max=_curve_json(distance_efforts={"5K": 1100}))
     records.detect_new_records_for_activity(db, older)
 
     created = records.rebuild_personal_records(db)
@@ -206,6 +223,26 @@ def test_get_recent_records_filters_by_window(db):
     assert recent[0].activity_id == recent_act.id
 
 
+def test_get_distance_top_n_ranks_fastest_first(db):
+    _add_activity(db, days_ago=30, mean_max=_curve_json(distance_efforts={"5K": 1400}))
+    _add_activity(db, days_ago=20, mean_max=_curve_json(distance_efforts={"5K": 1300}))
+    _add_activity(db, days_ago=10, mean_max=_curve_json(distance_efforts={"5K": 1250}))
+    _add_activity(db, days_ago=5, mean_max=_curve_json(distance_efforts={"5K": 1230}))
+    records.rebuild_personal_records(db)
+
+    top_n = records.get_distance_top_n(db, top_n=3)
+    values = [r.value for r in top_n["5K"]]
+    assert values == [1230, 1250, 1300]  # fastest first, only top 3
+
+
+def test_get_distance_top_n_scoped_to_distance_type(db):
+    _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}, distance_efforts={"5K": 1200}))
+    records.rebuild_personal_records(db)
+
+    top_n = records.get_distance_top_n(db)
+    assert list(top_n.keys()) == ["5K"]
+
+
 # --- lazy backfill (pre-existing history synced before this feature shipped) ---
 
 def test_ensure_records_backfilled_mines_pre_existing_history(db):
@@ -225,10 +262,17 @@ def test_ensure_records_backfilled_mines_pre_existing_history(db):
     assert bests[0].value == 300
 
 
-def test_ensure_records_backfilled_is_a_noop_once_records_exist(db, monkeypatch):
+def test_ensure_records_backfilled_records_version_and_is_a_noop_after(db, monkeypatch):
     _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}))
-    records.rebuild_personal_records(db)
-    assert db.query(PersonalRecord).count() == 1
+    records.ensure_records_backfilled(db)
+
+    status = (
+        db.query(SyncStatus)
+        .filter(SyncStatus.user_id == DEFAULT_USER_ID, SyncStatus.key == "personal_records_backfill_version")
+        .first()
+    )
+    assert status is not None
+    assert int(status.value) == records._BACKFILL_VERSION
 
     called = []
     monkeypatch.setattr(records, "rebuild_personal_records", lambda *a, **k: called.append(1))
@@ -239,6 +283,10 @@ def test_ensure_records_backfilled_is_a_noop_once_records_exist(db, monkeypatch)
 def test_ensure_records_backfilled_is_a_noop_with_no_history(db, monkeypatch):
     called = []
     monkeypatch.setattr(records, "rebuild_personal_records", lambda *a, **k: called.append(1))
+    records.ensure_records_backfilled(db)
+    assert called == []
+    # No history to version either way, but should not raise or loop forever
+    # on a second call.
     records.ensure_records_backfilled(db)
     assert called == []
 
@@ -319,12 +367,31 @@ def test_personal_records_endpoint_returns_current_and_recent(client, session_fa
     assert len(body["recent"]) == 1  # only the day-5 activity falls in the 90-day window
 
 
+def test_personal_records_endpoint_returns_distance_bests_and_labels(client, session_factory):
+    db = session_factory()
+    _add_activity(db, days_ago=10, mean_max=_curve_json(distance_efforts={"5K": 1300}))
+    _add_activity(db, days_ago=1, mean_max=_curve_json(distance_efforts={"5K": 1200}))
+    records.rebuild_personal_records(db)
+    db.close()
+
+    resp = client.get("/api/v1/personal-records")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["distance_labels"][:3] == ["400m", "1/2 mile", "1K"]
+    assert "Marathon" in body["distance_labels"]
+    assert len(body["distance_bests"]["5K"]) == 2
+    assert body["distance_bests"]["5K"][0]["value"] == 1200  # fastest first
+    assert body["distance_bests"]["5K"][1]["value"] == 1300
+
+
 def test_activity_detail_includes_personal_records(client, session_factory):
     db = session_factory()
-    older = _add_activity(db, days_ago=10, mean_max=_curve_json(power={"300": 280}))
+    # Oldest activity establishes the initial baseline PR (nothing preceded it).
+    baseline = _add_activity(db, days_ago=20, mean_max=_curve_json(power={"300": 280}))
+    # A weaker effort in between never beats the baseline, so it sets no record.
+    slower = _add_activity(db, days_ago=10, mean_max=_curve_json(power={"300": 260}))
     newer = _add_activity(db, days_ago=1, mean_max=_curve_json(power={"300": 300}))
-    records.detect_new_records_for_activity(db, newer)
-    newer_id, older_id = newer.id, older.id
+    slower_id, newer_id = slower.id, newer.id
     db.close()
 
     resp = client.get(f"/api/v1/activities/{newer_id}")
@@ -335,5 +402,5 @@ def test_activity_detail_includes_personal_records(client, session_factory):
     assert body["personal_records"][0]["value"] == 300
     assert body["personal_records"][0]["previous_value"] == 280
 
-    resp2 = client.get(f"/api/v1/activities/{older_id}")
+    resp2 = client.get(f"/api/v1/activities/{slower_id}")
     assert resp2.json()["personal_records"] is None

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -284,3 +284,21 @@ def test_backfill_missing_distance_efforts_also_covers_fully_missing_curves(db):
     assert streams.backfill_missing_distance_efforts(db) == 1
     act = db.query(Activity).first()
     assert "distance_efforts" in json.loads(act.mean_max_json)
+
+
+def test_backfill_missing_distance_efforts_bounded_by_limit(db):
+    """A whole-history rollout matches every existing activity at once; this
+    must stay bounded per call rather than loading/parsing everything (each
+    row's laps_json can run multiple MB) in a single request."""
+    samples = [{"t": t, "power": 250, "speed": 3.5, "hr": 150} for t in range(120)]
+    details = _make_details(samples, with_elev=False)
+    for i in range(5):
+        db.add(Activity(
+            garmin_id=i, activity_type="running", name="Run",
+            laps_json=json.dumps(details), mean_max_json=None,
+        ))
+    db.commit()
+
+    assert streams.backfill_missing_distance_efforts(db, limit=3) == 3
+    remaining = db.query(Activity).filter(Activity.mean_max_json.is_(None)).count()
+    assert remaining == 2

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -139,6 +139,93 @@ def test_compute_curves_none_when_unparseable():
     assert streams.compute_curves_from_details({}, "running") is None
 
 
+# --- distance-window "Best Efforts" (Strava-style, not whole-activity) ---
+
+def test_best_time_for_distance_constant_pace():
+    # 5 m/s for 200 s -> 1000 m covered; 500 m should take exactly 100 s.
+    time = list(range(201))
+    distance = [5.0 * t for t in time]
+    assert streams._best_time_for_distance(time, distance, 500.0) == 100.0
+
+
+def test_best_time_for_distance_finds_fastest_window_not_just_from_start():
+    # Slow (2 m/s) for 100 s, then fast (10 m/s) for 50 s, then slow again.
+    # The fastest 400 m window should be entirely within the fast segment.
+    time = list(range(0, 200))
+    distance = []
+    d = 0.0
+    for t in time:
+        if t < 100:
+            speed = 2.0
+        elif t < 150:
+            speed = 10.0
+        else:
+            speed = 2.0
+        d += speed
+        distance.append(d)
+    best = streams._best_time_for_distance(time, distance, 400.0)
+    assert best is not None
+    assert round(best) == 40  # 400 m at 10 m/s
+
+
+def test_best_time_for_distance_none_when_never_covered():
+    time = list(range(10))
+    distance = [1.0 * t for t in time]
+    assert streams._best_time_for_distance(time, distance, 5000.0) is None
+
+
+def test_best_time_for_distance_clips_gps_regression():
+    # A GPS glitch briefly reports distance going backwards; should be ignored
+    # rather than corrupting the window search.
+    time = [0, 1, 2, 3, 4, 5]
+    distance = [0.0, 10.0, 8.0, 20.0, 30.0, 40.0]  # dip at t=2
+    best = streams._best_time_for_distance(time, distance, 30.0)
+    assert best is not None
+
+
+def test_compute_distance_efforts_reachable_distances_only():
+    # Constant 4 m/s for 1300 s -> 5200 m covered: reaches 1K/1mile/2mile/5K but not 10K.
+    time = list(range(0, 1301))
+    distance = [4.0 * t for t in time]
+    s = {"time": time, "distance": distance}
+    efforts = streams.compute_distance_efforts(s, "running")
+    assert "1K" in efforts
+    assert "5K" in efforts
+    assert "10K" not in efforts
+    assert round(efforts["1K"]) == 250  # 1000 m at 4 m/s = 250 s
+
+
+def test_compute_distance_efforts_skipped_for_treadmill():
+    time = list(range(0, 1301))
+    distance = [4.0 * t for t in time]
+    s = {"time": time, "distance": distance}
+    assert streams.compute_distance_efforts(s, "treadmill_running") == {}
+
+
+def test_compute_curves_from_details_includes_distance_efforts():
+    samples = [
+        {"t": t, "power": 250, "speed": 4.0, "hr": 150, "elev": 0, "dist": 4.0 * t}
+        for t in range(1301)
+    ]
+    curves = streams.compute_curves_from_details(_make_details(samples), "running")
+    assert "1K" in curves["distance_efforts"]
+    assert "10K" not in curves["distance_efforts"]
+
+
+def test_compute_curves_from_details_half_marathon_yields_5k_and_10k():
+    """A half-marathon-length run should also report 5K/10K best efforts, not
+    just a Half Marathon one — the point of the rolling-window approach."""
+    samples = [
+        {"t": t, "power": 250, "speed": 4.0, "hr": 150, "elev": 0, "dist": 4.0 * t}
+        for t in range(5300)  # 21200 m at 4 m/s
+    ]
+    curves = streams.compute_curves_from_details(_make_details(samples), "running")
+    efforts = curves["distance_efforts"]
+    assert "5K" in efforts
+    assert "10K" in efforts
+    assert "Half Marathon" in efforts
+
+
 # --- backfill ---
 
 def test_backfill_missing_curves(db):
@@ -158,3 +245,42 @@ def test_backfill_missing_curves(db):
 
     # Second run is a no-op (already populated).
     assert streams.backfill_missing_curves(db) == 0
+
+
+def test_backfill_missing_distance_efforts_recomputes_old_format_blob(db):
+    samples = [
+        {"t": t, "power": 250, "speed": 4.0, "hr": 150, "elev": 0, "dist": 4.0 * t}
+        for t in range(1301)
+    ]
+    details = _make_details(samples)
+    # Simulate a curve computed before distance_efforts existed: no such key.
+    old_blob = json.dumps({"power": {"60": 250}, "speed": {}, "gap_speed": {}, "hr": {},
+                          "is_treadmill": False, "duration": 1300.0})
+    db.add(Activity(
+        garmin_id=1, activity_type="running", name="Run",
+        laps_json=json.dumps(details), mean_max_json=old_blob,
+    ))
+    db.commit()
+
+    updated = streams.backfill_missing_distance_efforts(db)
+    assert updated == 1
+    act = db.query(Activity).first()
+    curve = json.loads(act.mean_max_json)
+    assert "1K" in curve["distance_efforts"]
+
+    # Second run is a no-op (already has distance_efforts).
+    assert streams.backfill_missing_distance_efforts(db) == 0
+
+
+def test_backfill_missing_distance_efforts_also_covers_fully_missing_curves(db):
+    samples = [{"t": t, "power": 250, "speed": 3.5, "hr": 150} for t in range(120)]
+    details = _make_details(samples, with_elev=False)
+    db.add(Activity(
+        garmin_id=1, activity_type="running", name="Run",
+        laps_json=json.dumps(details), mean_max_json=None,
+    ))
+    db.commit()
+
+    assert streams.backfill_missing_distance_efforts(db) == 1
+    act = db.query(Activity).first()
+    assert "distance_efforts" in json.loads(act.mean_max_json)


### PR DESCRIPTION
Detect and celebrate all-time bests from data already computed during
sync: duration-based power/GAP-speed bests from mean-max curves, and
race-distance bests (5K/10K/half/marathon) from activity distance and
duration. New activities are checked incrementally against prior history
by date; a historical backfill triggers one chronological rebuild pass
instead (its pages arrive newest-first, so incremental detection during
backfill would compare against incomplete history).

Surfaces as a "New PB" badge on Activity Detail, a Peak Performances tab
on Trends, and a one-line mention in the AI activity-analysis context.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MEzQ2pzW5EpxAw4KANnPSq