### PR TITLE
Implement P1-1: per-run RPE + daily check-in (subjective feedback)

### DIFF
--- a/alembic/versions/p9q0r1s2t3u4_add_rpe_and_daily_checkin.py
+++ b/alembic/versions/p9q0r1s2t3u4_add_rpe_and_daily_checkin.py
@@ -1,0 +1,56 @@
+"""add activity rpe and daily_checkins table
+
+Revision ID: p9q0r1s2t3u4
+Revises: o8p9q0r1s2t3
+Create Date: 2026-07-05
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision: str = "p9q0r1s2t3u4"
+down_revision: Union[str, None] = "o8p9q0r1s2t3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLE = "activities"
+
+
+def _has_column(insp: object, table: str, col: str) -> bool:
+    return any(c["name"] == col for c in insp.get_columns(table))
+
+
+def upgrade() -> None:
+    insp = inspect(op.get_bind())
+
+    with op.batch_alter_table(_TABLE) as batch_op:
+        if not _has_column(insp, _TABLE, "rpe"):
+            batch_op.add_column(sa.Column("rpe", sa.Integer(), nullable=True))
+
+    if "daily_checkins" not in insp.get_table_names():
+        op.create_table(
+            "daily_checkins",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("user_id", sa.Integer(), nullable=False, default=1),
+            sa.Column("date", sa.Date(), nullable=False),
+            sa.Column("soreness", sa.Integer(), nullable=True),
+            sa.Column("energy", sa.Integer(), nullable=True),
+            sa.Column("mood", sa.Integer(), nullable=True),
+            sa.Column("soreness_note", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("user_id", "date", name="uq_daily_checkins_user_date"),
+        )
+        op.create_index("ix_daily_checkins_date", "daily_checkins", ["date"])
+        op.create_index("ix_daily_checkins_user_id", "daily_checkins", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_daily_checkins_user_id", "daily_checkins")
+    op.drop_index("ix_daily_checkins_date", "daily_checkins")
+    op.drop_table("daily_checkins")
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_column("rpe")

--- a/app/coach/context.py
+++ b/app/coach/context.py
@@ -20,6 +20,7 @@ from app.models import (
     Activity,
     AthleteProfile,
     CoachMemory,
+    DailyCheckin,
     DailySummary,
     GarminCalendarEvent,
     Insight,
@@ -467,6 +468,25 @@ def _recent_hot_runs(
     return hot_runs
 
 
+def _format_checkin_note(checkin: DailyCheckin | None) -> str:
+    """Return a one-line "how the athlete says they feel" note for the readiness section."""
+    if checkin is None:
+        return ""
+    taps = []
+    if checkin.soreness is not None:
+        taps.append(f"Soreness {checkin.soreness}/5 (5=none)")
+    if checkin.energy is not None:
+        taps.append(f"Energy {checkin.energy}/5")
+    if checkin.mood is not None:
+        taps.append(f"Mood {checkin.mood}/5")
+    if not taps:
+        return ""
+    note = f"- How the athlete says they feel today: {', '.join(taps)}"
+    if checkin.soreness_note:
+        note += f" (sore area noted: {checkin.soreness_note})"
+    return note
+
+
 def _recent_heat_stress_note(
     db: Session,
     reference_date: date,
@@ -564,7 +584,12 @@ def _build_context(
         .all()
     )
     recent_rhr = [row[0] for row in recent_rhr_rows]
-    readiness = training_load.compute_readiness(today_summary, load_point, recent_rhr)
+    checkin = (
+        db.query(DailyCheckin)
+        .filter(DailyCheckin.user_id == user_id, DailyCheckin.date == reference_date)
+        .first()
+    )
+    readiness = training_load.compute_readiness(today_summary, load_point, recent_rhr, checkin)
     readiness_context = training_load.format_readiness_context(readiness)
 
     # Append a heat-stress note to readiness when recent runs were hot/humid.
@@ -572,6 +597,11 @@ def _build_context(
     heat_penalty_note = _recent_heat_stress_note(db, reference_date, user_id)
     if heat_penalty_note:
         readiness_context = (readiness_context + "\n" + heat_penalty_note).strip()
+
+    # Append the athlete's own daily check-in, if logged today.
+    checkin_note = _format_checkin_note(checkin)
+    if checkin_note:
+        readiness_context = (readiness_context + "\n" + checkin_note).strip()
 
     if readiness_context:
         insert_pos = min(3, len(sections))

--- a/app/models.py
+++ b/app/models.py
@@ -140,6 +140,7 @@ class Activity(Base):
     feedback_rating = Column(String(10), nullable=True)   # "good" or "bad"
     feedback_tags = Column(Text, nullable=True)            # JSON array of setback tags
     feedback_text = Column(Text, nullable=True)            # optional custom text
+    rpe = Column(Integer, nullable=True)                   # Borg CR10 session RPE, 1-10
 
 
 class DailySummary(Base):
@@ -170,6 +171,32 @@ class DailySummary(Base):
     raw_json = Column(Text)
     synced_at = Column(DateTime, default=_utcnow)
     ai_analyzed = Column(Boolean, default=False)
+
+
+class DailyCheckin(Base):
+    """The athlete's self-reported feel for a day (P1-1) — soreness, energy, mood.
+
+    Unlike ``DailySummary`` (device-derived), these three 1-5 taps are entered
+    directly by the athlete on Today and are optional/skippable. Higher is
+    always "better": low soreness, high energy, good mood. ``soreness_note``
+    is an optional free-text location (e.g. "left knee") so persistent
+    soreness in the same area can be detected and remembered as a niggle.
+    """
+
+    __tablename__ = "daily_checkins"
+    __table_args__ = (
+        UniqueConstraint("user_id", "date", name="uq_daily_checkins_user_date"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = _user_id_column()
+    date = Column(Date, nullable=False, index=True)
+    soreness = Column(Integer, nullable=True)   # 1 (very sore) - 5 (no soreness)
+    energy = Column(Integer, nullable=True)     # 1 (depleted) - 5 (energized)
+    mood = Column(Integer, nullable=True)       # 1 (low) - 5 (great)
+    soreness_note = Column(Text, nullable=True)  # optional location, e.g. "left knee"
+    created_at = Column(DateTime, default=_utcnow)
+    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
 
 
 class Insight(Base):

--- a/app/plan_adaptation.py
+++ b/app/plan_adaptation.py
@@ -9,7 +9,7 @@ no AI involved.
 
 from __future__ import annotations
 
-from app.models import TrainingPlanDay
+from app.models import DailyCheckin, TrainingPlanDay
 from app.schemas import PlanAdaptationSuggestion, TrainingReadiness
 
 HARD_WORKOUT_TYPES = {"tempo", "interval", "long"}
@@ -21,10 +21,30 @@ _DOWNGRADE_DISTANCE_FACTOR = 0.6
 _UPGRADE_DISTANCE_FACTOR = 0.15
 _UPGRADE_DISTANCE_CAP_M = 2000.0
 
+# Check-in taps are 1 (worst) - 5 (best); at/below these thresholds the athlete
+# is reporting they feel bad enough to override a merely-Fair/Good composite
+# score, the same way a "legs dead" report should downgrade a hard day.
+_CHECKIN_SORENESS_OVERRIDE = 2
+_CHECKIN_LOW_OVERRIDE = 2
+
+
+def _checkin_feels_bad(checkin: DailyCheckin | None) -> bool:
+    """Whether today's check-in alone warrants easing off a hard session."""
+    if checkin is None:
+        return False
+    if checkin.soreness is not None and checkin.soreness <= _CHECKIN_SORENESS_OVERRIDE:
+        return True
+    if checkin.energy is not None and checkin.energy <= _CHECKIN_LOW_OVERRIDE:
+        return True
+    if checkin.mood is not None and checkin.mood <= _CHECKIN_LOW_OVERRIDE:
+        return True
+    return False
+
 
 def suggest_adaptation(
     plan_day: TrainingPlanDay | None,
     readiness: TrainingReadiness | None,
+    checkin: DailyCheckin | None = None,
 ) -> PlanAdaptationSuggestion | None:
     """Propose a rule-based swap for today's plan day, or None if no change is warranted."""
     if plan_day is None or readiness is None:
@@ -33,6 +53,25 @@ def suggest_adaptation(
     workout_type = plan_day.workout_type
 
     if workout_type in HARD_WORKOUT_TYPES:
+        if readiness.score > 50 and _checkin_feels_bad(checkin):
+            suggested_distance = (
+                round(plan_day.target_distance_m * _DOWNGRADE_DISTANCE_FACTOR)
+                if plan_day.target_distance_m
+                else None
+            )
+            return PlanAdaptationSuggestion(
+                plan_day_id=plan_day.id,
+                direction="downgrade",
+                current_workout_type=workout_type,
+                suggested_workout_type="easy",
+                current_target_distance_m=plan_day.target_distance_m,
+                suggested_target_distance_m=suggested_distance,
+                reason=(
+                    "Your check-in says you're not feeling it today — consider "
+                    f"swapping today's {workout_type} for an easy effort."
+                ),
+                readiness_score=readiness.score,
+            )
         if readiness.score <= 30:
             return PlanAdaptationSuggestion(
                 plan_day_id=plan_day.id,

--- a/app/routers/activities.py
+++ b/app/routers/activities.py
@@ -213,6 +213,7 @@ def api_submit_feedback(
     activity.feedback_rating = feedback.rating
     activity.feedback_tags = json.dumps(feedback.tags) if feedback.tags else None
     activity.feedback_text = feedback.text
+    activity.rpe = feedback.rpe
     activity.ai_analyzed = False
 
     # Delete existing insight

--- a/app/routers/daily.py
+++ b/app/routers/daily.py
@@ -3,6 +3,7 @@ import threading
 from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.auth import get_current_user
@@ -11,6 +12,8 @@ from app.models import (
     AIJob,
     Activity,
     AthleteProfile,
+    CoachMemory,
+    DailyCheckin,
     DailySummary,
     GarminCalendarEvent,
     Insight,
@@ -22,6 +25,8 @@ from app.schemas import (
     AIJobEnqueuedResponse,
     AIJobResponse,
     ActivitySummary,
+    DailyCheckinRequest,
+    DailyCheckinResponse,
     DailySummaryDetail,
     DailySummaryResponse,
     InsightResponse,
@@ -198,7 +203,14 @@ def api_today(
         .all()
     )
     recent_rhr = [row[0] for row in recent_rhr_rows]
-    readiness = training_load.compute_readiness(daily_summary, current_load, recent_rhr)
+
+    # The athlete's own check-in for the selected day, if logged
+    checkin = (
+        db.query(DailyCheckin)
+        .filter(DailyCheckin.user_id == uid, DailyCheckin.date == selected)
+        .first()
+    )
+    readiness = training_load.compute_readiness(daily_summary, current_load, recent_rhr, checkin)
 
     # Readiness-driven plan adaptation suggestion for the selected day's plan day
     plan_day = (
@@ -206,7 +218,7 @@ def api_today(
         .filter(TrainingPlanDay.user_id == uid, TrainingPlanDay.day_date == selected)
         .first()
     )
-    plan_adaptation = plan_adaptation_mod.suggest_adaptation(plan_day, readiness)
+    plan_adaptation = plan_adaptation_mod.suggest_adaptation(plan_day, readiness, checkin)
     if plan_adaptation is not None:
         dismissed = (
             db.query(SyncStatus)
@@ -230,7 +242,97 @@ def api_today(
         training_load=current_load,
         readiness=readiness,
         plan_adaptation=plan_adaptation,
+        daily_checkin=DailyCheckinResponse.model_validate(checkin) if checkin else None,
     )
+
+
+# --- Daily Check-in ---
+
+# Soreness tap (1=very sore - 5=none) at/below this, with a matching note across
+# the last few check-ins, is "persistent soreness in one area" worth remembering.
+_SORENESS_NIGGLE_THRESHOLD = 2
+_SORENESS_NIGGLE_STREAK = 3
+
+
+def _maybe_record_soreness_niggle(db: Session, uid: int, checkin: DailyCheckin) -> None:
+    """Auto-record a CoachMemory niggle when the same area has been reported
+    sore for ``_SORENESS_NIGGLE_STREAK`` consecutive check-ins."""
+    note = (checkin.soreness_note or "").strip()
+    if not note or checkin.soreness is None or checkin.soreness > _SORENESS_NIGGLE_THRESHOLD:
+        return
+
+    recent = (
+        db.query(DailyCheckin)
+        .filter(DailyCheckin.user_id == uid, DailyCheckin.date <= checkin.date)
+        .order_by(DailyCheckin.date.desc())
+        .limit(_SORENESS_NIGGLE_STREAK)
+        .all()
+    )
+    if len(recent) < _SORENESS_NIGGLE_STREAK:
+        return
+    if not all(
+        r.soreness is not None
+        and r.soreness <= _SORENESS_NIGGLE_THRESHOLD
+        and (r.soreness_note or "").strip().lower() == note.lower()
+        for r in recent
+    ):
+        return
+
+    already_remembered = (
+        db.query(CoachMemory)
+        .filter(
+            CoachMemory.user_id == uid,
+            CoachMemory.category == "niggle",
+            CoachMemory.active.is_(True),
+            func.lower(CoachMemory.tag) == note.lower(),
+        )
+        .first()
+    )
+    if already_remembered:
+        return
+
+    db.add(CoachMemory(
+        user_id=uid,
+        category="niggle",
+        tag=note,
+        note=(
+            f"Reported sore ({note}) on {_SORENESS_NIGGLE_STREAK} consecutive "
+            "daily check-ins."
+        ),
+    ))
+    db.commit()
+
+
+@router.post("/daily-checkin", response_model=DailyCheckinResponse)
+def api_submit_daily_checkin(
+    body: DailyCheckinRequest,
+    date_str: str = Query(None, alias="date"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Upsert the athlete's soreness/energy/mood check-in for a day (default today)."""
+    uid = current_user.id
+    selected = _parse_date(date_str) if date_str else date.today()
+
+    checkin = (
+        db.query(DailyCheckin)
+        .filter(DailyCheckin.user_id == uid, DailyCheckin.date == selected)
+        .first()
+    )
+    if checkin is None:
+        checkin = DailyCheckin(user_id=uid, date=selected)
+        db.add(checkin)
+
+    checkin.soreness = body.soreness
+    checkin.energy = body.energy
+    checkin.mood = body.mood
+    checkin.soreness_note = body.soreness_note
+    db.commit()
+    db.refresh(checkin)
+
+    _maybe_record_soreness_niggle(db, uid, checkin)
+
+    return DailyCheckinResponse.model_validate(checkin)
 
 
 # --- Daily Summaries ---

--- a/app/routers/plan.py
+++ b/app/routers/plan.py
@@ -9,6 +9,7 @@ from app.auth import get_current_user
 from app.database import get_db
 from app.models import (
     AthleteProfile,
+    DailyCheckin,
     DailySummary,
     SeasonPlanWeek,
     SyncStatus,
@@ -222,8 +223,13 @@ def api_adapt_plan_day(
         .all()
     )
     recent_rhr = [row[0] for row in recent_rhr_rows]
-    readiness = training_load.compute_readiness(daily_summary, current_load, recent_rhr)
-    suggestion = plan_adaptation_mod.suggest_adaptation(plan_day, readiness)
+    checkin = (
+        db.query(DailyCheckin)
+        .filter(DailyCheckin.user_id == uid, DailyCheckin.date == plan_day.day_date)
+        .first()
+    )
+    readiness = training_load.compute_readiness(daily_summary, current_load, recent_rhr, checkin)
+    suggestion = plan_adaptation_mod.suggest_adaptation(plan_day, readiness, checkin)
     if suggestion is None:
         raise HTTPException(status_code=409, detail="No adaptation suggestion applies to this plan day")
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -4,7 +4,7 @@ import json
 from datetime import date, datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class ActivitySummary(BaseModel):
@@ -62,6 +62,7 @@ class FeedbackRequest(BaseModel):
     rating: Literal["good", "bad"]
     tags: list[str] | None = None
     text: str | None = None
+    rpe: int | None = Field(default=None, ge=1, le=10)
 
 
 class GarminCredentialsRequest(BaseModel):
@@ -178,6 +179,7 @@ class ActivityDetail(BaseModel):
     feedback_rating: str | None = None
     feedback_tags: list[str] | None = None
     feedback_text: str | None = None
+    rpe: int | None = None
 
     # Related insight
     insight: InsightResponse | None = None
@@ -375,6 +377,25 @@ class TrainingReadiness(BaseModel):
     fatigue_component: int | None = None    # 0-100, ATL-based (higher = less fatigued)
     rhr_component: int | None = None        # 0-100, resting HR trend vs 7d avg
     hrv_component: int | None = None        # 0-100, overnight HRV vs personal baseline
+    subjective_component: int | None = None  # 0-100, from the athlete's daily check-in
+
+
+class DailyCheckinRequest(BaseModel):
+    soreness: int | None = Field(default=None, ge=1, le=5)
+    energy: int | None = Field(default=None, ge=1, le=5)
+    mood: int | None = Field(default=None, ge=1, le=5)
+    soreness_note: str | None = None
+
+
+class DailyCheckinResponse(BaseModel):
+    date: date
+    soreness: int | None = None
+    energy: int | None = None
+    mood: int | None = None
+    soreness_note: str | None = None
+
+    class Config:
+        from_attributes = True
 
 
 class TrainingLoadResponse(BaseModel):
@@ -404,6 +425,7 @@ class TodayResponse(BaseModel):
     training_load: TrainingLoadPoint | None = None
     readiness: TrainingReadiness | None = None
     plan_adaptation: PlanAdaptationSuggestion | None = None
+    daily_checkin: DailyCheckinResponse | None = None
 
 
 class SettingsResponse(BaseModel):

--- a/app/training_load.py
+++ b/app/training_load.py
@@ -28,6 +28,7 @@ from app.models import (
     DEFAULT_USER_ID,
     Activity,
     AthleteProfile,
+    DailyCheckin,
     DailyLoadSeries,
     DailySummary,
     SyncStatus,
@@ -63,8 +64,8 @@ def _intensity_to_tss(duration_hr: float, intensity: float) -> float:
 def estimate_tss(activity: Activity, profile: AthleteProfile | None) -> tuple[float, str]:
     """Return ``(tss, source)`` for one activity.
 
-    Source is one of ``power`` (stored), ``pace``, ``hr``, ``duration``, or
-    ``none`` (no usable duration).
+    Source is one of ``power`` (stored), ``pace``, ``hr``, ``srpe``, ``duration``,
+    or ``none`` (no usable duration).
     """
     if activity.training_stress_score and activity.training_stress_score > 0:
         return float(activity.training_stress_score), "power"
@@ -88,6 +89,13 @@ def estimate_tss(activity: Activity, profile: AthleteProfile | None) -> tuple[fl
     if thr_hr and activity.avg_hr and activity.avg_hr > 0:
         intensity = activity.avg_hr / thr_hr
         return _intensity_to_tss(duration_hr, intensity), "hr"
+
+    # sRPE-based load (Foster): the athlete's own effort rating stands in for
+    # an intensity factor (RPE 10/10 ~= max effort ~= IF 1.0), the same scale
+    # the duration floor below assumes a fixed RPE-7-equivalent for.
+    if activity.rpe and activity.rpe > 0:
+        intensity = activity.rpe / 10.0
+        return _intensity_to_tss(duration_hr, intensity), "srpe"
 
     # Duration-only floor so the session still registers some load.
     return _intensity_to_tss(duration_hr, _DEFAULT_IF), "duration"
@@ -475,10 +483,26 @@ def _hrv_component(daily: DailySummary | None) -> int | None:
     return None
 
 
+def _subjective_component(checkin: DailyCheckin | None) -> int | None:
+    """Score the athlete's daily check-in 0–100 (average of soreness/energy/mood).
+
+    Each tap is 1 (worst) - 5 (best), so higher is always better; a 1-5 scale
+    maps onto 0-100 as ``(value - 1) / 4 * 100``.
+    """
+    if checkin is None:
+        return None
+    taps = [v for v in (checkin.soreness, checkin.energy, checkin.mood) if v is not None]
+    if not taps:
+        return None
+    avg = sum(taps) / len(taps)
+    return int(round((avg - 1) / 4 * 100))
+
+
 def compute_readiness(
     daily: DailySummary | None,
     load_point: TrainingLoadPoint | None,
     recent_rhr: list[int],
+    checkin: DailyCheckin | None = None,
 ) -> TrainingReadiness | None:
     """Compute a composite 0–100 readiness score from wellness and load inputs.
 
@@ -488,17 +512,20 @@ def compute_readiness(
     - fatigue_component: 100 − ATL (capped 0–100); higher = less fatigued
     - rhr_component: resting HR today vs 7-day average; lower today = better
     - hrv_component: overnight HRV vs personal baseline; higher = better recovered
+    - subjective_component: the athlete's own daily check-in (soreness/energy/mood)
 
     Any missing component is excluded from the weighted average so a partial
     data day still yields a meaningful score.
     """
-    # Weights — must sum to 1.0
+    # Weights — sum to 1.0 when every component is present; missing components
+    # are excluded and the remainder is renormalized (see total_weight below).
     WEIGHTS = {
         "sleep": 0.25,
         "recovery": 0.25,
         "fatigue": 0.20,
         "rhr": 0.10,
         "hrv": 0.20,
+        "subjective": 0.20,
     }
 
     # Sleep component
@@ -538,6 +565,9 @@ def compute_readiness(
     # HRV component — last-night HRV vs personal baseline (Garmin's status factor)
     hrv_component = _hrv_component(daily)
 
+    # Subjective component — the athlete's own daily check-in
+    subjective_component = _subjective_component(checkin)
+
     # Weighted composite
     weighted_sum = 0.0
     total_weight = 0.0
@@ -547,6 +577,7 @@ def compute_readiness(
         (fatigue_component, WEIGHTS["fatigue"]),
         (rhr_component, WEIGHTS["rhr"]),
         (hrv_component, WEIGHTS["hrv"]),
+        (subjective_component, WEIGHTS["subjective"]),
     ):
         if comp_val is not None:
             weighted_sum += comp_val * weight
@@ -564,6 +595,7 @@ def compute_readiness(
         fatigue_component=fatigue_component,
         rhr_component=rhr_component,
         hrv_component=hrv_component,
+        subjective_component=subjective_component,
     )
 
 
@@ -620,4 +652,6 @@ def format_readiness_context(readiness: TrainingReadiness | None) -> str:
         lines.append(f"- Resting HR trend: {readiness.rhr_component}/100")
     if readiness.hrv_component is not None:
         lines.append(f"- HRV (vs baseline): {readiness.hrv_component}/100")
+    if readiness.subjective_component is not None:
+        lines.append(f"- How the athlete says they feel (check-in): {readiness.subjective_component}/100")
     return "## Training Readiness\n" + "\n".join(lines)

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -208,7 +208,7 @@ new/existing tests pass (backend + frontend)._
 
 ### P1 — Ask the athlete, plan the real race
 
-#### P1-1 · Subjective feedback: per-run RPE + daily check-in
+#### P1-1 · Subjective feedback: per-run RPE + daily check-in ✅ Done.
 **What:** Two small subjective inputs, both feeding existing models. (a)
 **Per-activity RPE (1–10)** added to the existing feedback prompt (rating/tags/
 text already flow through `POST /activities/{id}/feedback`); stored on
@@ -237,6 +237,29 @@ lines), `app/plan_adaptation.py` (soreness folds into bands),
 `frontend/src/components/today/DailyCheckinCard.tsx` + `.css` (new),
 `frontend/src/api/{types,hooks}.ts`, `tests/test_training_load.py`,
 `tests/test_readiness.py`, `tests/test_api_endpoints.py`.
+_Implemented as described, scoped to P1-1 only. File locations follow the
+post-P3-1 split: routes landed in `app/routers/daily.py` (`/today`,
+`POST /daily-checkin`), `app/routers/activities.py` (feedback `rpe`), and
+`app/routers/plan.py` (adapt-day re-derivation now also reads the day's
+check-in); context lines landed in `app/coach/context.py`. The sRPE branch
+reuses the existing `_intensity_to_tss` helper with `intensity = rpe / 10`,
+so it sits on the same 100-TSS-per-threshold-hour scale as the pace/HR
+branches instead of introducing a separate arbitrary-units metric. The
+subjective readiness component is a new `"subjective": 0.20` entry in the
+existing weights dict — averaging whichever of soreness/energy/mood were
+tapped (1=worst, 5=best) onto 0–100 — and folds in for free via the
+composite's existing "exclude missing components" normalization.
+`plan_adaptation.suggest_adaptation` gained a direct check-in override
+(severe soreness or low energy/mood forces a downgrade on a hard day even
+when the composite score alone is "Good", the same way a bad HRV night
+would), rather than relying solely on the diluted composite score to move
+the reading across a band. "Persistent soreness in one area" is detected
+from an optional free-text `soreness_note` on the check-in (no per-body-part
+UI): three consecutive check-ins reporting soreness ≤2/5 with a matching
+note auto-record a `CoachMemory` niggle directly (same shape as the
+chat `mark_setback` tool), deduplicated so it's written once per area. All
+new and existing tests pass (893 backend); `npm run build`, `tsc -b`, and
+the Vitest suite (57 cases) are clean._
 
 #### P1-2 · Conditions-aware race pacing
 **What:** Fold expected race-day conditions into the pacing plans from v3/v4.

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -10,6 +10,8 @@ import type {
   DailySummaryDetail,
   CalendarDay,
   CalendarEvent,
+  DailyCheckin,
+  DailyCheckinRequest,
   FeedbackRequest,
   GarminConnectResult,
   GarminConnectionStatus,
@@ -59,6 +61,17 @@ export function useToday(date: string) {
   return useQuery({
     queryKey: ['today', date],
     queryFn: () => apiGet<TodayResponse>(`/today?date=${date}`),
+  })
+}
+
+export function useSubmitDailyCheckin() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ date, checkin }: { date: string; checkin: DailyCheckinRequest }) =>
+      apiPost<DailyCheckin>(`/daily-checkin?date=${date}`, checkin),
+    onSuccess: (_, { date }) => {
+      qc.invalidateQueries({ queryKey: ['today', date] })
+    },
   })
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -49,6 +49,7 @@ export interface FeedbackRequest {
   rating: 'good' | 'bad'
   tags?: string[]
   text?: string
+  rpe?: number | null
 }
 
 export interface GarminCredentialsRequest {
@@ -136,6 +137,7 @@ export interface ActivityDetail extends ActivitySummary {
   feedback_rating: string | null
   feedback_tags: string[] | null
   feedback_text: string | null
+  rpe: number | null
   insight: InsightResponse | null
   scheduled_workout: CalendarEvent | null
   adherence: WorkoutAdherence | null
@@ -276,6 +278,22 @@ export interface TrainingReadiness {
   fatigue_component: number | null
   rhr_component: number | null
   hrv_component: number | null
+  subjective_component: number | null
+}
+
+export interface DailyCheckinRequest {
+  soreness?: number | null
+  energy?: number | null
+  mood?: number | null
+  soreness_note?: string | null
+}
+
+export interface DailyCheckin {
+  date: string
+  soreness: number | null
+  energy: number | null
+  mood: number | null
+  soreness_note: string | null
 }
 
 export interface TrainingLoadResponse {
@@ -305,6 +323,7 @@ export interface TodayResponse {
   training_load: TrainingLoadPoint | null
   readiness: TrainingReadiness | null
   plan_adaptation: PlanAdaptationSuggestion | null
+  daily_checkin: DailyCheckin | null
 }
 
 export interface SettingsResponse {

--- a/frontend/src/components/activity-detail/FeedbackPrompt.css
+++ b/frontend/src/components/activity-detail/FeedbackPrompt.css
@@ -51,6 +51,42 @@
   color: #e74c3c;
 }
 
+.feedback-prompt__rpe-question {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 20px 0 8px;
+}
+
+.feedback-prompt__rpe-scale {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.feedback-prompt__rpe-chip {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.feedback-prompt__rpe-chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.feedback-prompt__rpe-chip--selected {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
 .feedback-prompt__loading {
   display: flex;
   align-items: center;

--- a/frontend/src/components/activity-detail/FeedbackPrompt.tsx
+++ b/frontend/src/components/activity-detail/FeedbackPrompt.tsx
@@ -8,12 +8,15 @@ interface Props {
   activityId: number
 }
 
+const RPE_SCALE = Array.from({ length: 10 }, (_, i) => i + 1)
+
 export default function FeedbackPrompt({ activityId }: Props) {
   const [showModal, setShowModal] = useState(false)
+  const [rpe, setRpe] = useState<number | null>(null)
   const submitFeedback = useSubmitFeedback()
 
   const handleThumbsUp = () => {
-    submitFeedback.mutate({ id: activityId, feedback: { rating: 'good' } })
+    submitFeedback.mutate({ id: activityId, feedback: { rating: 'good', rpe } })
   }
 
   const handleThumbsDown = () => {
@@ -22,12 +25,12 @@ export default function FeedbackPrompt({ activityId }: Props) {
 
   const handleSetbackSubmit = (tags: string[], text?: string) => {
     setShowModal(false)
-    submitFeedback.mutate({ id: activityId, feedback: { rating: 'bad', tags, text } })
+    submitFeedback.mutate({ id: activityId, feedback: { rating: 'bad', tags, text, rpe } })
   }
 
   const handleSetbackSkip = () => {
     setShowModal(false)
-    submitFeedback.mutate({ id: activityId, feedback: { rating: 'bad' } })
+    submitFeedback.mutate({ id: activityId, feedback: { rating: 'bad', rpe } })
   }
 
   if (submitFeedback.isPending) {
@@ -66,6 +69,22 @@ export default function FeedbackPrompt({ activityId }: Props) {
             >
               <ThumbsDown size={22} />
             </button>
+          </div>
+
+          <p className="feedback-prompt__rpe-question">
+            How hard did it feel? (optional)
+          </p>
+          <div className="feedback-prompt__rpe-scale">
+            {RPE_SCALE.map(value => (
+              <button
+                key={value}
+                type="button"
+                className={`feedback-prompt__rpe-chip ${rpe === value ? 'feedback-prompt__rpe-chip--selected' : ''}`}
+                onClick={() => setRpe(rpe === value ? null : value)}
+              >
+                {value}
+              </button>
+            ))}
           </div>
         </div>
       </section>

--- a/frontend/src/components/today/DailyCheckinCard.css
+++ b/frontend/src/components/today/DailyCheckinCard.css
@@ -1,0 +1,114 @@
+.daily-checkin-card {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.checkin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.checkin-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.checkin-edit-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.checkin-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.checkin-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.checkin-row-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+
+.checkin-row-hint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.checkin-row-taps {
+  display: flex;
+  gap: 8px;
+}
+
+.checkin-tap {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.checkin-tap:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.checkin-tap--selected {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.checkin-note-input {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.85rem;
+  box-sizing: border-box;
+}
+
+.checkin-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.checkin-skip {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 8px 4px;
+}
+
+.checkin-submit {
+  font-size: 0.85rem;
+  padding: 8px 16px;
+}

--- a/frontend/src/components/today/DailyCheckinCard.tsx
+++ b/frontend/src/components/today/DailyCheckinCard.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react'
+import { useSubmitDailyCheckin } from '../../api/hooks'
+import type { DailyCheckin } from '../../api/types'
+import './DailyCheckinCard.css'
+
+interface Props {
+  date: string
+  checkin: DailyCheckin | null
+}
+
+const SCALE = [1, 2, 3, 4, 5]
+
+function TapRow({
+  label,
+  hint,
+  value,
+  onChange,
+}: {
+  label: string
+  hint: string
+  value: number | null
+  onChange: (v: number) => void
+}) {
+  return (
+    <div className="checkin-row">
+      <div className="checkin-row-label">
+        <span>{label}</span>
+        <span className="checkin-row-hint">{hint}</span>
+      </div>
+      <div className="checkin-row-taps">
+        {SCALE.map(v => (
+          <button
+            key={v}
+            type="button"
+            className={`checkin-tap ${value === v ? 'checkin-tap--selected' : ''}`}
+            onClick={() => onChange(v)}
+          >
+            {v}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default function DailyCheckinCard({ date, checkin }: Props) {
+  const [editing, setEditing] = useState(!checkin)
+  const [dismissed, setDismissed] = useState(false)
+  const [soreness, setSoreness] = useState<number | null>(checkin?.soreness ?? null)
+  const [energy, setEnergy] = useState<number | null>(checkin?.energy ?? null)
+  const [mood, setMood] = useState<number | null>(checkin?.mood ?? null)
+  const [sorenessNote, setSorenessNote] = useState(checkin?.soreness_note ?? '')
+  const submitCheckin = useSubmitDailyCheckin()
+
+  // Reset local state when the viewed date (or its check-in) changes.
+  useEffect(() => {
+    setSoreness(checkin?.soreness ?? null)
+    setEnergy(checkin?.energy ?? null)
+    setMood(checkin?.mood ?? null)
+    setSorenessNote(checkin?.soreness_note ?? '')
+    setEditing(!checkin)
+    setDismissed(false)
+  }, [date, checkin])
+
+  if (dismissed && !checkin) return null
+
+  const canSubmit = soreness !== null || energy !== null || mood !== null
+
+  const handleSubmit = () => {
+    submitCheckin.mutate(
+      { date, checkin: { soreness, energy, mood, soreness_note: sorenessNote.trim() || null } },
+      { onSuccess: () => setEditing(false) },
+    )
+  }
+
+  if (!editing && checkin) {
+    return (
+      <div className="card daily-checkin-card">
+        <div className="checkin-header">
+          <h3 className="checkin-title">How you're feeling</h3>
+          <button className="checkin-edit-btn" onClick={() => setEditing(true)}>
+            Edit
+          </button>
+        </div>
+        <div className="checkin-summary">
+          {checkin.soreness != null && <span>Soreness {checkin.soreness}/5</span>}
+          {checkin.energy != null && <span>Energy {checkin.energy}/5</span>}
+          {checkin.mood != null && <span>Mood {checkin.mood}/5</span>}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="card daily-checkin-card">
+      <h3 className="checkin-title">How are you feeling today?</h3>
+      <TapRow label="Soreness" hint="1 = very sore, 5 = none" value={soreness} onChange={setSoreness} />
+      <TapRow label="Energy" hint="1 = depleted, 5 = energized" value={energy} onChange={setEnergy} />
+      <TapRow label="Mood" hint="1 = low, 5 = great" value={mood} onChange={setMood} />
+      {soreness !== null && soreness <= 3 && (
+        <input
+          className="checkin-note-input"
+          type="text"
+          placeholder="Where's it sore? (optional, e.g. left knee)"
+          value={sorenessNote}
+          onChange={e => setSorenessNote(e.target.value)}
+        />
+      )}
+      <div className="checkin-actions">
+        <button
+          className="checkin-skip"
+          onClick={() => (checkin ? setEditing(false) : setDismissed(true))}
+        >
+          {checkin ? 'Cancel' : 'Skip'}
+        </button>
+        <button
+          className="btn-primary checkin-submit"
+          onClick={handleSubmit}
+          disabled={!canSubmit || submitCheckin.isPending}
+        >
+          {checkin ? 'Update' : 'Log check-in'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/today/ReadinessCard.tsx
+++ b/frontend/src/components/today/ReadinessCard.tsx
@@ -57,6 +57,7 @@ export default function ReadinessCard({ readiness }: Props) {
         <ComponentBar label="Freshness" value={readiness.fatigue_component} />
         <ComponentBar label="Resting HR" value={readiness.rhr_component} />
         <ComponentBar label="HRV" value={readiness.hrv_component} />
+        <ComponentBar label="How you feel" value={readiness.subjective_component} />
       </div>
     </div>
   )

--- a/frontend/src/components/today/TodayView.tsx
+++ b/frontend/src/components/today/TodayView.tsx
@@ -7,6 +7,7 @@ import ScheduledWorkoutCard from './ScheduledWorkoutCard'
 import WeekOverview from './WeekOverview'
 import TrainingLoadChart from './TrainingLoadChart'
 import ReadinessCard from './ReadinessCard'
+import DailyCheckinCard from './DailyCheckinCard'
 import PlanAdaptationCard from './PlanAdaptationCard'
 import InsightsList from './InsightsList'
 import RacePacingCard from './RacePacingCard'
@@ -134,6 +135,11 @@ export default function TodayView() {
           <ReadinessCard readiness={data.readiness} />
         </section>
       )}
+
+      {/* Daily check-in: soreness / energy / mood */}
+      <section className="today-section">
+        <DailyCheckinCard date={dateKey} checkin={data?.daily_checkin ?? null} />
+      </section>
 
       {/* Readiness-driven plan adaptation suggestion */}
       {data?.plan_adaptation && (

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -341,6 +341,26 @@ def test_feedback_rejects_invalid_rating(client, db, no_threads):
     assert resp.status_code == 422
 
 
+def test_submit_feedback_stores_rpe(client, db, patch_db_session):
+    import app.ai_coach as ai_coach
+    patch_db_session(ai_coach)
+    act = _add_activity(db, datetime(2026, 6, 1, 7, 0))
+    resp = client.post(
+        f"/api/v1/activities/{act.id}/feedback",
+        json={"rating": "good", "rpe": 6},
+    )
+    assert resp.status_code == 200
+    db.expire_all()
+    refreshed = db.get(Activity, act.id)
+    assert refreshed.rpe == 6
+
+
+def test_feedback_rejects_rpe_out_of_range(client, db, no_threads):
+    act = _add_activity(db, datetime(2026, 6, 1, 7, 0))
+    resp = client.post(f"/api/v1/activities/{act.id}/feedback", json={"rating": "good", "rpe": 11})
+    assert resp.status_code == 422
+
+
 @pytest.mark.parametrize("sync_type", ["activities", "daily", "calendar"])
 def test_trigger_sync_accepted(client, no_threads, sync_type):
     resp = client.post(f"/api/v1/sync/{sync_type}")

--- a/tests/test_daily_checkin.py
+++ b/tests/test_daily_checkin.py
@@ -1,0 +1,121 @@
+"""Tests for the daily check-in endpoint and persistent-soreness niggle detection (P1-1)."""
+
+from datetime import date
+
+from app.models import CoachMemory, DailyCheckin
+
+
+def test_submit_checkin_creates_row(client, db):
+    resp = client.post(
+        "/api/v1/daily-checkin?date=2026-06-17",
+        json={"soreness": 4, "energy": 3, "mood": 5},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["date"] == "2026-06-17"
+    assert body["soreness"] == 4
+    assert body["energy"] == 3
+    assert body["mood"] == 5
+    assert db.query(DailyCheckin).count() == 1
+
+
+def test_submit_checkin_defaults_to_today(client, db):
+    resp = client.post("/api/v1/daily-checkin", json={"soreness": 3})
+    assert resp.status_code == 200
+    assert resp.json()["date"] == date.today().isoformat()
+
+
+def test_submit_checkin_upserts_same_day(client, db):
+    client.post("/api/v1/daily-checkin?date=2026-06-17", json={"soreness": 2, "energy": 2})
+    resp = client.post("/api/v1/daily-checkin?date=2026-06-17", json={"soreness": 5, "mood": 4})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["soreness"] == 5
+    assert body["energy"] is None  # overwritten, not merged
+    assert body["mood"] == 4
+    assert db.query(DailyCheckin).count() == 1
+
+
+def test_submit_checkin_all_taps_optional(client, db):
+    # An empty check-in (all taps skipped) is still a valid submission.
+    resp = client.post("/api/v1/daily-checkin?date=2026-06-17", json={})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["soreness"] is None
+    assert body["energy"] is None
+    assert body["mood"] is None
+
+
+def test_checkin_rejects_out_of_range_taps(client):
+    resp = client.post("/api/v1/daily-checkin?date=2026-06-17", json={"soreness": 6})
+    assert resp.status_code == 422
+
+
+def test_checkin_accepts_soreness_note(client, db):
+    resp = client.post(
+        "/api/v1/daily-checkin?date=2026-06-17",
+        json={"soreness": 2, "soreness_note": "left knee"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["soreness_note"] == "left knee"
+
+
+def test_today_endpoint_returns_null_checkin_when_none_logged(client, db):
+    resp = client.get("/api/v1/today?date=2026-06-17")
+    assert resp.status_code == 200
+    assert resp.json()["daily_checkin"] is None
+
+
+def test_today_endpoint_returns_logged_checkin(client, db):
+    client.post("/api/v1/daily-checkin?date=2026-06-17", json={"soreness": 4, "energy": 4, "mood": 4})
+    resp = client.get("/api/v1/today?date=2026-06-17")
+    assert resp.json()["daily_checkin"]["soreness"] == 4
+
+
+# --- Persistent soreness -> CoachMemory niggle ---
+
+def test_persistent_sore_area_creates_niggle_after_three_checkins(client, db):
+    for d in ("2026-06-15", "2026-06-16", "2026-06-17"):
+        resp = client.post(
+            f"/api/v1/daily-checkin?date={d}",
+            json={"soreness": 2, "soreness_note": "left knee"},
+        )
+        assert resp.status_code == 200
+
+    niggles = db.query(CoachMemory).filter(CoachMemory.category == "niggle").all()
+    assert len(niggles) == 1
+    assert niggles[0].tag == "left knee"
+    assert niggles[0].active is True
+
+
+def test_no_niggle_before_three_consecutive_checkins(client, db):
+    for d in ("2026-06-16", "2026-06-17"):
+        client.post(f"/api/v1/daily-checkin?date={d}", json={"soreness": 1, "soreness_note": "left knee"})
+    assert db.query(CoachMemory).count() == 0
+
+
+def test_no_niggle_without_soreness_note(client, db):
+    for d in ("2026-06-15", "2026-06-16", "2026-06-17"):
+        client.post(f"/api/v1/daily-checkin?date={d}", json={"soreness": 1})
+    assert db.query(CoachMemory).count() == 0
+
+
+def test_no_niggle_when_soreness_recovers(client, db):
+    client.post("/api/v1/daily-checkin?date=2026-06-15", json={"soreness": 1, "soreness_note": "left knee"})
+    client.post("/api/v1/daily-checkin?date=2026-06-16", json={"soreness": 1, "soreness_note": "left knee"})
+    # Recovered on the third day - no niggle should be recorded.
+    client.post("/api/v1/daily-checkin?date=2026-06-17", json={"soreness": 5, "soreness_note": "left knee"})
+    assert db.query(CoachMemory).count() == 0
+
+
+def test_no_niggle_when_area_changes(client, db):
+    client.post("/api/v1/daily-checkin?date=2026-06-15", json={"soreness": 1, "soreness_note": "left knee"})
+    client.post("/api/v1/daily-checkin?date=2026-06-16", json={"soreness": 1, "soreness_note": "right calf"})
+    client.post("/api/v1/daily-checkin?date=2026-06-17", json={"soreness": 1, "soreness_note": "left knee"})
+    assert db.query(CoachMemory).count() == 0
+
+
+def test_niggle_not_duplicated_on_further_sore_checkins(client, db):
+    for d in ("2026-06-15", "2026-06-16", "2026-06-17", "2026-06-18"):
+        client.post(f"/api/v1/daily-checkin?date={d}", json={"soreness": 2, "soreness_note": "left knee"})
+    assert db.query(CoachMemory).filter(CoachMemory.category == "niggle").count() == 1

--- a/tests/test_plan_adaptation.py
+++ b/tests/test_plan_adaptation.py
@@ -1,6 +1,6 @@
 """Tests for readiness-driven plan day adaptation (P1-1)."""
 
-from app.models import TrainingPlanDay
+from app.models import DailyCheckin, TrainingPlanDay
 from app.plan_adaptation import suggest_adaptation
 from app.schemas import TrainingReadiness
 
@@ -19,6 +19,10 @@ def _day(workout_type="tempo", target_distance_m=10000.0, day_id=1):
 
 def _readiness(score, label="Fair"):
     return TrainingReadiness(score=score, label=label)
+
+
+def _checkin(*, soreness=None, energy=None, mood=None):
+    return DailyCheckin(soreness=soreness, energy=energy, mood=mood)
 
 
 def test_no_suggestion_without_plan_day():
@@ -93,3 +97,48 @@ def test_rest_day_never_suggests():
 def test_strength_and_cross_days_never_suggest():
     assert suggest_adaptation(_day(workout_type="strength"), _readiness(95)) is None
     assert suggest_adaptation(_day(workout_type="cross"), _readiness(95)) is None
+
+
+# --- Check-in override ---
+
+def test_checkin_feels_bad_overrides_good_readiness_on_hard_day():
+    day = _day(workout_type="tempo", target_distance_m=10000.0)
+    # Readiness alone ("Good", 70) would not trigger any suggestion.
+    assert suggest_adaptation(day, _readiness(70, "Good")) is None
+    suggestion = suggest_adaptation(day, _readiness(70, "Good"), _checkin(soreness=1))
+    assert suggestion is not None
+    assert suggestion.direction == "downgrade"
+    assert suggestion.suggested_workout_type == "easy"
+    assert suggestion.suggested_target_distance_m == 6000.0
+
+
+def test_checkin_low_energy_also_overrides():
+    day = _day(workout_type="interval")
+    suggestion = suggest_adaptation(day, _readiness(80, "Very Good"), _checkin(energy=2))
+    assert suggestion is not None
+    assert suggestion.direction == "downgrade"
+
+
+def test_checkin_low_mood_also_overrides():
+    day = _day(workout_type="long")
+    suggestion = suggest_adaptation(day, _readiness(80, "Very Good"), _checkin(mood=1))
+    assert suggestion is not None
+    assert suggestion.direction == "downgrade"
+
+
+def test_checkin_feeling_fine_does_not_override_good_readiness():
+    day = _day(workout_type="tempo")
+    assert suggest_adaptation(day, _readiness(70, "Good"), _checkin(soreness=5, energy=5, mood=5)) is None
+
+
+def test_checkin_override_does_not_apply_to_easy_days():
+    day = _day(workout_type="easy", target_distance_m=8000.0)
+    assert suggest_adaptation(day, _readiness(70, "Good"), _checkin(soreness=1)) is None
+
+
+def test_checkin_does_not_downgrade_already_low_readiness_twice():
+    # Low readiness already downgrades to rest; the check-in doesn't change that outcome.
+    day = _day(workout_type="tempo")
+    suggestion = suggest_adaptation(day, _readiness(25, "Low"), _checkin(soreness=1))
+    assert suggestion is not None
+    assert suggestion.suggested_workout_type == "rest"

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -5,7 +5,7 @@ from datetime import date, datetime, timedelta
 import pytest
 
 from app import training_load
-from app.models import Activity, DailySummary
+from app.models import Activity, DailyCheckin, DailySummary
 from app.schemas import TrainingLoadPoint
 
 
@@ -40,6 +40,10 @@ def _daily(
 
 def _load(atl: float) -> TrainingLoadPoint:
     return TrainingLoadPoint(date=date.today(), tss=0, ctl=0, atl=atl, tsb=0)
+
+
+def _checkin(*, soreness=None, energy=None, mood=None):
+    return DailyCheckin(date=date.today(), soreness=soreness, energy=energy, mood=mood)
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +250,52 @@ def test_hrv_component_folds_into_composite():
 
 
 # ---------------------------------------------------------------------------
+# Subjective component (daily check-in)
+# ---------------------------------------------------------------------------
+
+def test_subjective_component_none_without_checkin():
+    result = training_load.compute_readiness(_daily(sleep_score=80), None, [])
+    assert result is not None
+    assert result.subjective_component is None
+
+
+def test_subjective_component_none_when_checkin_has_no_taps():
+    result = training_load.compute_readiness(None, None, [], _checkin())
+    assert result is None
+
+
+def test_subjective_component_best_case_gives_100():
+    result = training_load.compute_readiness(None, None, [], _checkin(soreness=5, energy=5, mood=5))
+    assert result is not None
+    assert result.subjective_component == 100
+
+
+def test_subjective_component_worst_case_gives_0():
+    result = training_load.compute_readiness(None, None, [], _checkin(soreness=1, energy=1, mood=1))
+    assert result is not None
+    assert result.subjective_component == 0
+
+
+def test_subjective_component_averages_present_taps():
+    # soreness=3 -> 50, energy=5 -> 100 -> avg 75
+    result = training_load.compute_readiness(None, None, [], _checkin(soreness=3, energy=5))
+    assert result is not None
+    assert result.subjective_component == 75
+
+
+def test_subjective_component_folds_into_composite():
+    # Strong check-in should lift the composite versus a bad one, all else equal.
+    good = training_load.compute_readiness(
+        _daily(sleep_score=70), None, [], _checkin(soreness=5, energy=5, mood=5)
+    )
+    bad = training_load.compute_readiness(
+        _daily(sleep_score=70), None, [], _checkin(soreness=1, energy=1, mood=1)
+    )
+    assert good is not None and bad is not None
+    assert good.score > bad.score
+
+
+# ---------------------------------------------------------------------------
 # Labels
 # ---------------------------------------------------------------------------
 
@@ -335,6 +385,12 @@ def test_format_readiness_context_includes_components():
     assert "Resting HR" in text
 
 
+def test_format_readiness_context_includes_subjective_component():
+    result = training_load.compute_readiness(None, None, [], _checkin(soreness=4, energy=4, mood=4))
+    text = training_load.format_readiness_context(result)
+    assert "check-in" in text.lower()
+
+
 # ---------------------------------------------------------------------------
 # API endpoint — /today includes readiness
 # ---------------------------------------------------------------------------
@@ -364,6 +420,18 @@ def test_today_endpoint_includes_readiness_when_data_available(client, db):
     r = body["readiness"]
     assert 0 <= r["score"] <= 100
     assert r["label"] in ("Low", "Fair", "Good", "Very Good", "Excellent")
+
+
+def test_today_endpoint_folds_in_daily_checkin(client, db):
+    db.add(DailyCheckin(date=date(2026, 6, 17), soreness=5, energy=5, mood=5))
+    db.commit()
+    resp = client.get("/api/v1/today?date=2026-06-17")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["readiness"] is not None
+    assert body["readiness"]["subjective_component"] == 100
+    assert body["daily_checkin"] is not None
+    assert body["daily_checkin"]["soreness"] == 5
 
 
 def test_today_endpoint_readiness_null_without_any_data(client, db):

--- a/tests/test_training_load.py
+++ b/tests/test_training_load.py
@@ -46,6 +46,37 @@ def test_estimate_tss_hr_based_when_no_pace_threshold():
     assert round(tss) == 100
 
 
+def test_estimate_tss_srpe_used_when_no_pace_or_hr_reference():
+    # RPE 7/10 for 1 hour -> intensity 0.7 -> TSS = 1 * 0.7^2 * 100 = 49
+    act = Activity(duration_sec=3600, rpe=7)
+    tss, source = training_load.estimate_tss(act, None)
+    assert source == "srpe"
+    assert round(tss) == 49
+
+
+def test_estimate_tss_srpe_max_effort():
+    # RPE 10/10 for 30 min -> intensity 1.0 -> TSS = 0.5 * 1.0^2 * 100 = 50
+    act = Activity(duration_sec=1800, rpe=10)
+    tss, source = training_load.estimate_tss(act, None)
+    assert source == "srpe"
+    assert round(tss) == 50
+
+
+def test_estimate_tss_srpe_takes_priority_over_duration_floor():
+    act = Activity(duration_sec=3600, rpe=3)
+    tss, source = training_load.estimate_tss(act, None)
+    assert source == "srpe"
+    # RPE 3/10 is a much lighter intensity than the default 0.70 duration-floor guess.
+    assert tss < training_load._intensity_to_tss(1.0, training_load._DEFAULT_IF)
+
+
+def test_estimate_tss_pace_reference_takes_priority_over_srpe():
+    profile = AthleteProfile(threshold_pace_min_km=5.0)
+    act = Activity(duration_sec=3600, avg_pace_min_km=5.0, rpe=2)
+    tss, source = training_load.estimate_tss(act, profile)
+    assert source == "pace"
+
+
 def test_estimate_tss_duration_floor_without_references():
     act = Activity(duration_sec=3600)
     tss, source = training_load.estimate_tss(act, None)


### PR DESCRIPTION
Adds Activity.rpe and a DailyCheckin (soreness/energy/mood) model feeding
the existing systems: sRPE joins the TSS fallback chain between hrTSS and
the duration floor, readiness gains a subjective component, plan
adaptation can override a hard day on a bad check-in alone, and
persistent soreness in one area auto-records a CoachMemory niggle. Adds
the RPE selector to the activity feedback prompt and a new DailyCheckinCard
on Today.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XjRCejVGB5s7eWKBQheD1J