### PR TITLE
Tag activities that fulfil scheduled workouts on Today view

### DIFF
--- a/app/routers/daily.py
+++ b/app/routers/daily.py
@@ -180,7 +180,32 @@ def api_today(
         .order_by(GarminCalendarEvent.id.asc())
         .all()
     )
-    scheduled_events = [_enrich_event_with_steps(e) for e in scheduled_events_rows]
+    # Match completed activities to scheduled workouts. When an activity fulfils
+    # a scheduled workout (same day, same sport category), drop that workout from
+    # the "Scheduled" list and tag the activity so the UI shows a "workout" badge.
+    activity_summaries = [ActivitySummary.model_validate(a) for a in activities]
+    summary_by_id = {s.id: s for s in activity_summaries}
+    claimed_activity_ids: set[int] = set()
+    remaining_events = []
+    for event in scheduled_events_rows:
+        workout_category = (
+            _categorize_activity_type(event.workout_type) if event.workout_type else "run"
+        )
+        matched = next(
+            (
+                a
+                for a in activities
+                if a.id not in claimed_activity_ids
+                and _categorize_activity_type(a.activity_type) == workout_category
+            ),
+            None,
+        )
+        if matched is not None:
+            claimed_activity_ids.add(matched.id)
+            summary_by_id[matched.id].workout_tag = event.title or event.workout_type or "Workout"
+        else:
+            remaining_events.append(event)
+    scheduled_events = [_enrich_event_with_steps(e) for e in remaining_events]
 
     # Current training load snapshot (Fitness/Fatigue/Form) as of the selected date
     current_load = training_load.current_load(db, as_of=selected, user_id=uid)
@@ -221,7 +246,7 @@ def api_today(
 
     return TodayResponse(
         selected_date=selected,
-        activities=[ActivitySummary.model_validate(a) for a in activities],
+        activities=activity_summaries,
         daily_summary=DailySummaryResponse.model_validate(daily_summary) if daily_summary else None,
         weekly_data=weekly_data,
         insights=[InsightResponse.model_validate(i) for i in latest_insights],

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -20,6 +20,9 @@ class ActivitySummary(BaseModel):
     avg_pace_min_km: float | None = None
     calories: float | None = None
     elevation_gain: float | None = None
+    # Set when this activity fulfils a scheduled workout on the same day. Carries
+    # the matched workout's label so the UI can show a "workout" tag.
+    workout_tag: str | None = None
 
     class Config:
         from_attributes = True

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -33,6 +33,7 @@ export interface ActivitySummary {
   avg_pace_min_km: number | null
   calories: number | null
   elevation_gain: number | null
+  workout_tag?: string | null
 }
 
 export interface InsightResponse {

--- a/frontend/src/components/today/WorkoutCard.css
+++ b/frontend/src/components/today/WorkoutCard.css
@@ -19,6 +19,24 @@
   margin-bottom: 6px;
 }
 
+.workout-header-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.workout-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 999px;
+  color: var(--success);
+  background: rgba(46, 204, 113, 0.14);
+}
+
 .workout-time {
   font-size: 0.75rem;
   color: var(--text-muted);

--- a/frontend/src/components/today/WorkoutCard.tsx
+++ b/frontend/src/components/today/WorkoutCard.tsx
@@ -3,6 +3,7 @@ import type { ActivitySummary } from '../../api/types'
 import { getActivityColor, colorMap } from '../../utils/colors'
 import { formatDistance, formatDuration, formatPace } from '../../utils/formatting'
 import { format, parseISO } from '../../utils/date'
+import { CheckCircle } from 'lucide-react'
 import './WorkoutCard.css'
 
 interface Props {
@@ -25,7 +26,15 @@ export default function WorkoutCard({ activity }: Props) {
       onClick={() => navigate(`/activities/${activity.id}`)}
     >
       <div className="workout-header">
-        <span className="badge" style={{ background: `${color}22`, color }}>{typeLabel}</span>
+        <div className="workout-header-left">
+          <span className="badge" style={{ background: `${color}22`, color }}>{typeLabel}</span>
+          {activity.workout_tag && (
+            <span className="workout-tag" title={activity.workout_tag}>
+              <CheckCircle size={12} />
+              Workout
+            </span>
+          )}
+        </div>
         {activity.started_at && (
           <span className="workout-time">{format(parseISO(activity.started_at), 'HH:mm')}</span>
         )}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -59,3 +59,26 @@ flag. The manual `/sync` endpoint is scoped to the calling user.
 
 **Models, not FKs.** Following the existing convention (`TrainingPlanDay.plan_id`
 is a plain indexed int, not a `ForeignKey`), `user_id` is a plain indexed integer.
+
+---
+
+# Today view: matched workout tagging
+
+Goal: when an activity fulfils a scheduled workout on the same day, the
+scheduled card disappears from Today and the activity is tagged as a workout.
+
+## Tasks
+- [x] schemas.py: add `workout_tag` to `ActivitySummary`.
+- [x] routers/daily.py `/today`: match activities to scheduled workouts by
+      same-day + sport category; drop matched workouts from `scheduled_events`,
+      set `workout_tag` on the matched activity summary.
+- [x] frontend types + WorkoutCard: render a "Workout" badge when tagged.
+- [x] tests: matched run consumes the scheduled card + tags the activity;
+      non-matching sport leaves the scheduled card and no tag.
+
+## Review
+- Matching reuses the existing `_categorize_activity_type` grouping so a run
+  fulfils a running workout while a ride/walk does not; each workout claims at
+  most one activity (1:1), and workouts with no matching activity stay scheduled.
+- Backend change is confined to `/today`; the activity-detail page still shows
+  the planned workout + adherence unchanged.

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -595,6 +595,45 @@ def test_today_plan_adaptation_suppressed_when_dismissed(client, db):
     assert resp.json()["plan_adaptation"] is None
 
 
+def test_today_matched_workout_drops_scheduled_and_tags_activity(client, db):
+    """A completed run on the day of a scheduled running workout consumes the
+    scheduled card and tags the activity as fulfilling that workout."""
+    day = date(2026, 6, 17)
+    db.add(GarminCalendarEvent(
+        garmin_id="wk_ep", event_type="workout", date=day,
+        title="Tempo 8K", workout_type="running",
+    ))
+    _add_activity(db, datetime(2026, 6, 17, 8, 0), name="Tempo Run")
+    db.commit()
+
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    body = resp.json()
+    # Scheduled workout is consumed by the matching activity.
+    assert body["scheduled_events"] == []
+    # The activity carries the workout tag.
+    assert len(body["activities"]) == 1
+    assert body["activities"][0]["workout_tag"] == "Tempo 8K"
+
+
+def test_today_unmatched_workout_stays_scheduled(client, db):
+    """A cycling activity does not fulfil a scheduled running workout; the
+    scheduled card remains and the activity is not tagged."""
+    day = date(2026, 6, 17)
+    db.add(GarminCalendarEvent(
+        garmin_id="wk_ep2", event_type="workout", date=day,
+        title="Tempo 8K", workout_type="running",
+    ))
+    _add_activity(db, datetime(2026, 6, 17, 8, 0), activity_type="cycling", name="Ride")
+    db.commit()
+
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["scheduled_events"]) == 1
+    assert body["activities"][0]["workout_tag"] is None
+
+
 def test_adapt_day_accept_downgrade_to_rest(client, db):
     day = date(2026, 6, 17)
     _seed_low_readiness_daily(db, day)


### PR DESCRIPTION
When a completed activity matches a scheduled workout on the same day
(same sport category), drop that workout from the Today "Scheduled" list
and tag the activity with a "Workout" badge instead. Matching reuses the
existing activity-type categorization so a run fulfils a running workout
while a ride or walk does not; each workout claims at most one activity
and unmatched workouts stay scheduled.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018ZzCkNsLfB17e44w5tP4bu