### PR TITLE
Implement P2-1: injury-risk early warning that acts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -243,12 +243,19 @@ def _push_plan_adaptation_if_needed(user_id: int, today_summary: DailySummary | 
             .all()
         ]
         readiness = training_load.compute_readiness(today_summary, current_load, recent_rhr)
-        suggestion = plan_adaptation_mod.suggest_adaptation(plan_day, readiness)
+        active_niggle = plan_adaptation_mod.get_active_niggle(db, user_id)
+        suggestion = plan_adaptation_mod.suggest_adaptation(
+            plan_day,
+            readiness,
+            injury_risk=current_load.injury_risk if current_load else None,
+            active_niggle=active_niggle,
+        )
         if suggestion is None:
             return
 
         title = (
-            "Consider easing off today" if suggestion.direction == "downgrade"
+            "Load caution: consider easing off" if suggestion.trigger == "risk"
+            else "Consider easing off today" if suggestion.direction == "downgrade"
             else "You're primed for more today"
         )
         notifications_mod.notify(

--- a/app/plan_adaptation.py
+++ b/app/plan_adaptation.py
@@ -1,15 +1,24 @@
-"""Daily readiness-driven workout adaptation (P1-1).
+"""Daily readiness-driven workout adaptation (P1-1) and risk-triggered caution (P2-1).
 
 Closes the loop between the readiness score computed in ``training_load`` and
 the static ``TrainingPlanDay`` prescription: a hard day paired with low
 readiness is downgraded, and an easy day paired with excellent readiness gets
 a small upgrade nudge. Purely rule-based (readiness bands x workout type) —
 no AI involved.
+
+P2-1 adds a second, independent trigger: the ACWR/ramp-rate-derived
+``injury_risk`` flag (``DailyLoadSeries``) and any active soreness
+``CoachMemory`` niggle. Either can force a hard-day cutback *even when
+readiness alone looks Good* — a good HRV night doesn't undo an accumulating
+load spike or a nagging niggle — and suppresses the easy-day upgrade nudge so
+the coach never suggests "add more" while risk is elevated.
 """
 
 from __future__ import annotations
 
-from app.models import DailyCheckin, TrainingPlanDay
+from sqlalchemy.orm import Session
+
+from app.models import CoachMemory, DailyCheckin, TrainingPlanDay
 from app.schemas import PlanAdaptationSuggestion, TrainingReadiness
 
 HARD_WORKOUT_TYPES = {"tempo", "interval", "long"}
@@ -26,6 +35,20 @@ _UPGRADE_DISTANCE_CAP_M = 2000.0
 # score, the same way a "legs dead" report should downgrade a hard day.
 _CHECKIN_SORENESS_OVERRIDE = 2
 _CHECKIN_LOW_OVERRIDE = 2
+
+
+def get_active_niggle(db: Session, user_id: int) -> CoachMemory | None:
+    """The athlete's most recently recorded active soreness niggle, if any."""
+    return (
+        db.query(CoachMemory)
+        .filter(
+            CoachMemory.user_id == user_id,
+            CoachMemory.category == "niggle",
+            CoachMemory.active.is_(True),
+        )
+        .order_by(CoachMemory.created_at.desc())
+        .first()
+    )
 
 
 def _checkin_feels_bad(checkin: DailyCheckin | None) -> bool:
@@ -45,14 +68,65 @@ def suggest_adaptation(
     plan_day: TrainingPlanDay | None,
     readiness: TrainingReadiness | None,
     checkin: DailyCheckin | None = None,
+    injury_risk: str | None = None,
+    active_niggle: CoachMemory | None = None,
 ) -> PlanAdaptationSuggestion | None:
-    """Propose a rule-based swap for today's plan day, or None if no change is warranted."""
+    """Propose a rule-based swap for today's plan day, or None if no change is warranted.
+
+    ``injury_risk`` (from ``DailyLoadSeries``/``TrainingLoadPoint``) and
+    ``active_niggle`` (an active soreness ``CoachMemory`` row) are optional
+    P2-1 risk signals: a "high" risk reading or a live niggle forces a hard-day
+    cutback regardless of the readiness band, and blocks the easy-day upgrade
+    nudge.
+    """
     if plan_day is None or readiness is None:
         return None
 
     workout_type = plan_day.workout_type
+    risk_high = injury_risk == "high"
 
     if workout_type in HARD_WORKOUT_TYPES:
+        if readiness.score <= 30:
+            return PlanAdaptationSuggestion(
+                plan_day_id=plan_day.id,
+                direction="downgrade",
+                current_workout_type=workout_type,
+                suggested_workout_type="rest",
+                current_target_distance_m=plan_day.target_distance_m,
+                suggested_target_distance_m=None,
+                reason=(
+                    f"Readiness is Low today ({readiness.score}/100) — consider "
+                    f"resting instead of today's {workout_type} session."
+                ),
+                readiness_score=readiness.score,
+                trigger="readiness",
+            )
+        if risk_high or active_niggle is not None:
+            causes = []
+            if risk_high:
+                causes.append("your training-load risk is elevated (ACWR/ramp-rate)")
+            if active_niggle is not None:
+                causes.append(f"you've been noting soreness ({active_niggle.tag})")
+            suggested_distance = (
+                round(plan_day.target_distance_m * _DOWNGRADE_DISTANCE_FACTOR)
+                if plan_day.target_distance_m
+                else None
+            )
+            return PlanAdaptationSuggestion(
+                plan_day_id=plan_day.id,
+                direction="downgrade",
+                current_workout_type=workout_type,
+                suggested_workout_type="easy",
+                current_target_distance_m=plan_day.target_distance_m,
+                suggested_target_distance_m=suggested_distance,
+                reason=(
+                    "Load caution: " + " and ".join(causes) + " — consider swapping "
+                    f"today's {workout_type} for an easy effort to protect against "
+                    f"injury, even though readiness looks {readiness.label.lower()}."
+                ),
+                readiness_score=readiness.score,
+                trigger="risk",
+            )
         if readiness.score > 50 and _checkin_feels_bad(checkin):
             suggested_distance = (
                 round(plan_day.target_distance_m * _DOWNGRADE_DISTANCE_FACTOR)
@@ -71,20 +145,7 @@ def suggest_adaptation(
                     f"swapping today's {workout_type} for an easy effort."
                 ),
                 readiness_score=readiness.score,
-            )
-        if readiness.score <= 30:
-            return PlanAdaptationSuggestion(
-                plan_day_id=plan_day.id,
-                direction="downgrade",
-                current_workout_type=workout_type,
-                suggested_workout_type="rest",
-                current_target_distance_m=plan_day.target_distance_m,
-                suggested_target_distance_m=None,
-                reason=(
-                    f"Readiness is Low today ({readiness.score}/100) — consider "
-                    f"resting instead of today's {workout_type} session."
-                ),
-                readiness_score=readiness.score,
+                trigger="checkin",
             )
         if readiness.score <= 50:
             suggested_distance = (
@@ -104,10 +165,11 @@ def suggest_adaptation(
                     f"swapping today's {workout_type} for an easy effort."
                 ),
                 readiness_score=readiness.score,
+                trigger="readiness",
             )
         return None
 
-    if workout_type in EASY_WORKOUT_TYPES and readiness.score >= 86:
+    if workout_type in EASY_WORKOUT_TYPES and readiness.score >= 86 and not risk_high:
         suggested_distance = (
             min(
                 plan_day.target_distance_m * (1 + _UPGRADE_DISTANCE_FACTOR),
@@ -129,6 +191,7 @@ def suggest_adaptation(
                 "primed. Feel free to add a few strides or extend today's easy run."
             ),
             readiness_score=readiness.score,
+            trigger="readiness",
         )
 
     return None

--- a/app/routers/daily.py
+++ b/app/routers/daily.py
@@ -243,7 +243,14 @@ def api_today(
         .filter(TrainingPlanDay.user_id == uid, TrainingPlanDay.day_date == selected)
         .first()
     )
-    plan_adaptation = plan_adaptation_mod.suggest_adaptation(plan_day, readiness, checkin)
+    active_niggle = plan_adaptation_mod.get_active_niggle(db, uid)
+    plan_adaptation = plan_adaptation_mod.suggest_adaptation(
+        plan_day,
+        readiness,
+        checkin,
+        injury_risk=current_load.injury_risk if current_load else None,
+        active_niggle=active_niggle,
+    )
     if plan_adaptation is not None:
         dismissed = (
             db.query(SyncStatus)

--- a/app/routers/plan.py
+++ b/app/routers/plan.py
@@ -229,7 +229,14 @@ def api_adapt_plan_day(
         .first()
     )
     readiness = training_load.compute_readiness(daily_summary, current_load, recent_rhr, checkin)
-    suggestion = plan_adaptation_mod.suggest_adaptation(plan_day, readiness, checkin)
+    active_niggle = plan_adaptation_mod.get_active_niggle(db, uid)
+    suggestion = plan_adaptation_mod.suggest_adaptation(
+        plan_day,
+        readiness,
+        checkin,
+        injury_risk=current_load.injury_risk if current_load else None,
+        active_niggle=active_niggle,
+    )
     if suggestion is None:
         raise HTTPException(status_code=409, detail="No adaptation suggestion applies to this plan day")
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -415,6 +415,10 @@ class PlanAdaptationSuggestion(BaseModel):
     suggested_target_distance_m: float | None = None
     reason: str
     readiness_score: int
+    # What triggered this suggestion (P2-1): a plain readiness band, the
+    # athlete's own check-in, or an ACWR/ramp-rate/niggle risk flag — lets the
+    # UI render a distinct "load caution" variant for risk-triggered rows.
+    trigger: Literal["readiness", "checkin", "risk"] = "readiness"
 
 
 class TodayResponse(BaseModel):

--- a/app/training_load.py
+++ b/app/training_load.py
@@ -632,6 +632,12 @@ def format_training_load_context(point: TrainingLoadPoint | None) -> str:
         lines.append(f"- Ramp rate (28d CTL change): {point.ramp_rate_28d:+.1f}")
     if point.injury_risk:
         lines.append(f"- Injury risk: {point.injury_risk}")
+    if point.injury_risk == "high":
+        lines.append(
+            "- **Load caution (mandatory)**: injury risk is HIGH — do not prescribe "
+            "or encourage hard/interval/tempo/long efforts until ACWR falls back "
+            "under 1.3; prioritize easy running and recovery."
+        )
     if point.rsb_zone_label and point.rsb_recommendation:
         lines.append(f"- Running Stress Balance: {point.rsb_zone_label}. {point.rsb_recommendation}")
     return "\n".join(lines)

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -311,7 +311,7 @@ latest briefing insight), `app/schemas.py`,
 
 ### P2 — Sharper analysis, honest load
 
-#### P2-1 · Injury-risk early warning that acts
+#### P2-1 · Injury-risk early warning that acts ✅ Done.
 **What:** Promote the ACWR / ramp-rate / `injury_risk` flags (computed daily in
 `DailyLoadSeries`) plus active `CoachMemory` niggles into a proactive loop: when
 risk crosses into "high" — even on a good-readiness day — surface a caution card
@@ -330,6 +330,28 @@ the suggestion/accept mechanism exists; this connects them.
 directive), `app/schemas.py`,
 `frontend/src/components/today/PlanAdaptationCard.tsx` (risk variant),
 `tests/test_plan_adaptation.py`, `tests/test_api_endpoints.py`.
+_Implemented as described, scoped to P2-1 only. File locations follow the
+post-P3-1 split: the three call sites that compute the readiness-driven
+suggestion — `app/routers/daily.py` (`/today`), `app/routers/plan.py`
+(`/training-plan/adapt-day`), and `app/main.py`
+(`_push_plan_adaptation_if_needed`) — now also pass the day's
+`TrainingLoadPoint.injury_risk` and the athlete's most recent active niggle
+(a new `plan_adaptation.get_active_niggle` helper) into `suggest_adaptation`.
+A `risk` branch fires a hard-day downgrade whenever `injury_risk == "high"`
+or a niggle is active, ahead of the readiness-band checks, so it applies even
+on a Good/Excellent readiness day; it does not override the more severe
+low-readiness rest recommendation. The same risk flag also suppresses the
+easy-day upgrade nudge — the coach never suggests "add more" while risk is
+elevated. `PlanAdaptationSuggestion` gained a `trigger`
+(`"readiness" | "checkin" | "risk"`) field (default `"readiness"`, so no
+existing behavior changed) that the same push path
+(`_push_plan_adaptation_if_needed`) and the same `PlanAdaptationCard` read to
+title/style the risk case distinctly — no new push category or UI component,
+reusing the P1-1/P0-1 plumbing end to end. The "mandatory" plan/chat context
+directive landed in `training_load.format_training_load_context` (shared by
+`app/coach/context.py` and `app/coach/plans.py`), appended only when
+`injury_risk == "high"`. All new and existing tests pass (backend + `tsc -b`
++ Vitest)._
 
 #### P2-2 · Season-over-season performance comparison
 **What:** Add a comparison overlay to the Performance Curve view: the fitted

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -311,6 +311,7 @@ export interface PlanAdaptationSuggestion {
   suggested_target_distance_m: number | null
   reason: string
   readiness_score: number
+  trigger: 'readiness' | 'checkin' | 'risk'
 }
 
 export interface TodayResponse {

--- a/frontend/src/components/today/PlanAdaptationCard.css
+++ b/frontend/src/components/today/PlanAdaptationCard.css
@@ -14,6 +14,15 @@
   background: color-mix(in srgb, var(--color-easy) 8%, var(--bg-card));
 }
 
+.plan-adaptation-risk {
+  border: 1px solid rgba(231, 76, 60, 0.45);
+  background: rgba(231, 76, 60, 0.08);
+}
+
+.plan-adaptation-risk .plan-adaptation-header {
+  color: #e74c3c;
+}
+
 .plan-adaptation-header {
   display: flex;
   align-items: center;

--- a/frontend/src/components/today/PlanAdaptationCard.tsx
+++ b/frontend/src/components/today/PlanAdaptationCard.tsx
@@ -1,6 +1,6 @@
 import { useAdaptPlanDay } from '../../api/hooks'
 import type { PlanAdaptationSuggestion } from '../../api/types'
-import { TrendingDown, TrendingUp, RefreshCw } from 'lucide-react'
+import { TrendingDown, TrendingUp, AlertTriangle, RefreshCw } from 'lucide-react'
 import './PlanAdaptationCard.css'
 
 interface Props {
@@ -15,16 +15,19 @@ function formatDistance(m: number | null): string | null {
 export default function PlanAdaptationCard({ suggestion }: Props) {
   const { mutate: adapt, isPending } = useAdaptPlanDay()
   const isDowngrade = suggestion.direction === 'downgrade'
+  const isRisk = suggestion.trigger === 'risk'
 
   const currentDist = formatDistance(suggestion.current_target_distance_m)
   const suggestedDist = formatDistance(suggestion.suggested_target_distance_m)
 
   return (
-    <div className={`card plan-adaptation-card plan-adaptation-${suggestion.direction}`}>
+    <div
+      className={`card plan-adaptation-card plan-adaptation-${suggestion.direction}${isRisk ? ' plan-adaptation-risk' : ''}`}
+    >
       <div className="plan-adaptation-header">
-        {isDowngrade ? <TrendingDown size={16} /> : <TrendingUp size={16} />}
+        {isRisk ? <AlertTriangle size={16} /> : isDowngrade ? <TrendingDown size={16} /> : <TrendingUp size={16} />}
         <span className="plan-adaptation-title">
-          {isDowngrade ? 'Suggested: ease off today' : 'Suggested: you\'re primed'}
+          {isRisk ? 'Load caution: consider easing off' : isDowngrade ? 'Suggested: ease off today' : 'Suggested: you\'re primed'}
         </span>
       </div>
       <p className="plan-adaptation-reason">{suggestion.reason}</p>

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -8,6 +8,8 @@ from app.models import (
     Activity,
     AthleteProfile,
     ChatMessage,
+    CoachMemory,
+    DailyLoadSeries,
     DailySummary,
     GarminCalendarEvent,
     Insight,
@@ -613,6 +615,42 @@ def test_today_plan_adaptation_suppressed_when_dismissed(client, db):
     resp = client.get(f"/api/v1/today?date={day.isoformat()}")
     assert resp.status_code == 200
     assert resp.json()["plan_adaptation"] is None
+
+
+def test_today_includes_risk_triggered_caution_despite_good_readiness(client, db):
+    """P2-1: a high ACWR/injury_risk reading forces a cutback suggestion even
+    when readiness alone would not trigger one."""
+    day = date(2026, 6, 17)
+    db.add(DailySummary(date=day, sleep_score=80, stress_avg=20, body_battery_high=80))
+    db.add(DailyLoadSeries(
+        date=day, tss=90.0, ctl=40.0, atl=65.0, tsb=-25.0,
+        acwr=1.62, injury_risk="high",
+    ))
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "tempo", "dist_m": 10000},
+    ])
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["plan_adaptation"] is not None
+    assert body["plan_adaptation"]["direction"] == "downgrade"
+    assert body["plan_adaptation"]["trigger"] == "risk"
+
+
+def test_today_includes_niggle_triggered_caution(client, db):
+    """P2-1: an active soreness niggle also forces a cutback on a hard day."""
+    day = date(2026, 6, 17)
+    db.add(DailySummary(date=day, sleep_score=80, stress_avg=20, body_battery_high=80))
+    db.add(CoachMemory(category="niggle", tag="left knee", note="Reported sore", active=True))
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "long", "dist_m": 20000},
+    ])
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["plan_adaptation"] is not None
+    assert body["plan_adaptation"]["trigger"] == "risk"
+    assert "left knee" in body["plan_adaptation"]["reason"]
 
 
 def test_today_matched_workout_drops_scheduled_and_tags_activity(client, db):

--- a/tests/test_plan_adaptation.py
+++ b/tests/test_plan_adaptation.py
@@ -1,6 +1,7 @@
-"""Tests for readiness-driven plan day adaptation (P1-1)."""
+"""Tests for readiness-driven plan day adaptation (P1-1) and risk-triggered
+caution (P2-1)."""
 
-from app.models import DailyCheckin, TrainingPlanDay
+from app.models import CoachMemory, DailyCheckin, TrainingPlanDay
 from app.plan_adaptation import suggest_adaptation
 from app.schemas import TrainingReadiness
 
@@ -142,3 +143,83 @@ def test_checkin_does_not_downgrade_already_low_readiness_twice():
     suggestion = suggest_adaptation(day, _readiness(25, "Low"), _checkin(soreness=1))
     assert suggestion is not None
     assert suggestion.suggested_workout_type == "rest"
+
+
+# --- Trigger field on existing branches (P2-1) ---
+
+def test_trigger_is_readiness_for_low_readiness_rest():
+    day = _day(workout_type="interval")
+    suggestion = suggest_adaptation(day, _readiness(25, "Low"))
+    assert suggestion.trigger == "readiness"
+
+
+def test_trigger_is_readiness_for_fair_readiness_downgrade():
+    day = _day(workout_type="tempo")
+    suggestion = suggest_adaptation(day, _readiness(45, "Fair"))
+    assert suggestion.trigger == "readiness"
+
+
+def test_trigger_is_checkin_for_checkin_override():
+    day = _day(workout_type="tempo")
+    suggestion = suggest_adaptation(day, _readiness(70, "Good"), _checkin(soreness=1))
+    assert suggestion.trigger == "checkin"
+
+
+def test_trigger_is_readiness_for_easy_day_upgrade():
+    day = _day(workout_type="easy", target_distance_m=8000.0)
+    suggestion = suggest_adaptation(day, _readiness(90, "Excellent"))
+    assert suggestion.trigger == "readiness"
+
+
+# --- Injury-risk / niggle trigger (P2-1) ---
+
+def test_high_injury_risk_downgrades_hard_day_despite_good_readiness():
+    day = _day(workout_type="tempo", target_distance_m=10000.0)
+    # Readiness alone ("Good", 70) would not trigger any suggestion.
+    assert suggest_adaptation(day, _readiness(70, "Good")) is None
+    suggestion = suggest_adaptation(day, _readiness(70, "Good"), injury_risk="high")
+    assert suggestion is not None
+    assert suggestion.direction == "downgrade"
+    assert suggestion.suggested_workout_type == "easy"
+    assert suggestion.suggested_target_distance_m == 6000.0
+    assert suggestion.trigger == "risk"
+    assert "ACWR" in suggestion.reason or "load risk" in suggestion.reason
+
+
+def test_moderate_injury_risk_does_not_trigger_cutback():
+    day = _day(workout_type="tempo")
+    assert suggest_adaptation(day, _readiness(70, "Good"), injury_risk="moderate") is None
+
+
+def test_active_niggle_downgrades_hard_day_despite_good_readiness():
+    day = _day(workout_type="long")
+    niggle = CoachMemory(category="niggle", tag="left knee", note="Reported sore")
+    suggestion = suggest_adaptation(day, _readiness(75, "Good"), active_niggle=niggle)
+    assert suggestion is not None
+    assert suggestion.direction == "downgrade"
+    assert suggestion.trigger == "risk"
+    assert "left knee" in suggestion.reason
+
+
+def test_low_readiness_rest_still_wins_over_risk():
+    # A rest recommendation from very low readiness is more severe than a
+    # risk-triggered easy-effort downgrade, so it takes priority.
+    day = _day(workout_type="interval")
+    suggestion = suggest_adaptation(day, _readiness(25, "Low"), injury_risk="high")
+    assert suggestion.suggested_workout_type == "rest"
+    assert suggestion.trigger == "readiness"
+
+
+def test_risk_does_not_apply_to_easy_or_rest_days():
+    assert suggest_adaptation(
+        _day(workout_type="easy"), _readiness(70, "Good"), injury_risk="high"
+    ) is None
+    assert suggest_adaptation(
+        _day(workout_type="rest"), _readiness(70, "Good"), injury_risk="high"
+    ) is None
+
+
+def test_high_injury_risk_suppresses_easy_day_upgrade():
+    day = _day(workout_type="easy", target_distance_m=8000.0)
+    assert suggest_adaptation(day, _readiness(90, "Excellent")) is not None
+    assert suggest_adaptation(day, _readiness(90, "Excellent"), injury_risk="high") is None

--- a/tests/test_training_load.py
+++ b/tests/test_training_load.py
@@ -266,6 +266,26 @@ def test_format_training_load_context_includes_rsb_recommendation():
     assert "Overreaching — high risk" in ctx
 
 
+def test_format_training_load_context_injects_mandatory_caution_when_risk_high():
+    """P2-1: high injury risk becomes a directive, not just a data point."""
+    from app.schemas import TrainingLoadPoint
+    high_risk_point = TrainingLoadPoint(
+        date=date(2026, 6, 10),
+        tss=80.0, ctl=40.0, atl=65.0, tsb=-25.0,
+        acwr=1.6, injury_risk="high",
+    )
+    ctx = training_load.format_training_load_context(high_risk_point)
+    assert "Load caution" in ctx
+    assert "mandatory" in ctx.lower()
+
+    moderate_risk_point = TrainingLoadPoint(
+        date=date(2026, 6, 10),
+        tss=80.0, ctl=40.0, atl=50.0, tsb=-10.0,
+        acwr=1.35, injury_risk="moderate",
+    )
+    assert "Load caution" not in training_load.format_training_load_context(moderate_risk_point)
+
+
 def test_training_load_endpoint_includes_acwr_fields(client, db):
     base = datetime(2026, 5, 1, 7, 0)
     for i in range(35):


### PR DESCRIPTION
Wire ACWR/ramp-rate injury_risk and active CoachMemory niggles into the
existing readiness-driven plan_adaptation loop: a hard day now gets a
rule-based cutback suggestion when risk is high or a niggle is active, even
on a good-readiness day, and the easy-day upgrade nudge is suppressed while
risk is elevated. Suggestions carry a new trigger field (readiness/checkin/
risk) so the same PlanAdaptationCard and P0-1 push path render a distinct
"load caution" variant without new plumbing. The AI plan/chat context also
gains a mandatory load-caution directive when injury_risk is high.