### PR TITLE
Add conditions-aware race pacing (P1-2)

### DIFF
--- a/app/pacing.py
+++ b/app/pacing.py
@@ -6,9 +6,10 @@ possible.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from app.streams import minetti_factor
+from app.weather import heat_pace_adjustment
 
 _MILE_IN_METERS = 1609.344
 
@@ -35,6 +36,10 @@ class PacingPlan:
     splits: list[PacingSplit] = field(default_factory=list)
     predicted_time_sec: float | None = None  # from CP/CV model for reference
     source: str = "goal"        # "goal" | "predicted" | "custom"
+    conditions_temp_c: float | None = None       # expected race-day temp, if supplied
+    conditions_dew_point_c: float | None = None  # expected race-day dew point, if supplied
+    conditions_penalty_pct: float | None = None  # heat penalty %, if conditions supplied
+    adjusted_target_time_sec: float | None = None  # target_time_sec scaled by the heat factor
 
 
 def _split_time(pace_min_km: float, dist_m: float) -> float:
@@ -163,6 +168,24 @@ def _build_terrain_splits(
     return splits
 
 
+def _apply_conditions_factor(splits: list[PacingSplit], factor: float) -> list[PacingSplit]:
+    """Scale each split's target pace/time by a heat/humidity factor (>= 1.0 = slower),
+    recomputing cumulative distance/time so the plan stays internally consistent.
+    """
+    scaled: list[PacingSplit] = []
+    cumulative_time = 0.0
+    for s in splits:
+        t = s.split_time_sec * factor
+        cumulative_time += t
+        scaled.append(replace(
+            s,
+            target_pace_min_km=round(s.target_pace_min_km * factor, 3),
+            split_time_sec=round(t, 1),
+            cumulative_time_sec=round(cumulative_time, 1),
+        ))
+    return scaled
+
+
 def generate_pacing_strategy(
     distance_m: float,
     target_time_sec: float,
@@ -171,6 +194,8 @@ def generate_pacing_strategy(
     predicted_time_sec: float | None = None,
     source: str = "goal",
     elevation_profile: list[tuple[float, float]] | None = None,
+    expected_temp_c: float | None = None,
+    expected_dew_point_c: float | None = None,
 ) -> PacingPlan:
     """Generate a race-day pacing plan.
 
@@ -187,6 +212,12 @@ def generate_pacing_strategy(
                             required when ``strategy == "terrain"``. Its distance
                             axis is scaled to ``distance_m``, so it doesn't need
                             to span the exact race distance.
+        expected_temp_c: Expected race-day temperature in °C. When supplied
+                          (with or without ``expected_dew_point_c``), every split's
+                          pace/time is scaled by the same heat factor used to
+                          weather-adjust past runs (composes with the terrain
+                          strategy — grade and heat multiply).
+        expected_dew_point_c: Expected race-day dew point in °C.
     """
     if distance_m <= 0 or target_time_sec <= 0:
         raise ValueError("distance_m and target_time_sec must be positive")
@@ -208,6 +239,13 @@ def generate_pacing_strategy(
             return overall_pace
         splits = _build_splits(distance_m, split_dist_m, pace_fn)
 
+    conditions_penalty_pct: float | None = None
+    adjusted_target_time_sec: float | None = None
+    if expected_temp_c is not None or expected_dew_point_c is not None:
+        factor, conditions_penalty_pct = heat_pace_adjustment(expected_temp_c, expected_dew_point_c)
+        splits = _apply_conditions_factor(splits, factor)
+        adjusted_target_time_sec = round(target_time_sec * factor, 1)
+
     return PacingPlan(
         distance_m=distance_m,
         target_time_sec=target_time_sec,
@@ -218,4 +256,8 @@ def generate_pacing_strategy(
         splits=splits,
         predicted_time_sec=predicted_time_sec,
         source=source,
+        conditions_temp_c=expected_temp_c,
+        conditions_dew_point_c=expected_dew_point_c,
+        conditions_penalty_pct=conditions_penalty_pct,
+        adjusted_target_time_sec=adjusted_target_time_sec,
     )

--- a/app/routers/races.py
+++ b/app/routers/races.py
@@ -1,5 +1,7 @@
 """Race pacing strategy generation and Garmin push."""
 import logging
+from datetime import date, datetime, timedelta, timezone
+from statistics import median
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func
@@ -11,11 +13,47 @@ from app.models import Activity, GarminCalendarEvent, User
 from app.schemas import PacingPushRequest, PacingStrategyResponse, PushWorkoutResponse
 from app import threshold as threshold_mod
 from app import streams as streams_mod
+from app import weather as weather_mod
 from app.utils import safe_json_loads
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+_CONDITIONS_LOOKBACK_DAYS = 14
+_CONDITIONS_SAMPLE_LIMIT = 5
+
+
+def _estimated_race_conditions(user_id: int, db: Session) -> tuple[float | None, float | None]:
+    """Median (temp_c, dew_point_c) from the athlete's recent weathered runs.
+
+    Used to pre-fill the expected race-day conditions inputs — no forecast API,
+    just the same weather data already synced from Garmin for past runs.
+    """
+    cutoff = datetime.combine(
+        date.today() - timedelta(days=_CONDITIONS_LOOKBACK_DAYS), datetime.min.time(), tzinfo=timezone.utc
+    )
+    recent = (
+        db.query(Activity)
+        .filter(
+            Activity.user_id == user_id,
+            Activity.weather_json.isnot(None),
+            Activity.started_at >= cutoff,
+        )
+        .order_by(Activity.started_at.desc())
+        .limit(_CONDITIONS_SAMPLE_LIMIT)
+        .all()
+    )
+    temps: list[float] = []
+    dew_points: list[float] = []
+    for act in recent:
+        weather = weather_mod.parse_weather(act.weather_json)
+        temp, dp = weather_mod.extract_temp_dewpoint_c(weather)
+        if temp is not None:
+            temps.append(temp)
+        if dp is not None:
+            dew_points.append(dp)
+    return (median(temps) if temps else None, median(dew_points) if dew_points else None)
 
 
 def _get_race_event(race_id: int, user_id: int, db: Session) -> GarminCalendarEvent:
@@ -76,6 +114,8 @@ def api_race_pacing(
     strategy: str = Query("even", pattern="^(even|negative_split|terrain)$"),
     split_unit: str = Query("km", pattern="^(km|mile)$"),
     target_time_sec: int | None = Query(None),
+    expected_temp_c: float | None = Query(None),
+    expected_dew_point_c: float | None = Query(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -84,6 +124,9 @@ def api_race_pacing(
     target_time_sec overrides goal_time_sec; if neither is set, falls back to
     the CV-model prediction from the performance curve. "terrain" strategy
     sources an elevation profile from the athlete's closest-distance past run.
+    expected_temp_c/expected_dew_point_c scale every split for expected race-day
+    heat/humidity (composes with the terrain strategy); the response always
+    includes a median estimate from recent weathered runs for the UI to pre-fill.
     """
     from app import pacing as pacing_mod
 
@@ -150,7 +193,10 @@ def api_race_pacing(
         predicted_time_sec=predicted_time,
         source=source,
         elevation_profile=elevation_profile,
+        expected_temp_c=expected_temp_c,
+        expected_dew_point_c=expected_dew_point_c,
     )
+    estimated_temp_c, estimated_dew_point_c = _estimated_race_conditions(current_user.id, db)
 
     return PacingStrategyResponse(
         race_id=race_id,
@@ -178,6 +224,12 @@ def api_race_pacing(
         source=plan.source,
         course_activity_id=course_activity.id if course_activity else None,
         course_activity_name=course_activity.name if course_activity else None,
+        conditions_temp_c=plan.conditions_temp_c,
+        conditions_dew_point_c=plan.conditions_dew_point_c,
+        conditions_penalty_pct=plan.conditions_penalty_pct,
+        adjusted_target_time_sec=plan.adjusted_target_time_sec,
+        estimated_temp_c=estimated_temp_c,
+        estimated_dew_point_c=estimated_dew_point_c,
     )
 
 
@@ -239,6 +291,8 @@ def api_push_race_pacing(
         strategy=body.strategy,
         elevation_profile=elevation_profile,
         split_unit=body.split_unit,
+        expected_temp_c=body.expected_temp_c,
+        expected_dew_point_c=body.expected_dew_point_c,
     )
 
     try:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -874,12 +874,20 @@ class PacingStrategyResponse(BaseModel):
     source: str                 # "goal" | "predicted" | "custom"
     course_activity_id: int | None = None    # activity the terrain profile was sourced from
     course_activity_name: str | None = None
+    conditions_temp_c: float | None = None       # expected race-day temp, if applied (°C)
+    conditions_dew_point_c: float | None = None  # expected race-day dew point, if applied (°C)
+    conditions_penalty_pct: float | None = None  # heat penalty %, if conditions applied
+    adjusted_target_time_sec: float | None = None  # target_time_sec scaled by the heat factor
+    estimated_temp_c: float | None = None        # median temp from recent weathered runs (UI prefill)
+    estimated_dew_point_c: float | None = None   # median dew point from recent weathered runs
 
 
 class PacingPushRequest(BaseModel):
     strategy: str = "even"
     split_unit: str = "km"
     target_time_sec: int | None = None
+    expected_temp_c: float | None = None
+    expected_dew_point_c: float | None = None
 
 
 class AIJobEnqueuedResponse(BaseModel):

--- a/app/weather.py
+++ b/app/weather.py
@@ -64,6 +64,28 @@ def heat_pace_adjustment(
     return 1.0 + total_pct / 100.0, total_pct
 
 
+def extract_temp_dewpoint_c(weather: dict | None) -> tuple[float | None, float | None]:
+    """Extract (temp_c, dew_point_c) from a parsed weather dict.
+
+    Garmin Connect's activity-weather endpoint always returns temp/dewPoint in
+    Fahrenheit, regardless of the account's display-unit setting (the app
+    converts for display) — convert here so callers get °C consistently.
+    """
+    if not weather:
+        return None, None
+
+    raw_temp = _get_field(weather, "temp", "temperature", "apparentTemperature")
+    raw_dp = _get_field(weather, "dewPoint", "dew_point")
+
+    try:
+        temp = _fahrenheit_to_celsius(float(raw_temp)) if raw_temp is not None else None
+        dp = _fahrenheit_to_celsius(float(raw_dp)) if raw_dp is not None else None
+    except (TypeError, ValueError):
+        return None, None
+
+    return temp, dp
+
+
 def weather_pace_info(
     weather: dict | None,
     avg_pace_min_km: float | None,
@@ -76,19 +98,8 @@ def weather_pace_info(
     if not weather or avg_pace_min_km is None:
         return None, None, None
 
-    raw_temp = _get_field(weather, "temp", "temperature", "apparentTemperature")
-    raw_dp = _get_field(weather, "dewPoint", "dew_point")
-
-    if raw_temp is None and raw_dp is None:
-        return None, None, None
-
-    # Garmin Connect's activity-weather endpoint always returns temp/dewPoint in
-    # Fahrenheit, regardless of the account's display-unit setting (the app
-    # converts for display) — convert here so the °C-based model is correct.
-    try:
-        temp = _fahrenheit_to_celsius(float(raw_temp)) if raw_temp is not None else None
-        dp = _fahrenheit_to_celsius(float(raw_dp)) if raw_dp is not None else None
-    except (TypeError, ValueError):
+    temp, dp = extract_temp_dewpoint_c(weather)
+    if temp is None and dp is None:
         return None, None, None
 
     factor, _ = heat_pace_adjustment(temp, dp)

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -261,7 +261,7 @@ chat `mark_setback` tool), deduplicated so it's written once per area. All
 new and existing tests pass (893 backend); `npm run build`, `tsc -b`, and
 the Vitest suite (57 cases) are clean._
 
-#### P1-2 · Conditions-aware race pacing
+#### P1-2 · Conditions-aware race pacing ✅ Done.
 **What:** Fold expected race-day conditions into the pacing plans from v3/v4.
 `GET /races/{id}/pacing` accepts optional `expected_temp_c` / `expected_dew_point_c`
 (UI inputs on the pacing card, pre-filled from the median conditions of the

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -514,13 +514,29 @@ export function usePushWorkoutToGarmin() {
 
 export function useRacePacing(
   raceId: number,
-  params: { strategy?: string; splitUnit?: string; targetTimeSec?: number | null } = {},
+  params: {
+    strategy?: string
+    splitUnit?: string
+    targetTimeSec?: number | null
+    expectedTempC?: number | null
+    expectedDewPointC?: number | null
+  } = {},
 ) {
-  const { strategy = 'even', splitUnit = 'km', targetTimeSec } = params
+  const { strategy = 'even', splitUnit = 'km', targetTimeSec, expectedTempC, expectedDewPointC } = params
   const qs = new URLSearchParams({ strategy, split_unit: splitUnit })
   if (targetTimeSec != null) qs.set('target_time_sec', String(targetTimeSec))
+  if (expectedTempC != null) qs.set('expected_temp_c', String(expectedTempC))
+  if (expectedDewPointC != null) qs.set('expected_dew_point_c', String(expectedDewPointC))
   return useQuery({
-    queryKey: ['race-pacing', raceId, strategy, splitUnit, targetTimeSec ?? null],
+    queryKey: [
+      'race-pacing',
+      raceId,
+      strategy,
+      splitUnit,
+      targetTimeSec ?? null,
+      expectedTempC ?? null,
+      expectedDewPointC ?? null,
+    ],
     queryFn: () => apiGet<PacingStrategyResponse>(`/races/${raceId}/pacing?${qs}`),
     enabled: raceId > 0,
   })

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -729,12 +729,20 @@ export interface PacingStrategyResponse {
   source: string          // "goal" | "predicted" | "custom"
   course_activity_id: number | null
   course_activity_name: string | null
+  conditions_temp_c: number | null
+  conditions_dew_point_c: number | null
+  conditions_penalty_pct: number | null
+  adjusted_target_time_sec: number | null
+  estimated_temp_c: number | null
+  estimated_dew_point_c: number | null
 }
 
 export interface PacingPushRequest {
   strategy: string
   split_unit: string
   target_time_sec?: number | null
+  expected_temp_c?: number | null
+  expected_dew_point_c?: number | null
 }
 
 export interface VapidPublicKeyResponse {

--- a/frontend/src/components/today/RacePacingCard.css
+++ b/frontend/src/components/today/RacePacingCard.css
@@ -72,6 +72,46 @@
   color: rgba(255, 255, 255, 0.9);
 }
 
+/* Expected conditions inputs */
+.race-pacing-conditions {
+  display: flex;
+  justify-content: center;
+  gap: 14px;
+}
+
+.race-pacing-conditions-field {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.race-pacing-conditions-field input {
+  width: 48px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+  padding: 3px 5px;
+  text-align: center;
+}
+
+.race-pacing-conditions-field input::-webkit-outer-spin-button,
+.race-pacing-conditions-field input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.race-pacing-conditions-note {
+  font-size: 0.7rem;
+  color: rgba(255, 200, 150, 0.85);
+  text-align: center;
+  padding: 0 4px;
+}
+
 /* Summary row */
 .race-pacing-summary {
   display: flex;

--- a/frontend/src/components/today/RacePacingCard.tsx
+++ b/frontend/src/components/today/RacePacingCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Watch, ChevronDown, ChevronUp, RefreshCw } from 'lucide-react'
 import { useRacePacing, usePushRacePacing } from '../../api/hooks'
 import { formatDuration } from '../../utils/formatting'
@@ -32,20 +32,50 @@ export default function RacePacingCard({ race }: Props) {
   const [strategy, setStrategy] = useState<'even' | 'negative_split' | 'terrain'>('even')
   const [splitUnit] = useState<'km' | 'mile'>('km')
   const [pushed, setPushed] = useState(false)
+  const [tempC, setTempC] = useState('')
+  const [dewPointC, setDewPointC] = useState('')
+  const estimatePrefilled = useRef(false)
+
+  const expectedTempC = tempC === '' ? null : Number(tempC)
+  const expectedDewPointC = dewPointC === '' ? null : Number(dewPointC)
 
   const { data: plan, isLoading, isError, error } = useRacePacing(race.id, {
     strategy,
     splitUnit,
+    expectedTempC,
+    expectedDewPointC,
   })
+
+  // Pre-fill the conditions inputs once from the median of the athlete's recent
+  // weathered runs, so the pacing card opens with a realistic estimate already
+  // applied rather than a neutral (unadjusted) plan.
+  useEffect(() => {
+    if (estimatePrefilled.current || !plan) return
+    if (plan.estimated_temp_c == null && plan.estimated_dew_point_c == null) return
+    estimatePrefilled.current = true
+    if (plan.estimated_temp_c != null) setTempC(String(Math.round(plan.estimated_temp_c)))
+    if (plan.estimated_dew_point_c != null) setDewPointC(String(Math.round(plan.estimated_dew_point_c)))
+  }, [plan])
 
   const { mutate: pushToGarmin, isPending: isPushing } = usePushRacePacing()
 
   const handlePush = () => {
     pushToGarmin(
-      { raceId: race.id, body: { strategy, split_unit: splitUnit } },
+      {
+        raceId: race.id,
+        body: {
+          strategy,
+          split_unit: splitUnit,
+          expected_temp_c: expectedTempC,
+          expected_dew_point_c: expectedDewPointC,
+        },
+      },
       { onSuccess: () => setPushed(true) },
     )
   }
+
+  const conditionsCostSec =
+    plan?.adjusted_target_time_sec != null ? plan.adjusted_target_time_sec - plan.target_time_sec : null
 
   return (
     <div className="race-pacing-card">
@@ -81,6 +111,29 @@ export default function RacePacingCard({ race }: Props) {
                 Terrain
               </button>
             </div>
+          </div>
+
+          <div className="race-pacing-conditions">
+            <label className="race-pacing-conditions-field">
+              <span>Temp °C</span>
+              <input
+                type="number"
+                inputMode="numeric"
+                placeholder="—"
+                value={tempC}
+                onChange={e => setTempC(e.target.value)}
+              />
+            </label>
+            <label className="race-pacing-conditions-field">
+              <span>Dew point °C</span>
+              <input
+                type="number"
+                inputMode="numeric"
+                placeholder="—"
+                value={dewPointC}
+                onChange={e => setDewPointC(e.target.value)}
+              />
+            </label>
           </div>
 
           {isLoading && <div className="race-pacing-loading">Loading splits…</div>}
@@ -120,6 +173,14 @@ export default function RacePacingCard({ race }: Props) {
               {strategy === 'terrain' && plan.course_activity_name && (
                 <div className="race-pacing-course-note">
                   Course profile from "{plan.course_activity_name}" — effort held constant over the grade.
+                </div>
+              )}
+
+              {conditionsCostSec != null && conditionsCostSec > 0 && plan.conditions_temp_c != null && (
+                <div className="race-pacing-conditions-note">
+                  At {plan.conditions_temp_c.toFixed(0)}°C
+                  {plan.conditions_dew_point_c != null && ` / dew point ${plan.conditions_dew_point_c.toFixed(0)}°C`}
+                  {' '}your {formatDuration(plan.target_time_sec)} goal costs ~+{formatDuration(conditionsCostSec)} — adjusted splits below.
                 </div>
               )}
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1175,6 +1175,88 @@ def test_race_pacing_even_strategy_has_no_course_activity(client, db):
     assert all(s["grade_pct"] is None for s in body["splits"])
 
 
+# --- /races/{id}/pacing conditions-aware pacing (P1-2) ---
+
+def test_race_pacing_with_expected_conditions_scales_splits(client, db):
+    race = _add_race(db)
+    baseline = client.get(f"/api/v1/races/{race.id}/pacing?strategy=even").json()
+    resp = client.get(
+        f"/api/v1/races/{race.id}/pacing"
+        "?strategy=even&expected_temp_c=30&expected_dew_point_c=20"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["conditions_temp_c"] == 30.0
+    assert body["conditions_dew_point_c"] == 20.0
+    assert body["conditions_penalty_pct"] > 0
+    assert body["adjusted_target_time_sec"] > body["target_time_sec"]
+    # Original goal time/pace stay put — only the splits and the adjusted total move.
+    assert body["target_time_sec"] == baseline["target_time_sec"]
+    assert body["splits"][0]["target_pace_min_km"] > baseline["splits"][0]["target_pace_min_km"]
+
+
+def test_race_pacing_without_conditions_has_no_adjustment(client, db):
+    race = _add_race(db)
+    resp = client.get(f"/api/v1/races/{race.id}/pacing?strategy=even")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["conditions_temp_c"] is None
+    assert body["conditions_penalty_pct"] is None
+    assert body["adjusted_target_time_sec"] is None
+
+
+def test_race_pacing_estimated_conditions_from_recent_weathered_runs(client, db):
+    race = _add_race(db)
+    _add_activity(
+        db, datetime.combine(date.today() - timedelta(days=2), datetime.min.time()),
+        weather_json=json.dumps({"temperature": 86, "dewPoint": 68}),  # 30C / 20C
+    )
+    _add_activity(
+        db, datetime.combine(date.today() - timedelta(days=4), datetime.min.time()),
+        weather_json=json.dumps({"temperature": 68, "dewPoint": 50}),  # ~20C / 10C
+    )
+    resp = client.get(f"/api/v1/races/{race.id}/pacing?strategy=even")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["estimated_temp_c"] == pytest.approx(25.0, abs=0.5)
+    assert body["estimated_dew_point_c"] == pytest.approx(15.0, abs=0.5)
+
+
+def test_race_pacing_estimated_conditions_none_without_recent_weather(client, db):
+    race = _add_race(db)
+    resp = client.get(f"/api/v1/races/{race.id}/pacing?strategy=even")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["estimated_temp_c"] is None
+    assert body["estimated_dew_point_c"] is None
+
+
+def test_race_pacing_push_applies_expected_conditions(client, db):
+    """Pushed splits reflect the heat-adjusted plan, not the unadjusted goal."""
+    from unittest.mock import patch
+    from app.models import User
+
+    dev = User(email="dev@localhost", garmin_email="g@garmin.com")
+    db.add(dev)
+    db.commit()
+
+    race = _add_race(db)
+    captured = {}
+
+    def fake_push(user, race_name, race_date, splits):
+        captured["splits"] = splits
+        return {"workout_name": "Race Pacing", "garmin_workout_id": 1, "scheduled_date": race_date.isoformat()}
+
+    with patch("app.garmin_sync.push_race_pacing_to_garmin", side_effect=fake_push):
+        resp = client.post(
+            f"/api/v1/races/{race.id}/pacing/push",
+            json={"strategy": "even", "split_unit": "km", "expected_temp_c": 30, "expected_dew_point_c": 20},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured["splits"][0].target_pace_min_km > 4.0  # baseline even pace at 2400s/10k is 4:00/km
+
+
 # --- Push notifications (P0-1) ---
 
 def test_vapid_public_key_not_configured_by_default(client):

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -364,3 +364,77 @@ def test_translate_race_pacing_estimated_duration():
 
     assert payload["estimatedDurationInSecs"] == pytest.approx(2400, abs=2)
     assert payload["estimatedDistanceInMeters"] == pytest.approx(10000.0, abs=1)
+
+
+# ---------------------------------------------------------------------------
+# Conditions-aware pacing (P1-2) — expected_temp_c / expected_dew_point_c
+# ---------------------------------------------------------------------------
+
+def test_no_conditions_leaves_plan_unchanged():
+    plan = generate_pacing_strategy(10000, 2400)
+    assert plan.conditions_temp_c is None
+    assert plan.conditions_dew_point_c is None
+    assert plan.conditions_penalty_pct is None
+    assert plan.adjusted_target_time_sec is None
+    assert plan.splits[0].target_pace_min_km == pytest.approx(4.0, abs=0.001)
+
+
+def test_neutral_conditions_do_not_change_splits():
+    # 10C / 5C dew point are the heat model's own neutral defaults -> factor 1.0
+    plan = generate_pacing_strategy(10000, 2400, expected_temp_c=10.0, expected_dew_point_c=5.0)
+    assert plan.conditions_penalty_pct == pytest.approx(0.0)
+    assert plan.adjusted_target_time_sec == pytest.approx(2400.0, abs=0.1)
+    assert plan.splits[0].target_pace_min_km == pytest.approx(4.0, abs=0.001)
+
+
+def test_hot_conditions_slow_every_split():
+    baseline = generate_pacing_strategy(10000, 2400)
+    hot = generate_pacing_strategy(10000, 2400, expected_temp_c=30.0, expected_dew_point_c=20.0)
+
+    assert hot.conditions_temp_c == 30.0
+    assert hot.conditions_dew_point_c == 20.0
+    assert hot.conditions_penalty_pct > 0
+    assert hot.adjusted_target_time_sec > 2400.0
+
+    for base_split, hot_split in zip(baseline.splits, hot.splits):
+        assert hot_split.target_pace_min_km > base_split.target_pace_min_km
+        assert hot_split.split_time_sec > base_split.split_time_sec
+
+
+def test_conditions_cumulative_time_matches_adjusted_target():
+    plan = generate_pacing_strategy(10000, 2400, expected_temp_c=30.0, expected_dew_point_c=20.0)
+    assert plan.splits[-1].cumulative_time_sec == pytest.approx(plan.adjusted_target_time_sec, abs=1.0)
+
+
+def test_conditions_only_temp_supplied_still_applies():
+    plan = generate_pacing_strategy(10000, 2400, expected_temp_c=30.0)
+    assert plan.conditions_penalty_pct > 0
+    assert plan.conditions_dew_point_c is None
+
+
+def test_conditions_compose_with_negative_split():
+    baseline = generate_pacing_strategy(10000, 2400, strategy="negative_split")
+    hot = generate_pacing_strategy(
+        10000, 2400, strategy="negative_split", expected_temp_c=30.0, expected_dew_point_c=20.0,
+    )
+    # Negative-split shape (first half slower than second half) is preserved...
+    assert hot.splits[0].target_pace_min_km > hot.splits[-1].target_pace_min_km
+    # ...while every split is slowed relative to the unadjusted plan.
+    for base_split, hot_split in zip(baseline.splits, hot.splits):
+        assert hot_split.target_pace_min_km > base_split.target_pace_min_km
+
+
+def test_conditions_compose_with_terrain():
+    profile = [(0.0, 0.0), (5000.0, 250.0), (10000.0, 0.0)]
+    baseline = generate_pacing_strategy(10000, 2400, strategy="terrain", elevation_profile=profile)
+    hot = generate_pacing_strategy(
+        10000, 2400, strategy="terrain", elevation_profile=profile,
+        expected_temp_c=30.0, expected_dew_point_c=20.0,
+    )
+    # Uphill-vs-downhill shape from terrain is preserved...
+    assert hot.splits[0].target_pace_min_km > hot.splits[-1].target_pace_min_km
+    # ...and grade info survives the conditions scaling.
+    assert hot.splits[0].grade_pct == baseline.splits[0].grade_pct
+    # ...while heat further slows every split on top of the terrain adjustment.
+    for base_split, hot_split in zip(baseline.splits, hot.splits):
+        assert hot_split.target_pace_min_km > base_split.target_pace_min_km


### PR DESCRIPTION
Fold expected race-day temperature/dew point into pacing plans, reusing
the heat model already built for retrospective weather adjustment.
generate_pacing_strategy() now scales every split by the same heat
factor (composing with terrain grade), and both pacing endpoints accept
expected_temp_c/expected_dew_point_c. The GET endpoint also returns a
median-conditions estimate from the athlete's recent weathered runs so
the pacing card can pre-fill the inputs with no forecast-API dependency.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014TTTxakBtWGHanym5vS51y