### PR TITLE
Add pre-workout briefing (P1-3)

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -63,6 +63,9 @@ from app.coach.plans import (
     detect_plan_realignment,
     generate_training_plan,
     weekly_review,
+    _BRIEFING_SYSTEM_PROMPT,
+    _build_briefing_trigger_data,
+    generate_briefing,
 )
 from app.coach.chat import (
     CHAT_SYSTEM_PROMPT,

--- a/app/coach/jobs.py
+++ b/app/coach/jobs.py
@@ -90,6 +90,8 @@ def execute_job(job_id: int) -> None:
             _shim.generate_training_plan(user_id=user_id, note=payload.get("note"))
         elif task_type == "weekly_review":
             _shim.weekly_review(user_id=user_id)
+        elif task_type == "generate_briefing":
+            _shim.generate_briefing(payload["plan_day_id"])
         else:
             raise ValueError(f"Unknown task_type: {task_type!r}")
 

--- a/app/coach/plans.py
+++ b/app/coach/plans.py
@@ -22,6 +22,7 @@ from sqlalchemy import func
 from app import training_load
 from app import threshold as threshold_mod
 from app import season_plan as season_plan_mod
+from app import nutrition as nutrition_mod
 from app.config import settings
 from app.models import (
     DEFAULT_USER_ID,
@@ -35,7 +36,14 @@ from app.models import (
     TrainingPlanDay,
 )
 from app.strength_routines import catalog_summary, get_routine
-from app.coach.context import _build_context, _format_activity_context, _format_athlete_profile_context, _load_zones, _load_zone_configs
+from app.coach.context import (
+    _build_context,
+    _format_activity_context,
+    _format_athlete_profile_context,
+    _load_zones,
+    _load_zone_configs,
+    recent_heat_stress,
+)
 from app.coach.providers import AITransientError, AIFatalError, _MAX_RETRIES, _BACKOFF_BASE
 
 logger = logging.getLogger(__name__)
@@ -928,3 +936,116 @@ def weekly_review(user_id: int = DEFAULT_USER_ID):
             )
         except Exception:
             logger.exception("Weekly review failed")
+
+
+_BRIEFING_SYSTEM_PROMPT = """You are an expert running coach writing a short, motivating pre-workout \
+briefing for today's scheduled training session — the one moment before the athlete heads out the door.
+
+Write 3-5 short sentences (no headers, no bullet lists) covering, in this order, whenever the
+supporting data is present:
+1. Why this session matters right now, given the current training phase/season block.
+2. The concrete execution target for today (pace/HR zone/effort, drawn from the scheduled session).
+3. A one-line readiness note: how the athlete is set up today, and whether to run the session as
+   written, ease off, or push.
+4. If a fuelling target is present (long efforts only), a one-line reminder of the carb/fluid target.
+5. If a heat-stress/conditions note is present, a one-line heads-up.
+
+Skip any point whose supporting data is not present rather than inventing detail. Keep the tone
+encouraging and direct, like a coach texting an athlete the morning of a key session. Start the
+response with "**Summary:** " followed by a single punchy sentence, then a blank line, then the
+full briefing."""
+
+
+def _build_briefing_trigger_data(
+    db: Session, plan: TrainingPlan | None, plan_day: TrainingPlanDay, user_id: int
+) -> str:
+    """Format today's scheduled session, season phase, and fuelling for the briefing prompt."""
+    parts = [f"**Scheduled session for {plan_day.day_date} ({plan_day.day_of_week})**"]
+    parts.append(f"Workout type: {plan_day.workout_type}")
+    if plan_day.target_distance_m:
+        parts.append(f"Target distance: {plan_day.target_distance_m / 1000:.1f} km")
+    if plan_day.target_pace_display:
+        parts.append(f"Target pace: {plan_day.target_pace_display}")
+    if plan_day.description:
+        parts.append(f"Description: {plan_day.description}")
+    if plan_day.notes:
+        parts.append(f"Coach notes: {plan_day.notes}")
+    if plan_day.week_theme:
+        parts.append(f"Week theme: {plan_day.week_theme}")
+
+    if plan:
+        phase_line = f"Season phase: {plan.phase}" if plan.phase else ""
+        if plan.overview:
+            phase_line += (" — " if phase_line else "") + plan.overview
+        if phase_line:
+            parts.append(phase_line)
+
+    # Fuelling guidance for long efforts (reuses the same helper as the plan-day API response).
+    if plan_day.workout_type == "long" and plan_day.target_distance_m and plan_day.target_pace_min_km:
+        profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == user_id).first()
+        duration_sec = (plan_day.target_distance_m / 1000.0) * plan_day.target_pace_min_km * 60.0
+        heat_stress = recent_heat_stress(db, plan_day.day_date, user_id)
+        guidance = nutrition_mod.compute_fuelling_guidance(
+            duration_sec=duration_sec,
+            intensity="long",
+            weight_kg=profile.weight_kg if profile else None,
+            heat_stress=heat_stress,
+        )
+        if guidance:
+            parts.append(f"Fuelling target: {guidance.note}")
+
+    return "\n".join(parts)
+
+
+def generate_briefing(plan_day_id: int) -> None:
+    """Generate a short pre-workout briefing Insight for a scheduled plan day.
+
+    Called as an AIJob after the morning daily sync, or on demand. Regenerating
+    (on-demand) replaces any existing briefing for the same plan day.
+    """
+    from app import ai_coach as _shim
+    from app import notifications as notifications_mod
+
+    with _shim.db_session() as db:
+        try:
+            plan_day = db.query(TrainingPlanDay).get(plan_day_id)
+            if not plan_day:
+                logger.warning("Plan day %s not found for briefing", plan_day_id)
+                return
+            user_id = plan_day.user_id or DEFAULT_USER_ID
+
+            db.query(Insight).filter(
+                Insight.user_id == user_id,
+                Insight.trigger_type == "briefing",
+                Insight.trigger_id == plan_day.id,
+            ).delete()
+
+            plan = db.query(TrainingPlan).filter(TrainingPlan.id == plan_day.plan_id).first()
+            trigger_data = _build_briefing_trigger_data(db, plan, plan_day, user_id)
+            full_context = _build_context(
+                db, "briefing", trigger_data, reference_date=plan_day.day_date, user_id=user_id
+            )
+            content, summary, category = _shim._call_ai(
+                db, full_context, "briefing", user_id, system_prompt=_BRIEFING_SYSTEM_PROMPT
+            )
+
+            db.add(Insight(
+                user_id=user_id,
+                created_at=datetime.now(timezone.utc),
+                trigger_type="briefing",
+                trigger_id=plan_day.id,
+                content=content,
+                summary=summary,
+                category=category,
+            ))
+            db.commit()
+            logger.info("Briefing generated for plan day %s: %s", plan_day.id, summary[:80])
+
+            notifications_mod.notify(
+                db, user_id, "briefing",
+                title="Today's briefing is ready",
+                body=summary,
+                url="/",
+            )
+        except Exception:
+            logger.exception("Briefing generation failed for plan day %s", plan_day_id)

--- a/app/coach/providers.py
+++ b/app/coach/providers.py
@@ -49,19 +49,36 @@ def _extract_summary_and_category(content: str, trigger_type: str) -> tuple[str,
         "activity": "workout_analysis",
         "daily_summary": "recovery",
         "weekly_review": "training_plan",
+        "briefing": "briefing",
     }
     return summary, category_map.get(trigger_type, "recommendation")
 
 
-def _call_claude(context: str, trigger_type: str, model: str) -> tuple[str, str, str]:
+# Framing for the user-role prompt, keyed by trigger_type. Trigger types not
+# listed here get the generic "Analyze this X data" framing.
+_USER_PROMPT_INSTRUCTION = {
+    "briefing": "Write today's pre-workout briefing based on this data",
+}
+
+
+def _build_user_prompt(trigger_type: str, context: str) -> str:
+    instruction = _USER_PROMPT_INSTRUCTION.get(
+        trigger_type, f"Analyze this {trigger_type} data and provide coaching insights"
+    )
+    return f"{instruction}:\n\n{context}"
+
+
+def _call_claude(
+    context: str, trigger_type: str, model: str, system_prompt: str | None = None
+) -> tuple[str, str, str]:
     """Call Claude API and return (content, summary, category)."""
     client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
-    user_prompt = f"Analyze this {trigger_type} data and provide coaching insights:\n\n{context}"
+    user_prompt = _build_user_prompt(trigger_type, context)
     try:
         response = client.messages.create(
             model=model,
             max_tokens=1024,
-            system=SYSTEM_PROMPT,
+            system=system_prompt or SYSTEM_PROMPT,
             messages=[{"role": "user", "content": user_prompt}],
         )
     except (
@@ -83,15 +100,17 @@ def _call_claude(context: str, trigger_type: str, model: str) -> tuple[str, str,
     return content, summary, category
 
 
-def _call_gemini(context: str, trigger_type: str, model: str) -> tuple[str, str, str]:
+def _call_gemini(
+    context: str, trigger_type: str, model: str, system_prompt: str | None = None
+) -> tuple[str, str, str]:
     """Call Gemini API and return (content, summary, category)."""
     client = genai.Client(api_key=settings.gemini_api_key)
-    user_prompt = f"Analyze this {trigger_type} data and provide coaching insights:\n\n{context}"
+    user_prompt = _build_user_prompt(trigger_type, context)
     try:
         response = client.models.generate_content(
             model=model,
             contents=user_prompt,
-            config=_genai_types.GenerateContentConfig(system_instruction=SYSTEM_PROMPT),
+            config=_genai_types.GenerateContentConfig(system_instruction=system_prompt or SYSTEM_PROMPT),
         )
     except _genai_errors.ServerError as exc:
         raise AITransientError(str(exc)) from exc
@@ -131,7 +150,11 @@ def _get_ai_config(db: Session, user_id: int = DEFAULT_USER_ID) -> tuple[str, st
 
 
 def _call_ai(
-    db: Session, context: str, trigger_type: str, user_id: int = DEFAULT_USER_ID
+    db: Session,
+    context: str,
+    trigger_type: str,
+    user_id: int = DEFAULT_USER_ID,
+    system_prompt: str | None = None,
 ) -> tuple[str, str, str]:
     """Dispatch to the configured AI provider with exponential backoff on transient errors."""
     from app import ai_coach as _shim
@@ -142,7 +165,7 @@ def _call_ai(
     last_exc: Exception = RuntimeError("no attempts made")
     for attempt in range(_MAX_RETRIES):
         try:
-            return call_fn(context, trigger_type, model)
+            return call_fn(context, trigger_type, model, system_prompt)
         except AIFatalError:
             raise  # configuration errors are not retryable
         except AITransientError as exc:

--- a/app/main.py
+++ b/app/main.py
@@ -194,6 +194,11 @@ def run_daily_sync_for_user(user_id: int) -> None:
     except Exception:
         logger.exception("Race-week reminder push check failed for user %s", user_id)
 
+    try:
+        _generate_briefing_if_needed(user_id)
+    except Exception:
+        logger.exception("Briefing generation check failed for user %s", user_id)
+
 
 def _push_plan_adaptation_if_needed(user_id: int, today_summary: DailySummary | None) -> None:
     """Push a readiness-driven plan-adaptation suggestion once per plan day.
@@ -263,6 +268,41 @@ def _push_plan_adaptation_if_needed(user_id: int, today_summary: DailySummary | 
         )
         db.add(SyncStatus(user_id=user_id, key=dedup_key, value=today.isoformat()))
         db.commit()
+
+
+def _generate_briefing_if_needed(user_id: int) -> None:
+    """Enqueue today's pre-workout briefing once per plan day, during the morning sync.
+
+    Dedupes per plan day via ``SyncStatus`` so a later re-run of the daily sync
+    doesn't regenerate (and re-push) the same briefing. The actual generation
+    runs on the AIJob worker, not inline, since it's an AI call.
+    """
+    from app.ai_coach import enqueue_job
+
+    today = date.today()
+    with db_session() as db:
+        plan_day = (
+            db.query(TrainingPlanDay)
+            .filter(TrainingPlanDay.user_id == user_id, TrainingPlanDay.day_date == today)
+            .first()
+        )
+        if plan_day is None:
+            return
+
+        dedup_key = f"briefing_generated:{plan_day.id}"
+        already_generated = (
+            db.query(SyncStatus)
+            .filter(SyncStatus.user_id == user_id, SyncStatus.key == dedup_key)
+            .first()
+        )
+        if already_generated:
+            return
+
+        plan_day_id = plan_day.id
+        db.add(SyncStatus(user_id=user_id, key=dedup_key, value=today.isoformat()))
+        db.commit()
+
+    enqueue_job("generate_briefing", {"plan_day_id": plan_day_id}, user_id)
 
 
 def _push_race_week_reminders(user_id: int, days_out: int = 7) -> None:

--- a/app/notifications.py
+++ b/app/notifications.py
@@ -33,6 +33,7 @@ CATEGORIES: dict[str, str] = {
     "personal_record": "Personal records",
     "reauth": "Garmin connection issues",
     "race_reminder": "Race-week reminders",
+    "briefing": "Pre-workout briefings",
 }
 
 _PREFS_KEY = "notification_preferences"

--- a/app/routers/daily.py
+++ b/app/routers/daily.py
@@ -263,6 +263,19 @@ def api_today(
         if dismissed:
             plan_adaptation = None
 
+    briefing = None
+    if plan_day is not None:
+        briefing = (
+            db.query(Insight)
+            .filter(
+                Insight.user_id == uid,
+                Insight.trigger_type == "briefing",
+                Insight.trigger_id == plan_day.id,
+            )
+            .order_by(Insight.created_at.desc())
+            .first()
+        )
+
     return TodayResponse(
         selected_date=selected,
         activities=activity_summaries,
@@ -275,6 +288,8 @@ def api_today(
         readiness=readiness,
         plan_adaptation=plan_adaptation,
         daily_checkin=DailyCheckinResponse.model_validate(checkin) if checkin else None,
+        plan_day_id=plan_day.id if plan_day is not None else None,
+        briefing=InsightResponse.model_validate(briefing) if briefing else None,
     )
 
 

--- a/app/routers/plan.py
+++ b/app/routers/plan.py
@@ -147,6 +147,32 @@ def api_generate_training_plan(current_user: User = Depends(get_current_user)):
     return AIJobEnqueuedResponse(status="queued", job_id=job_id)
 
 
+@router.post("/training-plan/days/{day_id}/briefing", response_model=AIJobEnqueuedResponse)
+def api_generate_briefing(
+    day_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Enqueue a pre-workout briefing for a scheduled plan day and return the job id.
+
+    Clients poll GET /api/v1/jobs/{job_id} until status is 'done', then refresh
+    Today (GET /api/v1/today) to pick up the new briefing insight. Regenerates
+    (replaces) any existing briefing for the day.
+    """
+    from app.ai_coach import enqueue_job
+
+    plan_day = (
+        db.query(TrainingPlanDay)
+        .filter(TrainingPlanDay.id == day_id, TrainingPlanDay.user_id == current_user.id)
+        .first()
+    )
+    if plan_day is None:
+        raise HTTPException(status_code=404, detail="Plan day not found")
+
+    job_id = enqueue_job("generate_briefing", {"plan_day_id": plan_day.id}, current_user.id)
+    return AIJobEnqueuedResponse(status="queued", job_id=job_id)
+
+
 @router.get("/season-plan", response_model=SeasonPlanResponse | None)
 def api_get_season_plan(
     db: Session = Depends(get_db),

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -433,6 +433,8 @@ class TodayResponse(BaseModel):
     readiness: TrainingReadiness | None = None
     plan_adaptation: PlanAdaptationSuggestion | None = None
     daily_checkin: DailyCheckinResponse | None = None
+    plan_day_id: int | None = None
+    briefing: InsightResponse | None = None
 
 
 class SettingsResponse(BaseModel):

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -284,7 +284,7 @@ and it prevents the classic blow-up the entire pacing feature exists to avoid.
 inputs, cost line), `frontend/src/api/types.ts`, `tests/test_pacing.py`,
 `tests/test_api_endpoints.py`.
 
-#### P1-3 · Pre-workout briefing (Runna-style)
+#### P1-3 · Pre-workout briefing (Runna-style) ✅ Done.
 **What:** A short, personalized **briefing for today's session**, generated as an
 `AIJob` after the morning daily sync (and on demand from the workout card):
 why this session matters in the current season phase, concrete execution targets
@@ -308,6 +308,35 @@ latest briefing insight), `app/schemas.py`,
 `frontend/src/components/today/BriefingCard.tsx` + `.css` (new), `TodayView.tsx`,
 `frontend/src/api/{types,hooks}.ts`, `tests/test_ai_coach.py`,
 `tests/test_job_queue.py`.
+_Implemented as described, scoped to P1-3 only. File locations follow the
+post-P3-1 split: `generate_briefing` and its prompt/context helper
+(`_build_briefing_trigger_data`) landed in `app/coach/plans.py` alongside
+`generate_training_plan`/`weekly_review`, with a `"generate_briefing"` branch
+added to `execute_job` in `app/coach/jobs.py` and both re-exported through the
+`app/ai_coach.py` shim; the on-demand endpoint landed in
+`app/routers/plan.py`, and the Today wiring (`plan_day_id` + `briefing`
+fields) in `app/routers/daily.py`/`app/schemas.py`. Rather than duplicate the
+retry/backoff dispatch in `app/coach/providers.py`, `_call_claude`/
+`_call_gemini`/`_call_ai` gained an optional `system_prompt` override (default
+unchanged) so the briefing gets its own forward-looking prompt instead of the
+generic post-hoc-analysis one, and `_extract_summary_and_category` gained a
+`"briefing"` category. The trigger data is deliberately thin (today's
+scheduled session, the plan's phase/overview, and a fuelling reminder for
+long efforts via the existing `app/nutrition.py` helper) — it's handed to the
+existing `_build_context`, which already contributes readiness (including the
+heat-stress one-liner from `app/weather.py`), profile, and load, so no new
+context plumbing was needed. The daily-sync hook
+(`main._generate_briefing_if_needed`) mirrors the P0-1 push
+helpers exactly: it enqueues (rather than calls inline) so the AI call runs on
+the job worker, not the scheduler thread, deduped per plan day via
+`SyncStatus` the same way `_push_plan_adaptation_if_needed` is. On the
+frontend, `BriefingCard.tsx` shows the generated note (Markdown) with a
+regenerate affordance, or a "Generate briefing" button when a plan day exists
+for the selected date but no briefing yet — polling the job the same way
+`ActivityDetailView`'s re-analyze flow does, via the existing `useJobStatus`
+hook. All new and existing tests pass (940 backend); `npm run build`, `tsc
+-b`, and the Vitest suite (57 cases, unchanged — new React Testing Library
+component coverage is P3-3's scope, not this item's) are clean._
 
 ### P2 — Sharper analysis, honest load
 

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -418,6 +418,13 @@ export function useGenerateTrainingPlan() {
   })
 }
 
+export function useGenerateBriefing() {
+  return useMutation({
+    mutationFn: (planDayId: number) =>
+      apiPost<AIJobEnqueuedResponse>(`/training-plan/days/${planDayId}/briefing`, {}),
+  })
+}
+
 export function useSeasonPlan() {
   return useQuery({
     queryKey: ['season-plan'],

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -326,6 +326,8 @@ export interface TodayResponse {
   readiness: TrainingReadiness | null
   plan_adaptation: PlanAdaptationSuggestion | null
   daily_checkin: DailyCheckin | null
+  plan_day_id: number | null
+  briefing: InsightResponse | null
 }
 
 export interface SettingsResponse {

--- a/frontend/src/components/today/BriefingCard.css
+++ b/frontend/src/components/today/BriefingCard.css
@@ -1,0 +1,84 @@
+.briefing-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-card));
+}
+
+.briefing-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--accent);
+}
+
+.briefing-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  flex: 1;
+}
+
+.briefing-regenerate {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s;
+}
+
+.briefing-regenerate:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.briefing-regenerate:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.briefing-content {
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.briefing-content p {
+  margin: 0 0 8px;
+}
+
+.briefing-content p:last-child {
+  margin-bottom: 0;
+}
+
+.briefing-content strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.briefing-hint {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.briefing-generate {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82rem;
+  padding: 6px 14px;
+}
+
+.briefing-generate:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+}

--- a/frontend/src/components/today/BriefingCard.tsx
+++ b/frontend/src/components/today/BriefingCard.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import ReactMarkdown from 'react-markdown'
+import { Sparkles, RefreshCw } from 'lucide-react'
+import { useGenerateBriefing, useJobStatus } from '../../api/hooks'
+import type { InsightResponse } from '../../api/types'
+import './BriefingCard.css'
+
+interface Props {
+  dateKey: string
+  planDayId: number | null
+  briefing: InsightResponse | null
+}
+
+export default function BriefingCard({ dateKey, planDayId, briefing }: Props) {
+  const qc = useQueryClient()
+  const generateBriefing = useGenerateBriefing()
+  const [jobId, setJobId] = useState<number | null>(null)
+  const { data: job } = useJobStatus(jobId)
+
+  const isGenerating =
+    generateBriefing.isPending ||
+    (jobId != null && job?.status !== 'done' && job?.status !== 'failed')
+
+  useEffect(() => {
+    if (job?.status === 'done' || job?.status === 'failed') {
+      qc.invalidateQueries({ queryKey: ['today', dateKey] })
+      setJobId(null)
+    }
+  }, [job?.status, dateKey, qc])
+
+  if (planDayId == null) return null
+
+  function handleGenerate() {
+    generateBriefing.mutate(planDayId!, {
+      onSuccess: (data) => { if (data?.job_id) setJobId(data.job_id) },
+    })
+  }
+
+  if (!briefing) {
+    return (
+      <div className="card briefing-card briefing-empty">
+        <div className="briefing-header">
+          <Sparkles size={16} />
+          <span className="briefing-title">Today's Briefing</span>
+        </div>
+        <p className="briefing-hint">Get a short pre-workout note tailored to today's session.</p>
+        <button className="btn-primary briefing-generate" onClick={handleGenerate} disabled={isGenerating}>
+          {isGenerating ? <RefreshCw size={13} className="spin" /> : <Sparkles size={13} />}
+          {isGenerating ? 'Generating…' : 'Generate briefing'}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="card briefing-card">
+      <div className="briefing-header">
+        <Sparkles size={16} />
+        <span className="briefing-title">Today's Briefing</span>
+        <button
+          className="briefing-regenerate"
+          onClick={handleGenerate}
+          disabled={isGenerating}
+          title="Regenerate briefing"
+        >
+          <RefreshCw size={13} className={isGenerating ? 'spin' : ''} />
+        </button>
+      </div>
+      <div className="briefing-content">
+        <ReactMarkdown>{briefing.content || briefing.summary || ''}</ReactMarkdown>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/today/TodayView.tsx
+++ b/frontend/src/components/today/TodayView.tsx
@@ -11,6 +11,7 @@ import DailyCheckinCard from './DailyCheckinCard'
 import PlanAdaptationCard from './PlanAdaptationCard'
 import InsightsList from './InsightsList'
 import RacePacingCard from './RacePacingCard'
+import BriefingCard from './BriefingCard'
 import StatHelpButton from '../info/StatHelpButton'
 import { AlertTriangle, RefreshCw } from 'lucide-react'
 import './TodayView.css'
@@ -77,6 +78,18 @@ export default function TodayView() {
   return (
     <div className="today-view">
       {isViewingToday && <TodayRealignmentBanner />}
+
+      {/* Pre-workout briefing */}
+      {data?.plan_day_id != null && (
+        <section className="today-section">
+          <BriefingCard
+            dateKey={dateKey}
+            planDayId={data.plan_day_id}
+            briefing={data.briefing ?? null}
+          />
+        </section>
+      )}
+
       {/* Today's workouts */}
       <section className="today-section">
         <h2 className="section-title">{dateLabel}'s workouts</h2>

--- a/tests/test_ai_coach.py
+++ b/tests/test_ai_coach.py
@@ -327,6 +327,11 @@ def test_extract_category_default_for_unknown_trigger():
     assert category == "recommendation"
 
 
+def test_extract_category_briefing():
+    _, category = ai_coach._extract_summary_and_category("x", "briefing")
+    assert category == "briefing"
+
+
 # --- _get_ai_config / _call_ai dispatch ---
 
 def test_get_ai_config_defaults(db):
@@ -347,8 +352,8 @@ def test_get_ai_config_from_db(db):
 def test_call_ai_dispatches_to_claude(db, monkeypatch):
     called = {}
 
-    def fake_claude(context, trigger_type, model):
-        called["claude"] = (context, trigger_type, model)
+    def fake_claude(context, trigger_type, model, system_prompt=None):
+        called["claude"] = (context, trigger_type, model, system_prompt)
         return ("content", "summary", "category")
 
     monkeypatch.setattr(ai_coach, "_call_claude", fake_claude)
@@ -361,7 +366,7 @@ def test_call_ai_dispatches_to_gemini(db, monkeypatch):
     db.add(SyncStatus(key="ai_provider", value="gemini"))
     db.add(SyncStatus(key="ai_model", value="gemini-2.5-flash"))
     db.commit()
-    monkeypatch.setattr(ai_coach, "_call_gemini", lambda c, t, m: ("g", "gs", "gc"))
+    monkeypatch.setattr(ai_coach, "_call_gemini", lambda c, t, m, system_prompt=None: ("g", "gs", "gc"))
     assert ai_coach._call_ai(db, "ctx", "activity") == ("g", "gs", "gc")
 
 
@@ -388,6 +393,32 @@ def test_call_gemini_uses_genai(monkeypatch):
     content, summary, category = ai_coach._call_gemini("ctx", "daily_summary", "gemini-x")
     assert summary == "good"
     assert category == "recovery"
+
+
+def test_call_claude_honors_custom_system_prompt(monkeypatch):
+    fake_msg = MagicMock()
+    fake_msg.content = [MagicMock(text="**Summary:** ok\nbody")]
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = fake_msg
+    monkeypatch.setattr(ai_coach.anthropic, "Anthropic", lambda *a, **k: fake_client)
+
+    ai_coach._call_claude("ctx", "briefing", "claude-x", system_prompt="Custom briefing prompt")
+
+    _, kwargs = fake_client.messages.create.call_args
+    assert kwargs["system"] == "Custom briefing prompt"
+
+
+def test_call_gemini_honors_custom_system_prompt(monkeypatch):
+    fake_response = MagicMock()
+    fake_response.text = "**Summary:** good\nrest"
+    fake_client = MagicMock()
+    fake_client.models.generate_content.return_value = fake_response
+    monkeypatch.setattr(ai_coach.genai, "Client", lambda api_key: fake_client)
+
+    ai_coach._call_gemini("ctx", "briefing", "gemini-x", system_prompt="Custom briefing prompt")
+
+    _, kwargs = fake_client.models.generate_content.call_args
+    assert kwargs["config"].system_instruction == "Custom briefing prompt"
 
 
 # --- analyze flows (DB redirected, AI mocked) ---
@@ -604,6 +635,149 @@ def test_weekly_review_no_activities_skips(db, patch_db_session, monkeypatch):
     ai_coach.weekly_review()
     called.assert_not_called()
     assert db.query(Insight).count() == 0
+
+
+# --- generate_briefing (P1-3) ---
+
+def _seed_plan_day(
+    db,
+    workout_type: str = "easy",
+    day_date: date = date(2026, 7, 7),
+    user_id: int = 1,
+    target_distance_m: float | None = None,
+    target_pace_min_km: float | None = None,
+) -> TrainingPlanDay:
+    plan = TrainingPlan(
+        user_id=user_id,
+        generated_at=datetime(2026, 7, 1, 9, 0, tzinfo=timezone.utc),
+        week_start=date(2026, 7, 6),
+        plan_weeks=4,
+        phase="build",
+        overview="Building toward the goal race.",
+    )
+    db.add(plan)
+    db.flush()
+    plan_day = TrainingPlanDay(
+        user_id=user_id,
+        plan_id=plan.id,
+        day_date=day_date,
+        day_of_week=day_date.strftime("%A"),
+        week_number=1,
+        workout_type=workout_type,
+        target_distance_m=target_distance_m,
+        target_pace_min_km=target_pace_min_km,
+        target_pace_display="5:15/km" if target_pace_min_km else None,
+        description="Test session",
+        week_theme="Aerobic Base",
+    )
+    db.add(plan_day)
+    db.commit()
+    db.refresh(plan_day)
+    return plan_day
+
+
+def test_generate_briefing_creates_insight(db, patch_db_session, monkeypatch):
+    patch_db_session(ai_coach)
+    plan_day = _seed_plan_day(db)
+    monkeypatch.setattr(
+        ai_coach, "_call_ai",
+        lambda d, c, t, user_id=1, system_prompt=None: (
+            "**Summary:** Easy aerobic day\nRun it easy.", "Easy aerobic day", "briefing",
+        ),
+    )
+
+    ai_coach.generate_briefing(plan_day.id)
+
+    insight = db.query(Insight).filter(Insight.trigger_type == "briefing").first()
+    assert insight is not None
+    assert insight.trigger_id == plan_day.id
+    assert insight.summary == "Easy aerobic day"
+    assert insight.category == "briefing"
+    assert insight.user_id == plan_day.user_id
+
+
+def test_generate_briefing_passes_briefing_system_prompt(db, patch_db_session, monkeypatch):
+    patch_db_session(ai_coach)
+    plan_day = _seed_plan_day(db)
+    captured = {}
+
+    def fake_call_ai(d, c, t, user_id=1, system_prompt=None):
+        captured["trigger_type"] = t
+        captured["system_prompt"] = system_prompt
+        return ("**Summary:** ok\nbody", "ok", "briefing")
+
+    monkeypatch.setattr(ai_coach, "_call_ai", fake_call_ai)
+    ai_coach.generate_briefing(plan_day.id)
+
+    assert captured["trigger_type"] == "briefing"
+    assert captured["system_prompt"] == ai_coach._BRIEFING_SYSTEM_PROMPT
+
+
+def test_generate_briefing_missing_plan_day_is_noop(db, patch_db_session, monkeypatch):
+    patch_db_session(ai_coach)
+    called = MagicMock()
+    monkeypatch.setattr(ai_coach, "_call_ai", called)
+
+    ai_coach.generate_briefing(99999)
+
+    called.assert_not_called()
+    assert db.query(Insight).count() == 0
+
+
+def test_generate_briefing_regenerate_replaces_existing(db, patch_db_session, monkeypatch):
+    patch_db_session(ai_coach)
+    plan_day = _seed_plan_day(db)
+    db.add(Insight(
+        user_id=plan_day.user_id,
+        trigger_type="briefing",
+        trigger_id=plan_day.id,
+        content="stale content",
+        summary="stale summary",
+        category="briefing",
+    ))
+    db.commit()
+
+    monkeypatch.setattr(
+        ai_coach, "_call_ai",
+        lambda d, c, t, user_id=1, system_prompt=None: (
+            "**Summary:** fresh\nbody", "fresh", "briefing",
+        ),
+    )
+    ai_coach.generate_briefing(plan_day.id)
+
+    briefings = db.query(Insight).filter(Insight.trigger_type == "briefing").all()
+    assert len(briefings) == 1
+    assert briefings[0].summary == "fresh"
+
+
+def test_generate_briefing_includes_fuelling_for_long_run(db, patch_db_session, monkeypatch):
+    patch_db_session(ai_coach)
+    plan_day = _seed_plan_day(
+        db, workout_type="long", target_distance_m=20000, target_pace_min_km=5.5,
+    )
+    captured = {}
+
+    def fake_call_ai(d, c, t, user_id=1, system_prompt=None):
+        captured["context"] = c
+        return ("**Summary:** long run day\nbody", "long run day", "briefing")
+
+    monkeypatch.setattr(ai_coach, "_call_ai", fake_call_ai)
+    ai_coach.generate_briefing(plan_day.id)
+
+    assert "Fuelling target" in captured["context"]
+
+
+def test_generate_briefing_ai_error_leaves_no_insight(db, patch_db_session, monkeypatch):
+    """An AI failure is swallowed (logged) rather than raised, matching weekly_review."""
+    patch_db_session(ai_coach)
+    plan_day = _seed_plan_day(db)
+    monkeypatch.setattr(
+        ai_coach, "_call_ai", MagicMock(side_effect=RuntimeError("boom")),
+    )
+
+    ai_coach.generate_briefing(plan_day.id)  # should not raise
+
+    assert db.query(Insight).filter(Insight.trigger_type == "briefing").count() == 0
 
 
 # --- _build_plan_adherence_context (P0-3) ---

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -617,6 +617,56 @@ def test_today_plan_adaptation_suppressed_when_dismissed(client, db):
     assert resp.json()["plan_adaptation"] is None
 
 
+def test_today_includes_plan_day_id(client, db):
+    day = date(2026, 6, 17)
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "easy"},
+    ])
+    plan_day = db.query(TrainingPlanDay).filter(TrainingPlanDay.day_date == day).first()
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    assert resp.json()["plan_day_id"] == plan_day.id
+
+
+def test_today_plan_day_id_null_without_plan(client, db):
+    day = date(2026, 6, 17)
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    assert resp.json()["plan_day_id"] is None
+
+
+def test_today_includes_latest_briefing_insight(client, db):
+    day = date(2026, 6, 17)
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "easy"},
+    ])
+    plan_day = db.query(TrainingPlanDay).filter(TrainingPlanDay.day_date == day).first()
+    db.add(Insight(
+        trigger_type="briefing",
+        trigger_id=plan_day.id,
+        content="**Summary:** Easy day\nRun easy.",
+        summary="Easy day",
+        category="briefing",
+    ))
+    db.commit()
+
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["briefing"] is not None
+    assert body["briefing"]["summary"] == "Easy day"
+
+
+def test_today_briefing_null_when_none_generated(client, db):
+    day = date(2026, 6, 17)
+    _seed_plan_and_days(db, [
+        {"date": day, "workout_type": "easy"},
+    ])
+    resp = client.get(f"/api/v1/today?date={day.isoformat()}")
+    assert resp.status_code == 200
+    assert resp.json()["briefing"] is None
+
+
 def test_today_includes_risk_triggered_caution_despite_good_readiness(client, db):
     """P2-1: a high ACWR/injury_risk reading forces a cutback suggestion even
     when readiness alone would not trigger one."""

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from app.models import AIJob, Activity
+from app.models import AIJob, Activity, TrainingPlan, TrainingPlanDay
 from app.ai_coach import enqueue_job, execute_job
 
 
@@ -133,6 +133,20 @@ def test_execute_job_dispatches_weekly_review(db, patch_db_session):
         execute_job(job_id)
 
     mock_fn.assert_called_once_with(user_id=5)
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "done"
+
+
+def test_execute_job_dispatches_generate_briefing(db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("generate_briefing", {"plan_day_id": 42}, user_id=1)
+
+    with patch.object(ai_mod, "generate_briefing") as mock_fn:
+        execute_job(job_id)
+
+    mock_fn.assert_called_once_with(42)
     job = db.query(AIJob).filter(AIJob.id == job_id).first()
     assert job.status == "done"
 
@@ -283,3 +297,60 @@ def test_api_generate_plan_returns_queued_job(client, db, patch_db_session):
     job = db.query(AIJob).filter(AIJob.id == body["job_id"]).first()
     assert job is not None
     assert job.task_type == "generate_plan"
+
+
+# ---------------------------------------------------------------------------
+# API endpoint: POST /training-plan/days/{id}/briefing (P1-3)
+# ---------------------------------------------------------------------------
+
+def _make_plan_day(db, user_id=1):
+    from datetime import date as _date
+    plan = TrainingPlan(
+        user_id=user_id,
+        week_start=_date(2026, 7, 6),
+        plan_weeks=4,
+        phase="build",
+    )
+    db.add(plan)
+    db.flush()
+    plan_day = TrainingPlanDay(
+        user_id=user_id,
+        plan_id=plan.id,
+        day_date=_date(2026, 7, 7),
+        day_of_week="Tuesday",
+        week_number=1,
+        workout_type="easy",
+        description="Easy run",
+    )
+    db.add(plan_day)
+    db.commit()
+    db.refresh(plan_day)
+    return plan_day
+
+
+def test_api_generate_briefing_returns_queued_job(client, db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    plan_day = _make_plan_day(db)
+    resp = client.post(f"/api/v1/training-plan/days/{plan_day.id}/briefing")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "queued"
+    assert isinstance(body["job_id"], int)
+
+    job = db.query(AIJob).filter(AIJob.id == body["job_id"]).first()
+    assert job is not None
+    assert job.task_type == "generate_briefing"
+    assert json.loads(job.payload_json)["plan_day_id"] == plan_day.id
+
+
+def test_api_generate_briefing_404_for_unknown_day(client):
+    resp = client.post("/api/v1/training-plan/days/99999/briefing")
+    assert resp.status_code == 404
+
+
+def test_api_generate_briefing_404_for_other_users_day(client, db):
+    plan_day = _make_plan_day(db, user_id=2)
+    resp = client.post(f"/api/v1/training-plan/days/{plan_day.id}/briefing")
+    assert resp.status_code == 404

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -246,6 +246,64 @@ def test_push_race_week_reminders_ignores_other_dates(db, patch_db_session, monk
     notify.assert_not_called()
 
 
+# --- pre-workout briefing enqueue (P1-3) ------------------------------------
+
+def test_generate_briefing_if_needed_enqueues_once_then_dedupes(db, patch_db_session, monkeypatch):
+    from datetime import date
+    from app.models import TrainingPlanDay
+    import app.ai_coach as ai_coach
+
+    patch_db_session(main)
+    plan_day = TrainingPlanDay(
+        user_id=1, plan_id=1, day_date=date.today(), day_of_week="Monday",
+        workout_type="tempo",
+    )
+    db.add(plan_day)
+    db.commit()
+    db.refresh(plan_day)
+
+    enqueue = MagicMock(return_value=1)
+    monkeypatch.setattr(ai_coach, "enqueue_job", enqueue)
+
+    main._generate_briefing_if_needed(1)
+    enqueue.assert_called_once_with("generate_briefing", {"plan_day_id": plan_day.id}, 1)
+
+    enqueue.reset_mock()
+    main._generate_briefing_if_needed(1)
+    enqueue.assert_not_called()
+
+
+def test_generate_briefing_if_needed_skips_without_plan_day(db, patch_db_session, monkeypatch):
+    import app.ai_coach as ai_coach
+
+    patch_db_session(main)
+    enqueue = MagicMock()
+    monkeypatch.setattr(ai_coach, "enqueue_job", enqueue)
+
+    main._generate_briefing_if_needed(1)
+    enqueue.assert_not_called()
+
+
+def test_run_daily_sync_generates_briefing_for_todays_plan_day(monkeypatch):
+    from datetime import date
+    import app.garmin_sync as garmin_sync
+    import app.ai_coach as ai_coach
+
+    user = _user(3)
+    monkeypatch.setattr(main, "db_session", _fake_db_session_returning(user))
+    monkeypatch.setattr(main, "_authenticate_or_flag", lambda u: True)
+    monkeypatch.setattr(garmin_sync, "sync_athlete_profile", MagicMock())
+    monkeypatch.setattr(garmin_sync, "sync_daily_summary", MagicMock(return_value=None))
+    monkeypatch.setattr(ai_coach, "analyze_daily_summary", MagicMock())
+
+    briefing_check = MagicMock()
+    monkeypatch.setattr(main, "_generate_briefing_if_needed", briefing_check)
+
+    main.run_daily_sync_for_user(3)
+
+    briefing_check.assert_called_once_with(3)
+
+
 # --- weekly review / plan generation fan out -------------------------------
 
 def test_scheduled_weekly_review_delegates_per_user(monkeypatch):


### PR DESCRIPTION
Generates a short, personalized briefing for today's scheduled session
(season phase, execution targets, readiness, fuelling, conditions) as
an AIJob after the morning daily sync or on demand, stored as a new
"briefing" Insight and pushed via the existing P0-1 notification path.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ce6zqeBVfYu92BGLvBx7Zt