### PR TITLE
P2-3: audit and fix multi-sport load accounting

### DIFF
--- a/alembic/versions/q0r1s2t3u4v5_add_sport_breakdown_to_daily_load_series.py
+++ b/alembic/versions/q0r1s2t3u4v5_add_sport_breakdown_to_daily_load_series.py
@@ -1,0 +1,36 @@
+"""add sport_breakdown_json to daily_load_series
+
+Revision ID: q0r1s2t3u4v5
+Revises: p9q0r1s2t3u4
+Create Date: 2026-07-08
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision: str = "q0r1s2t3u4v5"
+down_revision: Union[str, None] = "p9q0r1s2t3u4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLE = "daily_load_series"
+
+
+def _has_column(insp: object, table: str, col: str) -> bool:
+    return any(c["name"] == col for c in insp.get_columns(table))
+
+
+def upgrade() -> None:
+    insp = inspect(op.get_bind())
+
+    with op.batch_alter_table(_TABLE) as batch_op:
+        if not _has_column(insp, _TABLE, "sport_breakdown_json"):
+            batch_op.add_column(sa.Column("sport_breakdown_json", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_column("sport_breakdown_json")

--- a/app/coach/context.py
+++ b/app/coach/context.py
@@ -628,7 +628,17 @@ def _build_context(
                 p_sec = int((a.avg_pace_min_km - p_min) * 60)
                 pace = f"{p_min}:{p_sec:02d}/km"
             date_str = a.started_at.strftime("%m/%d") if a.started_at else "?"
-            act_lines.append(f"- {date_str}: {a.name} ({a.activity_type}) {dist} {dur} {pace} {hr}")
+            # Non-run sessions don't carry a pace/HR the athlete reads as
+            # "load" the way a run's does — surface the estimated TSS instead
+            # so cross-training contribution to fitness/fatigue is explicit.
+            cross_training = ""
+            if not training_load.is_run(a.activity_type):
+                tss, _ = training_load.estimate_tss(a, profile)
+                if tss > 0:
+                    cross_training = f"~{tss:.0f} TSS"
+            act_lines.append(
+                f"- {date_str}: {a.name} ({a.activity_type}) {dist} {dur} {pace} {hr} {cross_training}".rstrip()
+            )
         sections.append("## Recent Activities (14 days)\n" + "\n".join(act_lines))
 
     # Weekly volume (last 8 weeks)

--- a/app/models.py
+++ b/app/models.py
@@ -482,6 +482,7 @@ class DailyLoadSeries(Base):
     ramp_rate_7d = Column(Float, nullable=True)
     ramp_rate_28d = Column(Float, nullable=True)
     injury_risk = Column(String(20), nullable=True)
+    sport_breakdown_json = Column(Text, nullable=True)  # JSON {"run": 62.0, "ride": 18.0, ...}
     computed_at = Column(DateTime, default=_utcnow)
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -354,6 +354,7 @@ class TrainingLoadPoint(BaseModel):
     ramp_rate_7d: float | None = None  # CTL change over last 7 days
     ramp_rate_28d: float | None = None # CTL change over last 28 days
     injury_risk: str | None = None     # "low" | "moderate" | "high"
+    sport_breakdown: dict[str, float] | None = None  # TSS by sport_category for the day
 
     # Explicit Running Stress Balance read, derived from tsb/acwr — see
     # classify_tsb/classify_acwr above. Always populated from the raw values,

--- a/app/training_load.py
+++ b/app/training_load.py
@@ -16,6 +16,7 @@ the table, so a typical new-activity sync re-processes a handful of days instead
 of the full history.
 """
 
+import json
 import logging
 import math
 from collections import defaultdict
@@ -61,6 +62,35 @@ def _intensity_to_tss(duration_hr: float, intensity: float) -> float:
     return duration_hr * intensity ** 2 * 100.0
 
 
+# Sport categories for load accounting, matched against Garmin's ``typeKey``
+# substrings (e.g. "running", "treadmill_running", "road_biking", "strength_training").
+# Order matters: first matching category wins.
+_SPORT_CATEGORY_RULES: list[tuple[str, tuple[str, ...]]] = [
+    ("run", ("run", "treadmill")),
+    ("ride", ("cycling", "biking", "bike")),
+    ("swim", ("swim",)),
+    ("strength", ("strength", "yoga", "pilates")),
+]
+
+
+def sport_category(activity_type: str | None) -> str:
+    """Bucket a raw Garmin activity type into a coarse sport category.
+
+    One of ``run``, ``ride``, ``swim``, ``strength``, or ``other``.
+    """
+    if not activity_type:
+        return "other"
+    t = activity_type.lower()
+    for category, keywords in _SPORT_CATEGORY_RULES:
+        if any(k in t for k in keywords):
+            return category
+    return "other"
+
+
+def is_run(activity_type: str | None) -> bool:
+    return sport_category(activity_type) == "run"
+
+
 def estimate_tss(activity: Activity, profile: AthleteProfile | None) -> tuple[float, str]:
     """Return ``(tss, source)`` for one activity.
 
@@ -74,10 +104,18 @@ def estimate_tss(activity: Activity, profile: AthleteProfile | None) -> tuple[fl
     if duration_hr <= 0:
         return 0.0, "none"
 
-    # Pace-based rTSS: intensity = threshold_pace / actual_pace (min/km), so a
-    # faster (smaller) pace yields a higher intensity factor.
+    # Pace-based rTSS assumes a running gait: intensity = threshold_pace / actual
+    # pace (min/km). ``avg_pace_min_km`` is a generic distance/duration ratio
+    # computed for every synced activity (see garmin_sync._extract_activity_fields),
+    # so it must be gated to runs — otherwise a bike ride's much faster
+    # distance/time ratio reads as a sprint and wildly overstates its TSS.
     thr_pace = profile.threshold_pace_min_km if profile else None
-    if thr_pace and activity.avg_pace_min_km and activity.avg_pace_min_km > 0:
+    if (
+        is_run(activity.activity_type)
+        and thr_pace
+        and activity.avg_pace_min_km
+        and activity.avg_pace_min_km > 0
+    ):
         intensity = thr_pace / activity.avg_pace_min_km
         return _intensity_to_tss(duration_hr, intensity), "pace"
 
@@ -191,6 +229,7 @@ def _load_series_points(
             ramp_rate_7d=row.ramp_rate_7d,
             ramp_rate_28d=row.ramp_rate_28d,
             injury_risk=row.injury_risk or "low",
+            sport_breakdown=json.loads(row.sport_breakdown_json) if row.sport_breakdown_json else None,
         )
         for row in rows
     ]
@@ -206,8 +245,12 @@ def _daily_tss_range(
     end_date: date,
     profile: AthleteProfile | None,
     user_id: int,
-) -> dict[date, float]:
-    """Sum estimated TSS per calendar day in [start_date, end_date]."""
+) -> tuple[dict[date, float], dict[date, dict[str, float]]]:
+    """Sum estimated TSS per calendar day in [start_date, end_date].
+
+    Returns ``(totals, sport_totals)`` where ``sport_totals`` breaks each day's
+    total down by ``sport_category`` (e.g. ``{"run": 62.0, "ride": 18.0}``).
+    """
     start_dt = datetime.combine(start_date, datetime.min.time())
     end_dt = datetime.combine(end_date + timedelta(days=1), datetime.min.time())
     activities = (
@@ -221,12 +264,14 @@ def _daily_tss_range(
         .all()
     )
     totals: dict[date, float] = defaultdict(float)
+    sport_totals: dict[date, dict[str, float]] = defaultdict(lambda: defaultdict(float))
     for a in activities:
         day = a.started_at.date() if isinstance(a.started_at, datetime) else a.started_at
         tss, _ = estimate_tss(a, profile)
         if tss > 0:
             totals[day] += tss
-    return totals
+            sport_totals[day][sport_category(a.activity_type)] += tss
+    return totals, sport_totals
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +372,7 @@ def _ensure_series_current(
     db.commit()
 
     profile = db.query(AthleteProfile).filter(AthleteProfile.user_id == user_id).first()
-    daily_tss_map = _daily_tss_range(db, recompute_from, compute_to, profile, user_id)
+    daily_tss_map, daily_sport_map = _daily_tss_range(db, recompute_from, compute_to, profile, user_id)
 
     # Load the 28-day ramp-rate lookback from the persisted table.
     lookback_start = recompute_from - timedelta(days=28)
@@ -353,6 +398,10 @@ def _ensure_series_current(
             round(ctl - all_before[idx - 28].ctl, 1) if idx >= 28 else None
         )
         risk = _injury_risk(acwr, ramp_7d)
+        sport_breakdown = {
+            sport: round(val, 1) for sport, val in daily_sport_map.get(day, {}).items()
+        } or None
+        sport_breakdown_json = json.dumps(sport_breakdown) if sport_breakdown else None
 
         new_points.append(
             TrainingLoadPoint(
@@ -365,6 +414,7 @@ def _ensure_series_current(
                 ramp_rate_7d=ramp_7d,
                 ramp_rate_28d=ramp_28d,
                 injury_risk=risk,
+                sport_breakdown=sport_breakdown,
             )
         )
         new_db_rows.append(
@@ -379,6 +429,7 @@ def _ensure_series_current(
                 ramp_rate_7d=ramp_7d,
                 ramp_rate_28d=ramp_28d,
                 injury_risk=risk,
+                sport_breakdown_json=sport_breakdown_json,
                 computed_at=now_ts,
             )
         )

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -423,7 +423,7 @@ dashed chart line and delta callout chips; `CustomChartsView` adds a "Compare
 to previous period" checkbox that overlays a muted dashed line per selected
 metric. All new and existing tests pass (backend pytest, `tsc -b`, Vitest)._
 
-#### P2-3 · Multi-sport load audit & explicit handling
+#### P2-3 · Multi-sport load audit & explicit handling ✅ Done.
 **What:** Make non-running load honest and visible. Today the sync stores **all**
 activity types and the TSS chain is nominally sport-agnostic, but it was designed
 for runs (rTSS assumes running pace; thresholds filter to `_is_run`). Audit and
@@ -442,6 +442,27 @@ aggregation), `app/api.py` (training-load response sport split),
 `app/schemas.py`, `app/ai_coach.py` (context line),
 `frontend/src/components/today/TrainingLoadChart.tsx`,
 `tests/test_training_load.py` (ride/strength fixtures).
+_Implemented as described, scoped to P2-3 only. The audit found a real bug, not
+just missing presentation: `avg_pace_min_km` is computed for **every** synced
+activity regardless of sport (`garmin_sync._extract_activity_fields`), so a
+ride's much faster generic distance/time ratio was being read as a running
+pace and fed straight into rTSS — wildly overstating a bike ride's intensity
+and, downstream, CTL/ATL/ACWR/injury-risk. `app/training_load.py` gained a
+`sport_category()` classifier (`run` / `ride` / `swim` / `strength` / `other`,
+matched against Garmin `typeKey` substrings) and its `is_run()` helper now
+gates the pace-based branch in `estimate_tss`; hrTSS and the sRPE/duration
+floor were already sport-agnostic and needed no change. `_daily_tss_range`
+now also returns a per-day `{sport: tss}` breakdown, persisted as a new
+`DailyLoadSeries.sport_breakdown_json` column (migration
+`q0r1s2t3u4v5`) and surfaced on `TrainingLoadPoint.sport_breakdown` — no new
+endpoint needed, it rides along on the existing `GET /training-load`
+response. `TrainingLoadChart.tsx` adds a "Load by sport" stacked bar +
+legend (aggregated across the visible window) below the existing CTL/ATL/TSB
+legend, shown only when more than one sport contributed. The AI context's
+"Recent Activities" line now appends `~N TSS` for any non-run session (e.g.
+"Evening Ride (cycling) ... ~48 TSS"), reusing the same `estimate_tss` call
+the load series uses, so the coach and the chart never disagree. All new and
+existing tests pass (backend pytest, `tsc -b`, Vitest, `npm run build`)._
 
 ### P3 — Architecture & hygiene (pay down before the next cycle)
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -269,6 +269,7 @@ export interface TrainingLoadPoint {
   rsb_zone: string | null  // "detraining" | "productive" | "overreaching"
   rsb_zone_label: string | null
   rsb_recommendation: string | null
+  sport_breakdown: Record<string, number> | null  // TSS by sport category for the day
 }
 
 export interface TrainingReadiness {

--- a/frontend/src/components/today/TrainingLoadChart.css
+++ b/frontend/src/components/today/TrainingLoadChart.css
@@ -85,3 +85,37 @@
   height: 10px;
   border-radius: 2px;
 }
+
+.tl-sport-split {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.tl-sport-split-label {
+  display: block;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+  text-align: center;
+}
+
+.tl-sport-bar {
+  display: flex;
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.tl-sport-bar-seg {
+  height: 100%;
+}
+
+.tl-sport-split .tl-legend {
+  border-top: none;
+  margin-top: 8px;
+  padding-top: 0;
+}

--- a/frontend/src/components/today/TrainingLoadChart.tsx
+++ b/frontend/src/components/today/TrainingLoadChart.tsx
@@ -24,6 +24,30 @@ const ATL_COLOR = '#e17055' // Fatigue — orange
 const TSB_COLOR = '#00b894' // Form — green
 const ACWR_COLOR = '#fdcb6e' // ACWR — amber
 
+const SPORT_COLORS: Record<string, string> = {
+  run: '#6c5ce7',
+  ride: '#0984e3',
+  swim: '#00cec9',
+  strength: '#e17055',
+  other: '#b2bec3',
+}
+
+const SPORT_LABELS: Record<string, string> = {
+  run: 'Run',
+  ride: 'Ride',
+  swim: 'Swim',
+  strength: 'Strength',
+  other: 'Other',
+}
+
+function sportColor(sport: string): string {
+  return SPORT_COLORS[sport] ?? SPORT_COLORS.other
+}
+
+function sportLabel(sport: string): string {
+  return SPORT_LABELS[sport] ?? sport
+}
+
 // Form (TSB) and RSB (ACWR) zones/labels are computed server-side (see
 // classify_tsb/classify_acwr in app/schemas.py) so this badge and the AI
 // context never drift out of sync with each other.
@@ -83,6 +107,21 @@ export default function TrainingLoadChart({ current }: Props) {
   }))
 
   const hasAcwr = current.acwr != null
+
+  // Aggregate each day's sport_breakdown into a window total so the athlete
+  // sees at a glance how much of their load is running vs cross-training.
+  const sportTotals: Record<string, number> = {}
+  for (const p of points) {
+    if (!p.sport_breakdown) continue
+    for (const [sport, tss] of Object.entries(p.sport_breakdown)) {
+      sportTotals[sport] = (sportTotals[sport] ?? 0) + tss
+    }
+  }
+  const sportTotalSum = Object.values(sportTotals).reduce((sum, v) => sum + v, 0)
+  const sportShares = Object.entries(sportTotals)
+    .map(([sport, tss]) => ({ sport, tss, pct: sportTotalSum > 0 ? (tss / sportTotalSum) * 100 : 0 }))
+    .sort((a, b) => b.tss - a.tss)
+  const hasCrossTraining = sportShares.length > 1
 
   return (
     <div className="card training-load">
@@ -206,6 +245,30 @@ export default function TrainingLoadChart({ current }: Props) {
           <div className="tl-legend-item"><span className="tl-dot" style={{ background: ACWR_COLOR }} />ACWR</div>
         )}
       </div>
+
+      {hasCrossTraining && (
+        <div className="tl-sport-split">
+          <span className="tl-sport-split-label">Load by sport ({points.length}d)</span>
+          <div className="tl-sport-bar">
+            {sportShares.map(({ sport, pct }) => (
+              <div
+                key={sport}
+                className="tl-sport-bar-seg"
+                style={{ width: `${pct}%`, background: sportColor(sport) }}
+                title={`${sportLabel(sport)}: ${pct.toFixed(0)}%`}
+              />
+            ))}
+          </div>
+          <div className="tl-legend">
+            {sportShares.map(({ sport, pct }) => (
+              <div className="tl-legend-item" key={sport}>
+                <span className="tl-dot" style={{ background: sportColor(sport) }} />
+                {sportLabel(sport)} {pct.toFixed(0)}%
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/tests/test_training_load.py
+++ b/tests/test_training_load.py
@@ -5,17 +5,19 @@ from app.models import Activity, AthleteProfile
 
 
 def _add_activity(db, started_at, *, duration_sec=3600, tss=None,
-                  avg_pace_min_km=None, avg_hr=None, distance_m=10000):
+                  avg_pace_min_km=None, avg_hr=None, distance_m=10000,
+                  activity_type="running", name="Run", rpe=None):
     db.add(Activity(
         garmin_id=int(started_at.timestamp()),
-        activity_type="running",
-        name="Run",
+        activity_type=activity_type,
+        name=name,
         started_at=started_at,
         duration_sec=duration_sec,
         distance_m=distance_m,
         avg_pace_min_km=avg_pace_min_km,
         avg_hr=avg_hr,
         training_stress_score=tss,
+        rpe=rpe,
     ))
     db.commit()
 
@@ -32,7 +34,7 @@ def test_estimate_tss_prefers_stored_power_score():
 def test_estimate_tss_pace_based():
     # Running exactly at threshold pace for one hour ≈ 100 TSS.
     profile = AthleteProfile(threshold_pace_min_km=5.0)
-    act = Activity(duration_sec=3600, avg_pace_min_km=5.0)
+    act = Activity(duration_sec=3600, avg_pace_min_km=5.0, activity_type="running")
     tss, source = training_load.estimate_tss(act, profile)
     assert source == "pace"
     assert round(tss) == 100
@@ -72,7 +74,7 @@ def test_estimate_tss_srpe_takes_priority_over_duration_floor():
 
 def test_estimate_tss_pace_reference_takes_priority_over_srpe():
     profile = AthleteProfile(threshold_pace_min_km=5.0)
-    act = Activity(duration_sec=3600, avg_pace_min_km=5.0, rpe=2)
+    act = Activity(duration_sec=3600, avg_pace_min_km=5.0, rpe=2, activity_type="running")
     tss, source = training_load.estimate_tss(act, profile)
     assert source == "pace"
 
@@ -89,6 +91,99 @@ def test_estimate_tss_zero_without_duration():
     tss, source = training_load.estimate_tss(act, None)
     assert source == "none"
     assert tss == 0.0
+
+
+# --- Multi-sport load accounting (P2-3) ---
+
+def test_sport_category_classifies_common_garmin_types():
+    assert training_load.sport_category("running") == "run"
+    assert training_load.sport_category("treadmill_running") == "run"
+    assert training_load.sport_category("road_biking") == "ride"
+    assert training_load.sport_category("indoor_cycling") == "ride"
+    assert training_load.sport_category("lap_swimming") == "swim"
+    assert training_load.sport_category("strength_training") == "strength"
+    assert training_load.sport_category("yoga") == "strength"
+    assert training_load.sport_category("hiking") == "other"
+    assert training_load.sport_category(None) == "other"
+
+
+def test_is_run_true_only_for_run_category():
+    assert training_load.is_run("running") is True
+    assert training_load.is_run("cycling") is False
+    assert training_load.is_run(None) is False
+
+
+def test_estimate_tss_never_uses_pace_for_a_ride():
+    """A ride's generic distance/duration ratio must not be read as running pace.
+
+    30km in 1h (a plausible easy ride) is 2 min/km — far faster than any
+    runner's threshold pace, so treating it as rTSS would wildly overstate
+    the ride's intensity. hrTSS (or the duration floor) must be used instead.
+    """
+    profile = AthleteProfile(threshold_pace_min_km=5.0, threshold_hr=160)
+    ride = Activity(
+        duration_sec=3600, avg_pace_min_km=2.0, avg_hr=130,
+        activity_type="road_biking",
+    )
+    tss, source = training_load.estimate_tss(ride, profile)
+    assert source == "hr"
+    assert tss < 100  # an easy aerobic ride, not a max-effort sprint
+
+
+def test_estimate_tss_ride_without_hr_falls_to_duration_floor():
+    profile = AthleteProfile(threshold_pace_min_km=5.0)
+    ride = Activity(duration_sec=3600, avg_pace_min_km=2.0, activity_type="cycling")
+    tss, source = training_load.estimate_tss(ride, profile)
+    assert source == "duration"
+
+
+def test_estimate_tss_pace_based_still_applies_to_runs():
+    profile = AthleteProfile(threshold_pace_min_km=5.0)
+    run = Activity(duration_sec=3600, avg_pace_min_km=5.0, activity_type="running")
+    tss, source = training_load.estimate_tss(run, profile)
+    assert source == "pace"
+    assert round(tss) == 100
+
+
+def test_daily_load_series_tags_sport_breakdown(db):
+    base = datetime(2026, 6, 15, 7, 0)
+    _add_activity(db, base, tss=60.0, activity_type="running", name="Run")
+    _add_activity(db, base + timedelta(hours=10), tss=25.0, activity_type="cycling", name="Ride")
+    point = training_load.current_load(db, as_of=base.date())
+    assert point is not None
+    assert point.sport_breakdown == {"run": 60.0, "ride": 25.0}
+    assert point.tss == 85.0
+
+
+def test_training_load_endpoint_includes_sport_breakdown(client, db):
+    base = datetime(2026, 6, 1, 7, 0)
+    _add_activity(db, base, tss=60.0, activity_type="running", name="Run")
+    _add_activity(db, base + timedelta(hours=10), tss=25.0, activity_type="cycling", name="Ride")
+    resp = client.get("/api/v1/training-load?days=30&date=2026-06-01")
+    assert resp.status_code == 200
+    current = resp.json()["current"]
+    assert current["sport_breakdown"] == {"run": 60.0, "ride": 25.0}
+
+
+def test_context_notes_cross_training_tss_for_non_run_activity(db):
+    """P2-3: the AI context should surface cross-training load explicitly."""
+    _add_activity(
+        db, datetime(2026, 6, 10, 7, 0), activity_type="cycling", name="Evening Ride",
+        duration_sec=5400, avg_hr=140,
+    )
+    profile = AthleteProfile(threshold_hr=160)
+    db.add(profile)
+    db.commit()
+    context = ai_coach._build_context(db, "activity", "Test trigger", reference_date=date(2026, 6, 10))
+    assert "Evening Ride" in context
+    assert "TSS" in context.split("Evening Ride")[1].split("\n")[0]
+
+
+def test_context_recent_activities_omits_tss_for_runs(db):
+    _add_activity(db, datetime(2026, 6, 10, 7, 0), activity_type="running", name="Easy Run", tss=50.0)
+    context = ai_coach._build_context(db, "activity", "Test trigger", reference_date=date(2026, 6, 10))
+    run_line = [l for l in context.split("\n") if "Easy Run" in l][0]
+    assert "TSS" not in run_line
 
 
 # --- Series / snapshot ---


### PR DESCRIPTION
Gate pace-based rTSS to running activities only — avg_pace_min_km is
computed for every synced activity type, so a bike ride's much faster
distance/time ratio was being read as running pace and wildly
overstating its TSS (and downstream CTL/ATL/ACWR/injury-risk). Tag
DailyLoadSeries contributions by sport category, surface a per-sport
split on the training-load chart, and note cross-training TSS in the
AI coaching context.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PyL2Uq2fTbf5M7GpFzRhBj