### PR TITLE
Parallelize AI job worker with thread pool & per-job timeout

### DIFF
--- a/app/ai_coach.py
+++ b/app/ai_coach.py
@@ -43,6 +43,10 @@ from app.coach.providers import (
 from app.coach.jobs import (
     enqueue_job,
     execute_job,
+    _JOB_TIMEOUT_SECONDS,
+    _claim_job,
+    _claim_pending_jobs,
+    _run_claimed_job,
     _activity_user_id,
     _save_error_insight,
     analyze_activity,

--- a/app/coach/jobs.py
+++ b/app/coach/jobs.py
@@ -58,11 +58,21 @@ def enqueue_job(task_type: str, payload: dict, user_id: int) -> int:
         return job.id
 
 
-def execute_job(job_id: int) -> None:
-    """Claim and execute a single AIJob. Called by the APScheduler worker.
+# How long app.main's worker waits on a single claimed job before moving on
+# to the next poll (P3-2). Jobs run on a thread pool, not the scheduler
+# thread, so this bounds the *poll's* patience, not the job itself: Python
+# can't forcibly stop a thread mid-call, so a job that runs past this still
+# finishes on its own pool thread and records its own outcome -- the worker
+# just stops waiting on it so a single slow call never delays every other
+# user's jobs or the next scheduler tick.
+_JOB_TIMEOUT_SECONDS = 120
 
-    Atomically marks the job running, dispatches to the appropriate AI
-    function, then records done or schedules a retry (up to max_attempts).
+
+def _claim_job(job_id: int) -> dict | None:
+    """Atomically transition one job pending -> running.
+
+    Returns its dispatch fields, or None if it wasn't claimable (missing, or
+    already running/done/failed).
     """
     from app import ai_coach as _shim
     from app.models import AIJob
@@ -70,46 +80,128 @@ def execute_job(job_id: int) -> None:
     with _shim.db_session() as db:
         job = db.query(AIJob).filter(AIJob.id == job_id).first()
         if job is None or job.status not in ("pending",):
-            return
+            return None
         job.status = "running"
         job.started_at = datetime.now(timezone.utc)
         job.attempts += 1
         db.commit()
-        task_type = job.task_type
-        payload = json.loads(job.payload_json or "{}")
-        attempts = job.attempts
-        max_attempts = job.max_attempts
-        user_id = job.user_id
+        return {
+            "job_id": job.id,
+            "task_type": job.task_type,
+            "payload": json.loads(job.payload_json or "{}"),
+            "attempts": job.attempts,
+            "max_attempts": job.max_attempts,
+            "user_id": job.user_id,
+        }
 
-    try:
-        if task_type == "analyze_activity":
-            _shim.analyze_activity_force(payload["activity_id"])
-        elif task_type == "analyze_feedback":
-            _shim.analyze_activity_with_feedback(payload["activity_id"])
-        elif task_type == "generate_plan":
-            _shim.generate_training_plan(user_id=user_id, note=payload.get("note"))
-        elif task_type == "weekly_review":
-            _shim.weekly_review(user_id=user_id)
-        elif task_type == "generate_briefing":
-            _shim.generate_briefing(payload["plan_day_id"])
+
+def _claim_pending_jobs(limit: int = 5) -> list[dict]:
+    """Atomically claim up to ``limit`` oldest pending AIJobs in one transaction.
+
+    Selecting the candidates and flipping them to "running" happen together
+    (rather than the worker reading candidates and claiming them later), so
+    an overlapping poll -- one firing while the previous batch is still
+    executing on the thread pool -- can never dispatch the same job twice.
+    """
+    from app import ai_coach as _shim
+    from app.models import AIJob
+
+    with _shim.db_session() as db:
+        pending = (
+            db.query(AIJob)
+            .filter(
+                AIJob.status == "pending",
+                AIJob.attempts < AIJob.max_attempts,
+            )
+            .order_by(AIJob.created_at)
+            .limit(limit)
+            .all()
+        )
+        now = datetime.now(timezone.utc)
+        claimed = []
+        for job in pending:
+            job.status = "running"
+            job.started_at = now
+            job.attempts += 1
+            claimed.append({
+                "job_id": job.id,
+                "task_type": job.task_type,
+                "payload": json.loads(job.payload_json or "{}"),
+                "attempts": job.attempts,
+                "max_attempts": job.max_attempts,
+                "user_id": job.user_id,
+            })
+        db.commit()
+        return claimed
+
+
+def _dispatch(task_type: str, payload: dict, user_id: int) -> None:
+    """Route a claimed job to its AI function."""
+    from app import ai_coach as _shim
+
+    if task_type == "analyze_activity":
+        _shim.analyze_activity_force(payload["activity_id"])
+    elif task_type == "analyze_feedback":
+        _shim.analyze_activity_with_feedback(payload["activity_id"])
+    elif task_type == "generate_plan":
+        _shim.generate_training_plan(user_id=user_id, note=payload.get("note"))
+    elif task_type == "weekly_review":
+        _shim.weekly_review(user_id=user_id)
+    elif task_type == "generate_briefing":
+        _shim.generate_briefing(payload["plan_day_id"])
+    else:
+        raise ValueError(f"Unknown task_type: {task_type!r}")
+
+
+def _finish_claimed_job(claimed: dict, exc: Exception | None) -> None:
+    """Record a claimed job's outcome: done, or a retry/failed on error."""
+    from app import ai_coach as _shim
+    from app.models import AIJob
+
+    with _shim.db_session() as db:
+        job = db.query(AIJob).filter(AIJob.id == claimed["job_id"]).first()
+        if not job:
+            return
+        job.completed_at = datetime.now(timezone.utc)
+        if exc is None:
+            job.status = "done"
         else:
-            raise ValueError(f"Unknown task_type: {task_type!r}")
+            job.error_message = str(exc)[:1000]
+            job.status = "failed" if claimed["attempts"] >= claimed["max_attempts"] else "pending"
+        db.commit()
 
-        with _shim.db_session() as db:
-            job = db.query(AIJob).filter(AIJob.id == job_id).first()
-            if job:
-                job.status = "done"
-                job.completed_at = datetime.now(timezone.utc)
-                db.commit()
+
+def _run_claimed_job(claimed: dict) -> None:
+    """Dispatch an already-claimed job and record its outcome.
+
+    Takes a claim dict from ``_claim_job``/``_claim_pending_jobs`` -- it does
+    not re-check or re-claim the job. Safe to run on a worker-pool thread.
+    """
+    try:
+        _dispatch(claimed["task_type"], claimed["payload"], claimed["user_id"])
+        _finish_claimed_job(claimed, None)
     except Exception as exc:
-        logger.exception("Job %s (%s) failed on attempt %s/%s", job_id, task_type, attempts, max_attempts)
-        with _shim.db_session() as db:
-            job = db.query(AIJob).filter(AIJob.id == job_id).first()
-            if job:
-                job.error_message = str(exc)[:1000]
-                job.completed_at = datetime.now(timezone.utc)
-                job.status = "failed" if attempts >= max_attempts else "pending"
-                db.commit()
+        logger.exception(
+            "Job %s (%s) failed on attempt %s/%s",
+            claimed["job_id"], claimed["task_type"], claimed["attempts"], claimed["max_attempts"],
+        )
+        _finish_claimed_job(claimed, exc)
+
+
+def execute_job(job_id: int) -> None:
+    """Claim and execute a single AIJob synchronously.
+
+    Atomically marks the job running, dispatches to the appropriate AI
+    function, then records done or schedules a retry (up to max_attempts).
+    Used directly by tests and any one-off/manual invocation. The scheduled
+    worker (``app.main._worker_run_pending_jobs``) instead claims a batch at
+    once via ``_claim_pending_jobs`` and runs each with ``_run_claimed_job``
+    on a thread pool so multiple jobs execute concurrently.
+    """
+    claimed = _claim_job(job_id)
+    if claimed is None:
+        return
+    _run_claimed_job(claimed)
 
 
 def analyze_activity(activity: Activity):

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import ctypes
 import logging
 import os
@@ -25,6 +26,14 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 scheduler = BackgroundScheduler()
+
+# Small pool the AI job worker executes claimed jobs on (P3-2) -- sized to
+# match the worker's per-poll claim batch so a full batch always runs in
+# parallel rather than queuing behind each other on the pool itself.
+_JOB_POOL_SIZE = 5
+_job_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=_JOB_POOL_SIZE, thread_name_prefix="ai-job-worker"
+)
 
 _LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
 
@@ -387,29 +396,35 @@ def _scheduled_plan_generation():
 def _worker_run_pending_jobs():
     """APScheduler job: claim and execute pending AIJobs.
 
-    Picks up at most 5 pending jobs per poll cycle (oldest first) and runs
-    them synchronously in the scheduler thread. Each job atomically transitions
-    pending → running → done|failed, with retries up to max_attempts.
+    Claims up to _JOB_POOL_SIZE pending jobs (oldest first) atomically --
+    the read and the pending -> running transition happen together in
+    ``app.coach.jobs._claim_pending_jobs``, so an overlapping poll can never
+    dispatch the same job twice -- then runs them concurrently on a small
+    thread pool instead of serially in the scheduler thread. A single slow
+    job (e.g. a large plan generation) no longer delays every other user's
+    jobs or the next scheduler tick.
+
+    Each claimed job gets up to _JOB_TIMEOUT_SECONDS of wait time per poll.
+    A job that runs longer keeps executing on its pool thread and records
+    its own outcome whenever it finishes -- the poll just stops waiting on
+    it, so the scheduler thread is never blocked past the cap.
     """
-    from app.ai_coach import execute_job
-    from app.models import AIJob
+    from app.ai_coach import _claim_pending_jobs, _run_claimed_job, _JOB_TIMEOUT_SECONDS
 
-    with db_session() as db:
-        pending = (
-            db.query(AIJob)
-            .filter(
-                AIJob.status == "pending",
-                AIJob.attempts < AIJob.max_attempts,
-            )
-            .order_by(AIJob.created_at)
-            .limit(5)
-            .all()
-        )
-        job_ids = [j.id for j in pending]
-
-    for job_id in job_ids:
+    claimed_jobs = _claim_pending_jobs(limit=_JOB_POOL_SIZE)
+    futures = {
+        _job_executor.submit(_run_claimed_job, claimed): claimed["job_id"]
+        for claimed in claimed_jobs
+    }
+    for future, job_id in futures.items():
         try:
-            execute_job(job_id)
+            future.result(timeout=_JOB_TIMEOUT_SECONDS)
+        except concurrent.futures.TimeoutError:
+            logger.warning(
+                "Worker: job %s still running past %ds timeout; continuing "
+                "in the background, worker moving on to the next poll",
+                job_id, _JOB_TIMEOUT_SECONDS,
+            )
         except Exception:
             logger.exception("Worker: unexpected error executing job %s", job_id)
 
@@ -517,6 +532,7 @@ async def lifespan(app: FastAPI):
 
     # Shutdown
     scheduler.shutdown(wait=False)
+    _job_executor.shutdown(wait=False)
     logger.info("Scheduler stopped")
 
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -481,16 +481,43 @@ existing tests pass (backend pytest, `tsc -b`, Vitest, `npm run build`)._
   handful of call sites inside `app/coach/*` (db_session opens, provider/job
   dispatch) route through the `app.ai_coach` shim at call time so the existing
   monkeypatch-based tests keep working unchanged. All 795 tests pass._
-- **P3-2 · AI-job worker concurrency & sync isolation.** The worker claims up to
-  5 jobs but runs them **serially in the APScheduler thread**, so one slow plan
-  generation delays every user's analysis (and the next scheduler tick).
-  Execute claimed jobs on a small `ThreadPoolExecutor` (SQLite WAL tolerates
-  this; sessions are per-thread already), keep claiming atomic, and add a
-  per-job timeout. Similarly, per-user Garmin sync fan-out is serial — a
-  worthwhile follow-up only if multi-tenant use grows; note it, don't build it.
-  **S–M.** Files: `app/main.py` (`_worker_run_pending_jobs`),
+- **P3-2 · AI-job worker concurrency & sync isolation. ✅ Done.** The worker
+  claims up to 5 jobs but runs them **serially in the APScheduler thread**, so
+  one slow plan generation delays every user's analysis (and the next
+  scheduler tick). Execute claimed jobs on a small `ThreadPoolExecutor` (SQLite
+  WAL tolerates this; sessions are per-thread already), keep claiming atomic,
+  and add a per-job timeout. Similarly, per-user Garmin sync fan-out is serial
+  — a worthwhile follow-up only if multi-tenant use grows; note it, don't build
+  it. **S–M.** Files: `app/main.py` (`_worker_run_pending_jobs`),
   `app/ai_coach.py`/`app/coach/jobs.py` (`execute_job` timeout),
   `tests/test_job_queue.py`.
+  _Implemented as described. `app/coach/jobs.py`'s `execute_job` was split into
+  reusable pieces rather than wrapped: `_claim_job`/`_claim_pending_jobs`
+  atomically transition pending → running (single job or a whole batch, one
+  transaction each) and return the dispatch fields; `_run_claimed_job` is the
+  former dispatch-and-finalize half, now runnable independently on a worker
+  thread since it no longer re-claims. `execute_job(job_id)` is now `_claim_job`
+  + `_run_claimed_job` — unchanged behavior, so it's still safe for tests and
+  any one-off manual call. `app/main.py`'s `_worker_run_pending_jobs` claims a
+  batch of up to 5 jobs atomically via `_claim_pending_jobs` *before* any
+  dispatch happens (this is what makes claiming safe across overlapping polls
+  — a job is `"running"` in the DB the instant it's selected, not whenever its
+  pool thread happens to start), then submits each to a module-level
+  `ThreadPoolExecutor(max_workers=5)` (`_job_executor`) and waits on each
+  future with `future.result(timeout=_JOB_TIMEOUT_SECONDS)` — a new 120s
+  constant in `jobs.py`. Since Python can't forcibly stop a thread, a timeout
+  doesn't cancel or touch the job's row; the worker just stops waiting and
+  moves on, and the job records its own outcome whenever its pool thread
+  actually finishes — this is what keeps a single slow call from blocking the
+  scheduler thread (and therefore every other scheduled job) past the cap,
+  without racing the in-flight thread for the same DB row. `_job_executor`
+  shuts down (`wait=False`) alongside the scheduler on app shutdown. Per-user
+  Garmin sync fan-out (`_iter_garmin_users` loops in `_scheduled_activity_sync`
+  etc.) is unchanged, as scoped. All new and existing tests pass (969
+  backend), including a concurrency proof (two jobs rendezvous on a
+  `threading.Barrier`, which only both arrive if they truly ran in parallel)
+  and a timeout test (worker returns before a deliberately slow job finishes,
+  which then completes and self-records shortly after)._
 - **P3-3 · Frontend component tests.** Vitest covers only pure utils (57 cases);
   the adaptive-coaching UI (PlanAdaptationCard, RacePacingCard, ChatView action
   chips, FeedbackPrompt, and the new P0/P1 cards) has zero render coverage. Add

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -1,5 +1,7 @@
-"""Tests for the durable AI job queue (P2-1)."""
+"""Tests for the durable AI job queue (P2-1) and worker concurrency (P3-2)."""
 import json
+import threading
+import time
 from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 
@@ -224,6 +226,158 @@ def test_execute_job_raises_on_unknown_task_type(db, patch_db_session):
     job = db.query(AIJob).filter(AIJob.id == job_id).first()
     assert job.status == "failed"
     assert "unknown_type" in job.error_message.lower()
+
+
+# ---------------------------------------------------------------------------
+# _claim_pending_jobs — atomic batch claim (P3-2)
+# ---------------------------------------------------------------------------
+
+def test_claim_pending_jobs_marks_running_and_returns_dispatch_fields(db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("generate_plan", {"note": "hi"}, user_id=7)
+
+    claimed = ai_mod._claim_pending_jobs(limit=5)
+
+    assert len(claimed) == 1
+    assert claimed[0] == {
+        "job_id": job_id,
+        "task_type": "generate_plan",
+        "payload": {"note": "hi"},
+        "attempts": 1,
+        "max_attempts": 3,
+        "user_id": 7,
+    }
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "running"
+    assert job.started_at is not None
+
+
+def test_claim_pending_jobs_respects_limit_and_ordering(db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    ids = [enqueue_job("weekly_review", {}, user_id=1) for _ in range(4)]
+
+    claimed = ai_mod._claim_pending_jobs(limit=2)
+
+    assert [c["job_id"] for c in claimed] == ids[:2]
+    statuses = {
+        job_id: db.query(AIJob).filter(AIJob.id == job_id).first().status
+        for job_id in ids
+    }
+    assert statuses[ids[0]] == "running"
+    assert statuses[ids[1]] == "running"
+    assert statuses[ids[2]] == "pending"
+    assert statuses[ids[3]] == "pending"
+
+
+def test_claim_pending_jobs_skips_already_running_and_exhausted(db, patch_db_session):
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    running_id = enqueue_job("weekly_review", {}, user_id=1)
+    running_job = db.query(AIJob).filter(AIJob.id == running_id).first()
+    running_job.status = "running"
+
+    exhausted_id = enqueue_job("weekly_review", {}, user_id=1)
+    exhausted_job = db.query(AIJob).filter(AIJob.id == exhausted_id).first()
+    exhausted_job.attempts = 3  # == max_attempts, not retry-eligible
+    db.commit()
+
+    claimed = ai_mod._claim_pending_jobs(limit=5)
+
+    assert claimed == []
+
+
+# ---------------------------------------------------------------------------
+# app.main._worker_run_pending_jobs — pool concurrency & per-job timeout (P3-2)
+# ---------------------------------------------------------------------------
+
+def test_worker_runs_claimed_jobs_concurrently(db, patch_db_session):
+    """Two claimed jobs must actually run in parallel on the pool.
+
+    Both dispatch calls rendezvous on a 2-party barrier. If the worker still
+    ran them one at a time (the pre-P3-2 behavior), the first call would
+    block on the barrier waiting for a second party that never arrives until
+    it returns -- so it would time out and fail. Passing proves concurrency.
+    """
+    import app.ai_coach as ai_mod
+    import app.main as main_mod
+    patch_db_session(ai_mod)
+
+    barrier = threading.Barrier(2, timeout=5)
+
+    def blocking_review(**kwargs):
+        barrier.wait()
+
+    job1 = enqueue_job("weekly_review", {}, user_id=1)
+    job2 = enqueue_job("weekly_review", {}, user_id=2)
+
+    with patch.object(ai_mod, "weekly_review", side_effect=blocking_review):
+        main_mod._worker_run_pending_jobs()
+
+    db.expire_all()
+    assert db.query(AIJob).filter(AIJob.id == job1).first().status == "done"
+    assert db.query(AIJob).filter(AIJob.id == job2).first().status == "done"
+
+
+def test_worker_moves_on_after_job_timeout(db, patch_db_session, monkeypatch):
+    """A job that runs past the per-job timeout doesn't block the worker.
+
+    The worker should stop waiting on it (returning promptly) rather than
+    blocking the scheduler thread for the job's full duration; the job then
+    finishes on its own pool thread shortly after and records its outcome.
+    """
+    import app.ai_coach as ai_mod
+    import app.main as main_mod
+    patch_db_session(ai_mod)
+    monkeypatch.setattr(ai_mod, "_JOB_TIMEOUT_SECONDS", 0.1)
+
+    release = threading.Event()
+
+    def slow_review(**kwargs):
+        release.wait(timeout=5)
+
+    job_id = enqueue_job("weekly_review", {}, user_id=1)
+
+    with patch.object(ai_mod, "weekly_review", side_effect=slow_review):
+        start = time.monotonic()
+        main_mod._worker_run_pending_jobs()
+        elapsed = time.monotonic() - start
+
+    assert elapsed < 2.0  # bounded by the timeout, not the job's full duration
+
+    db.expire_all()
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "running"  # still in flight; worker didn't touch it
+
+    release.set()
+    time.sleep(0.3)  # let the pool thread finish and record its own outcome
+
+    db.expire_all()
+    job = db.query(AIJob).filter(AIJob.id == job_id).first()
+    assert job.status == "done"
+
+
+def test_worker_claims_before_dispatch_no_double_claim_across_polls(db, patch_db_session):
+    """A second poll fired while jobs are still running must not re-claim them.
+
+    Regression guard for the atomic-claim requirement: claiming happens
+    entirely up front (before any dispatch), so a job already "running"
+    can never be selected by a subsequent claim.
+    """
+    import app.ai_coach as ai_mod
+    patch_db_session(ai_mod)
+
+    job_id = enqueue_job("weekly_review", {}, user_id=1)
+
+    first_claim = ai_mod._claim_pending_jobs(limit=5)
+    assert [c["job_id"] for c in first_claim] == [job_id]
+
+    second_claim = ai_mod._claim_pending_jobs(limit=5)
+    assert second_claim == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Refactors the AI job worker to execute claimed jobs concurrently on a thread pool instead of serially in the APScheduler thread. Adds a per-job timeout so a single slow operation (e.g., large plan generation) no longer blocks the scheduler or delays other users' jobs.

## Key Changes

**Job claiming & dispatch refactoring** (`app/coach/jobs.py`):
- Split `execute_job` into reusable pieces:
  - `_claim_job(job_id)`: Atomically transition a single job pending → running, return dispatch fields
  - `_claim_pending_jobs(limit)`: Atomically claim up to N oldest pending jobs in one transaction
  - `_dispatch(task_type, payload, user_id)`: Route a job to its AI function
  - `_finish_claimed_job(claimed, exc)`: Record outcome (done/retry/failed)
  - `_run_claimed_job(claimed)`: Dispatch + finalize, safe to run on worker thread
  - `execute_job(job_id)`: Now `_claim_job` + `_run_claimed_job` — unchanged behavior for tests/manual calls
- Added `_JOB_TIMEOUT_SECONDS = 120` constant

**Worker concurrency** (`app/main.py`):
- Created module-level `ThreadPoolExecutor(max_workers=5)` (`_job_executor`)
- Rewrote `_worker_run_pending_jobs()` to:
  - Claim up to 5 jobs atomically *before* any dispatch (prevents double-claim across overlapping polls)
  - Submit each to the thread pool via `executor.submit(_run_claimed_job, claimed)`
  - Wait on futures with `future.result(timeout=_JOB_TIMEOUT_SECONDS)`
  - Log and continue if a job times out (job finishes on its pool thread, records its own outcome)
- Shutdown executor on app lifespan end

**Test coverage** (`tests/test_job_queue.py`):
- Added tests for `_claim_pending_jobs`: batch claiming, limit/ordering, skipping running/exhausted jobs
- Added concurrency proof: two jobs rendezvous on a `threading.Barrier` (only passes if truly parallel)
- Added timeout test: worker returns before slow job finishes, job self-records outcome shortly after
- Added regression guard: second poll can't re-claim already-running jobs

## Implementation Details

- **Atomic claiming**: Selecting candidates and flipping to "running" happen in a single transaction, so overlapping polls never dispatch the same job twice
- **Timeout semantics**: Python can't forcibly stop a thread, so timeout doesn't cancel the job — worker just stops waiting. Job finishes on its pool thread and records its own outcome independently
- **SQLite compatibility**: WAL mode tolerates concurrent writes from pool threads; sessions are per-thread already
- **Backward compatibility**: `execute_job(job_id)` behavior unchanged, safe for existing tests and manual invocation

Resolves P3-2 from IMPROVEMENT_PLAN.md.

https://claude.ai/code/session_01AxSNk78LgeYjGtbXMV9wZE