### PR TITLE
Fix test DB isolation by switching from in-memory to file-backed SQLite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
 
 from app import models  # noqa: F401 - ensure models register on Base.metadata
 from app.api import api_router
@@ -11,12 +10,18 @@ from app.database import Base, get_db
 
 
 @pytest.fixture
-def session_factory():
-    """In-memory SQLite shared across sessions via a single connection."""
+def session_factory(tmp_path):
+    """File-backed SQLite DB, mirroring production's engine (app/database.py).
+
+    A real file (rather than an in-memory DB pinned to a single StaticPool
+    connection) gives each thread its own physical connection, so
+    multi-threaded tests (e.g. the concurrent job worker) don't corrupt
+    each other's transaction state by sharing one sqlite3.Connection object
+    across threads.
+    """
     engine = create_engine(
-        "sqlite://",
+        f"sqlite:///{tmp_path / 'test.db'}",
         connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
     )
     Base.metadata.create_all(bind=engine)
     yield sessionmaker(bind=engine)


### PR DESCRIPTION
## Summary
Replace the in-memory SQLite database in tests with a file-backed database to ensure proper transaction isolation in multi-threaded test scenarios. The previous setup using `StaticPool` pinned all connections to a single `sqlite3.Connection` object, causing transaction state corruption when multiple threads accessed the database concurrently.

## Changes
- **Database backend**: Changed from `sqlite://` (in-memory) to `sqlite:///{tmp_path / 'test.db'}` (file-backed)
- **Connection pooling**: Removed `poolclass=StaticPool` to allow each thread its own physical connection
- **Fixture parameter**: Added `tmp_path` parameter to `session_factory` fixture to provide isolated temporary directory per test
- **Documentation**: Updated docstring to explain why file-backed DB is necessary for multi-threaded tests (e.g., concurrent job worker tests)

## Implementation Details
The file-backed approach mirrors the production database configuration in `app/database.py`. Each thread now gets its own SQLite connection from the connection pool, preventing shared transaction state corruption that occurred when all threads used a single pinned connection. The `check_same_thread=False` setting remains to allow the test client and background tasks to share the same session safely.

https://claude.ai/code/session_01XmemmEPHmhGmMepYruZFLB