### PR TITLE
Remove raw SyncStatus dump leaking into Settings page

### DIFF
--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -56,28 +56,19 @@ def api_me(current_user: User = Depends(get_current_user)):
 
 # --- Settings ---
 
-_INTERNAL_SYNC_KEYS = {"threshold_estimate", "training_load_series"}
-
-
 @router.get("/settings", response_model=SettingsResponse)
 def api_settings(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     uid = current_user.id
-    sync_statuses = {}
-    for s in db.query(SyncStatus).filter(SyncStatus.user_id == uid).all():
-        if s.key in _INTERNAL_SYNC_KEYS:
-            continue
-        sync_statuses[s.key] = {"value": s.value, "updated_at": str(s.updated_at) if s.updated_at else None}
-
     counts = {
         "activities": db.query(func.count(Activity.id)).filter(Activity.user_id == uid).scalar() or 0,
         "daily_summaries": db.query(func.count(DailySummary.id)).filter(DailySummary.user_id == uid).scalar() or 0,
         "insights": db.query(func.count(Insight.id)).filter(Insight.user_id == uid).scalar() or 0,
         "calendar_events": db.query(func.count(GarminCalendarEvent.id)).filter(GarminCalendarEvent.user_id == uid).scalar() or 0,
     }
-    return SettingsResponse(sync_statuses=sync_statuses, counts=counts)
+    return SettingsResponse(counts=counts)
 
 
 # Curated "last sync per job" keys -> display label, out of the full

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -439,7 +439,6 @@ class TodayResponse(BaseModel):
 
 
 class SettingsResponse(BaseModel):
-    sync_statuses: dict[str, Any] = {}
     counts: dict[str, int] = {}
 
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -332,7 +332,6 @@ export interface TodayResponse {
 }
 
 export interface SettingsResponse {
-  sync_statuses: Record<string, { value: string; updated_at: string | null }>
   counts: Record<string, number>
 }
 

--- a/frontend/src/components/settings/SettingsView.css
+++ b/frontend/src/components/settings/SettingsView.css
@@ -54,12 +54,6 @@
   margin-top: 2px;
 }
 
-.sync-time {
-  font-size: 0.7rem;
-  color: var(--text-muted);
-  margin-top: 1px;
-}
-
 .sync-buttons {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/settings/SettingsView.tsx
+++ b/frontend/src/components/settings/SettingsView.tsx
@@ -299,25 +299,6 @@ export default function SettingsView() {
         </div>
       </section>
 
-      {/* Sync status */}
-      <section className="settings-section">
-        <h2 className="section-title">Sync Status</h2>
-        <div className="card sync-list">
-          {Object.entries(data.sync_statuses).map(([key, status]) => (
-            <div key={key} className="sync-item">
-              <div className="sync-key">{key.replace(/_/g, ' ')}</div>
-              <div className="sync-value">{status.value || '-'}</div>
-              {status.updated_at && (
-                <div className="sync-time">{new Date(status.updated_at).toLocaleString()}</div>
-              )}
-            </div>
-          ))}
-          {Object.keys(data.sync_statuses).length === 0 && (
-            <div className="empty-state">No sync data yet</div>
-          )}
-        </div>
-      </section>
-
       {/* Manual sync buttons */}
       <section className="settings-section">
         <h2 className="section-title">Manual Sync</h2>

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -232,13 +232,11 @@ def test_insights_list_and_filter(client, db):
 
 # --- /settings ---
 
-def test_settings_counts_and_statuses(client, db):
+def test_settings_counts(client, db):
     _add_activity(db, datetime(2026, 6, 1, 7, 0))
-    db.add(SyncStatus(key="last_activity_sync", value="2026-06-01T00:00:00"))
     db.commit()
     body = client.get("/api/v1/settings").json()
     assert body["counts"]["activities"] == 1
-    assert "last_activity_sync" in body["sync_statuses"]
 
 
 # --- /health-detail (P3-4) ---


### PR DESCRIPTION
The Settings page rendered every SyncStatus row directly to the user
(minus a small, incomplete denylist), so internal bookkeeping like
perf-curve cache blobs, canary alarm flags, and backfill version
markers showed up as raw JSON under "Sync Status". That info is
already surfaced properly, with curated labels, by the System Health
section added later. Drop the redundant raw dump instead of patching
the denylist further.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014jSKhECt8J92wCT9ziUYqN