### PR TITLE
skin: phase 0 — skin plumbing & settings UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,9 +13,14 @@
   </head>
   <body>
     <script>
-      (function() {
+      (function () {
         var t = localStorage.getItem('theme');
-        if (t === 'light') document.documentElement.setAttribute('data-theme', 'light');
+        var s = localStorage.getItem('skin');
+        document.documentElement.setAttribute('data-theme', t === 'light' ? 'light' : 'dark');
+        document.documentElement.setAttribute(
+          'data-skin',
+          s === 'nothing-signal' || s === 'nothing-app' ? s : 'default'
+        );
       })();
     </script>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,18 +35,35 @@ export function useDateContext() {
   return useContext(DateContext)
 }
 
+export type Skin = 'default' | 'nothing-signal' | 'nothing-app'
+
+export const SKIN_LABELS: Record<Skin, string> = {
+  'default': 'Default',
+  'nothing-signal': 'Nothing — signal red',
+  'nothing-app': 'Nothing — app inks',
+}
+
 interface ThemeContextType {
   theme: 'dark' | 'light'
   toggleTheme: () => void
+  skin: Skin
+  setSkin: (s: Skin) => void
 }
 
 export const ThemeContext = createContext<ThemeContextType>({
   theme: 'dark',
   toggleTheme: () => {},
+  skin: 'default',
+  setSkin: () => {},
 })
 
 export function useTheme() {
   return useContext(ThemeContext)
+}
+
+export function useSkin() {
+  const { skin, setSkin } = useContext(ThemeContext)
+  return { skin, setSkin }
 }
 
 export interface RouteMeta {
@@ -92,6 +109,10 @@ export default function App() {
   const [theme, setTheme] = useState<'dark' | 'light'>(() => {
     return (localStorage.getItem('theme') as 'dark' | 'light') || 'dark'
   })
+  const [skin, setSkin] = useState<Skin>(() => {
+    const stored = localStorage.getItem('skin')
+    return stored === 'nothing-signal' || stored === 'nothing-app' ? stored : 'default'
+  })
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -99,6 +120,11 @@ export default function App() {
     document.documentElement.setAttribute('data-theme', theme)
     localStorage.setItem('theme', theme)
   }, [theme])
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-skin', skin)
+    localStorage.setItem('skin', skin)
+  }, [skin])
 
   const toggleTheme = () => setTheme(t => t === 'dark' ? 'light' : 'dark')
 
@@ -115,7 +141,7 @@ export default function App() {
   const showCalendar = !isDetailPage
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, toggleTheme, skin, setSkin }}>
     <DateContext.Provider value={{ selectedDate, setSelectedDate }}>
       <div className="app-shell">
         {showCalendar && (

--- a/frontend/src/components/settings/AppearanceSection.css
+++ b/frontend/src/components/settings/AppearanceSection.css
@@ -1,0 +1,115 @@
+.appearance-card {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.appearance-group-label {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+  padding: 0;
+}
+
+.appearance-segmented {
+  display: flex;
+  background: var(--bg-input);
+  border-radius: var(--radius-sm);
+  padding: 3px;
+  gap: 3px;
+}
+
+.appearance-segment {
+  flex: 1;
+  min-height: 44px;
+  border-radius: calc(var(--radius-sm) - 3px);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.appearance-segment.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.appearance-style {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.appearance-skin-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 44px;
+  padding: 8px 4px;
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.appearance-skin-row:hover {
+  background: var(--bg-hover);
+}
+
+.appearance-skin-row input[type="radio"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+  flex-shrink: 0;
+}
+
+.appearance-skin-swatch {
+  display: flex;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.swatch-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: block;
+  border: 1px solid var(--border);
+}
+
+.appearance-skin-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.appearance-skin-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.appearance-skin-desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* Static preview colours for each style row — deliberately independent of
+   the currently active skin, so a row always previews what selecting it
+   would look like. */
+[data-skin-preview="default"] .swatch-surface { background: #1a1a2e; }
+[data-skin-preview="default"] .swatch-ink { background: #e0e0e0; }
+[data-skin-preview="default"] .swatch-accent { background: #6c5ce7; }
+
+[data-skin-preview="nothing-signal"] .swatch-surface { background: #000; }
+[data-skin-preview="nothing-signal"] .swatch-ink { background: #fff; }
+[data-skin-preview="nothing-signal"] .swatch-accent { background: #d71921; }
+
+[data-skin-preview="nothing-app"] .swatch-surface { background: #000; }
+[data-skin-preview="nothing-app"] .swatch-ink { background: #fff; }
+[data-skin-preview="nothing-app"] .swatch-accent { background: #0984e3; }

--- a/frontend/src/components/settings/AppearanceSection.test.tsx
+++ b/frontend/src/components/settings/AppearanceSection.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { useState, useEffect } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ThemeContext, type Skin } from '../../App'
+import AppearanceSection from './AppearanceSection'
+
+// Mirrors App.tsx's real skin state + effect, so clicking a style row
+// exercises the same localStorage/DOM-attribute wiring the app uses — the
+// default ThemeContext value is a no-op stub and wouldn't catch regressions.
+function Harness() {
+  const [theme, setTheme] = useState<'dark' | 'light'>('dark')
+  const [skin, setSkin] = useState<Skin>(() => {
+    const stored = localStorage.getItem('skin')
+    return stored === 'nothing-signal' || stored === 'nothing-app' ? stored : 'default'
+  })
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-skin', skin)
+    localStorage.setItem('skin', skin)
+  }, [skin])
+
+  return (
+    <ThemeContext.Provider
+      value={{
+        theme,
+        toggleTheme: () => setTheme(t => (t === 'dark' ? 'light' : 'dark')),
+        skin,
+        setSkin,
+      }}
+    >
+      <AppearanceSection />
+    </ThemeContext.Provider>
+  )
+}
+
+describe('AppearanceSection', () => {
+  afterEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-skin')
+  })
+
+  it('renders three style options with the stored one checked', () => {
+    localStorage.setItem('skin', 'nothing-app')
+    render(<Harness />)
+
+    expect(screen.getAllByRole('radio')).toHaveLength(3)
+    expect(screen.getByRole('radio', { name: /nothing — app inks/i })).toBeChecked()
+    expect(screen.getByRole('radio', { name: /^default/i })).not.toBeChecked()
+  })
+
+  it('sets data-skin and persists to localStorage when "Nothing — app inks" is clicked', () => {
+    render(<Harness />)
+
+    fireEvent.click(screen.getByRole('radio', { name: /nothing — app inks/i }))
+
+    expect(document.documentElement.getAttribute('data-skin')).toBe('nothing-app')
+    expect(localStorage.getItem('skin')).toBe('nothing-app')
+  })
+
+  it('falls back to default for an invalid stored value', () => {
+    localStorage.setItem('skin', 'garbage')
+    render(<Harness />)
+
+    expect(screen.getByRole('radio', { name: /^default/i })).toBeChecked()
+  })
+})

--- a/frontend/src/components/settings/AppearanceSection.tsx
+++ b/frontend/src/components/settings/AppearanceSection.tsx
@@ -1,0 +1,68 @@
+import { useTheme, useSkin, SKIN_LABELS, type Skin } from '../../App'
+import './AppearanceSection.css'
+
+const SKINS: Skin[] = ['default', 'nothing-signal', 'nothing-app']
+
+const SKIN_DESCRIPTIONS: Record<Skin, string> = {
+  'default': 'The current look.',
+  'nothing-signal': 'Monochrome, dot-matrix. One red accent.',
+  'nothing-app': 'Monochrome layout, keeps the current workout colours.',
+}
+
+export default function AppearanceSection() {
+  const { theme, toggleTheme } = useTheme()
+  const { skin, setSkin } = useSkin()
+
+  return (
+    <section className="settings-section">
+      <h2 className="section-title">Appearance</h2>
+      <div className="card appearance-card">
+        <div>
+          <span className="appearance-group-label">Mode</span>
+          <div className="appearance-segmented" role="radiogroup" aria-label="Mode">
+            <button
+              type="button"
+              className={`appearance-segment ${theme === 'dark' ? 'active' : ''}`}
+              aria-pressed={theme === 'dark'}
+              onClick={() => theme !== 'dark' && toggleTheme()}
+            >
+              Dark
+            </button>
+            <button
+              type="button"
+              className={`appearance-segment ${theme === 'light' ? 'active' : ''}`}
+              aria-pressed={theme === 'light'}
+              onClick={() => theme !== 'light' && toggleTheme()}
+            >
+              Light
+            </button>
+          </div>
+        </div>
+
+        <fieldset className="appearance-style">
+          <legend className="appearance-group-label">Style</legend>
+          {SKINS.map(s => (
+            <label key={s} className="appearance-skin-row">
+              <input
+                type="radio"
+                name="skin"
+                value={s}
+                checked={skin === s}
+                onChange={() => setSkin(s)}
+              />
+              <span className="appearance-skin-swatch" data-skin-preview={s} aria-hidden="true">
+                <i className="swatch-dot swatch-surface" />
+                <i className="swatch-dot swatch-ink" />
+                <i className="swatch-dot swatch-accent" />
+              </span>
+              <span className="appearance-skin-text">
+                <span className="appearance-skin-name">{SKIN_LABELS[s]}</span>
+                <span className="appearance-skin-desc">{SKIN_DESCRIPTIONS[s]}</span>
+              </span>
+            </label>
+          ))}
+        </fieldset>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/settings/SettingsView.tsx
+++ b/frontend/src/components/settings/SettingsView.tsx
@@ -12,6 +12,7 @@ import {
   useSubmitGarminMfa,
   useDisconnectGarmin,
 } from '../../api/hooks'
+import AppearanceSection from './AppearanceSection'
 import AthleteProfileSection from './AthleteProfileSection'
 import CoachMemorySection from './CoachMemorySection'
 import NotificationsSection from './NotificationsSection'
@@ -269,6 +270,9 @@ export default function SettingsView() {
       </header>
 
       <div className="settings-body">
+      {/* Appearance: mode + visual style */}
+      <AppearanceSection />
+
       {/* Signed-in account */}
       <AccountSection />
 

--- a/frontend/src/components/trends/WellnessTrendsView.test.tsx
+++ b/frontend/src/components/trends/WellnessTrendsView.test.tsx
@@ -49,7 +49,7 @@ describe('WellnessTrendsView', () => {
   it('renders without error under the light theme (themed tooltip/tick colours)', async () => {
     vi.stubGlobal('fetch', mockFetch([summary()]))
     renderWithProviders(
-      <ThemeContext.Provider value={{ theme: 'light', toggleTheme: () => {} }}>
+      <ThemeContext.Provider value={{ theme: 'light', toggleTheme: () => {}, skin: 'default', setSkin: () => {} }}>
         <WellnessTrendsView />
       </ThemeContext.Provider>,
     )


### PR DESCRIPTION
Adds the Skin type ('default' | 'nothing-signal' | 'nothing-app') alongside
the existing theme context, persisted to localStorage and applied as
document.documentElement's data-skin attribute. A pre-paint inline script in
index.html sets both data-theme and data-skin before first render to avoid a
flash of the wrong appearance.

New Appearance section in Settings lets the user pick mode (dark/light) and
style (default vs. the two upcoming Nothing skins) via native radios, mounted
first in SettingsView. No visual change yet — later phases add the actual
Nothing CSS.

Per docs/NOTHING_OS_SKIN_PLAN.md phase 0.