### PR TITLE
skin: phase 0 — skin plumbing & settings UI

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
 import './styles/globals.css'
+import './styles/skins/nothing.css'
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -13,6 +13,8 @@
   --warning: #f39c12;
   --danger: #e74c3c;
   --border: #2d2d44;
+  --border-strong: #3d3d5c;
+  --dot-off: transparent;
   --radius: 12px;
   --radius-sm: 8px;
   --radius-xs: 6px;
@@ -31,6 +33,9 @@
 
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+
+  --font-ui: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "Roboto Mono", Menlo, Consolas, monospace;
 
   /* Spacing scale */
   --space-1: 4px;
@@ -73,6 +78,7 @@
   --accent: #6c5ce7;
   --accent-light: #5a4bd1;
   --border: #e0e4ec;
+  --border-strong: #c9cfda;
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.12);
 }
@@ -90,7 +96,7 @@ html {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-family: var(--font-ui);
   background: var(--bg);
   color: var(--text);
   min-height: 100dvh;

--- a/frontend/src/styles/skins/nothing.css
+++ b/frontend/src/styles/skins/nothing.css
@@ -1,0 +1,62 @@
+/* Nothing OS skin — Phase 1: token layer only.
+   No component rules here yet; see docs/NOTHING_OS_SKIN_PLAN.md Phase 3+. */
+
+/* ---- shared by both Nothing skins, both modes ---- */
+html[data-skin="nothing-signal"][data-theme="dark"],
+html[data-skin="nothing-signal"][data-theme="light"],
+html[data-skin="nothing-app"][data-theme="dark"],
+html[data-skin="nothing-app"][data-theme="light"] {
+  --radius: 26px;
+  --radius-sm: 20px;
+  --radius-xs: 12px;
+
+  --shadow-sm: none;
+  --shadow-md: none;
+
+  --font-ui: "Helvetica Neue", Helvetica, Arial, system-ui, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "Roboto Mono", Menlo, Consolas, monospace;
+}
+
+/* ---- dark (black) ---- */
+html[data-skin="nothing-signal"][data-theme="dark"],
+html[data-skin="nothing-app"][data-theme="dark"] {
+  --bg: #000000;
+  --bg-card: #0b0b0b;
+  --bg-input: #141414;
+  --bg-hover: #1a1a1a;
+  --surface: var(--bg-card);
+  --text: #ffffff;
+  --text-muted: #6e6e6e;
+  --text-secondary: #b4b4b4;
+  --border: #232323;
+  --border-strong: #3a3a3a;
+  --dot-off: rgba(255, 255, 255, 0.10);
+}
+
+/* ---- light (white) ---- */
+html[data-skin="nothing-signal"][data-theme="light"],
+html[data-skin="nothing-app"][data-theme="light"] {
+  --bg: #ffffff;
+  --bg-card: #f4f4f4;
+  --bg-input: #ebebeb;
+  --bg-hover: #e4e4e4;
+  --surface: var(--bg-card);
+  --text: #000000;
+  --text-muted: #8b8b8b;
+  --text-secondary: #4a4a4a;
+  --border: #e0e0e0;
+  --border-strong: #c8c8c8;
+  --dot-off: rgba(0, 0, 0, 0.10);
+}
+
+/* ---- accent per skin ---- */
+html[data-skin="nothing-signal"][data-theme="dark"],
+html[data-skin="nothing-signal"][data-theme="light"] {
+  --accent: #d71921;
+  --accent-light: #d71921;
+}
+
+/* app inks keeps the existing accent, unchanged from globals.css */
+html[data-skin="nothing-app"][data-theme="light"] {
+  --accent-light: #5a4bd1;
+}


### PR DESCRIPTION
Adds the Skin type ('default' | 'nothing-signal' | 'nothing-app') alongside
the existing theme context, persisted to localStorage and applied as
document.documentElement's data-skin attribute. A pre-paint inline script in
index.html sets both data-theme and data-skin before first render to avoid a
flash of the wrong appearance.

New Appearance section in Settings lets the user pick mode (dark/light) and
style (default vs. the two upcoming Nothing skins) via native radios, mounted
first in SettingsView. No visual change yet — later phases add the actual
Nothing CSS.

Per docs/NOTHING_OS_SKIN_PLAN.md phase 0.