### PR TITLE
skin: phase 0 — skin plumbing & settings UI

### DIFF
--- a/frontend/src/components/activity-detail/ChartTabs.tsx
+++ b/frontend/src/components/activity-detail/ChartTabs.tsx
@@ -4,8 +4,8 @@ import {
   ScatterChart, Scatter, ReferenceLine,
 } from 'recharts'
 import type { ChartSeries, MetricZone } from '../../api/types'
-import { useTheme } from '../../App'
-import { getAxisTick, getTooltipProps, getZoneColor, METRIC_COLORS, usePrefersReducedMotion } from '../../utils/chartTheme'
+import { useTheme, useSkin } from '../../App'
+import { getAxisTick, getTooltipProps, getChartTickColor, getZoneColor, METRIC_COLORS, usePrefersReducedMotion } from '../../utils/chartTheme'
 import './ChartTabs.css'
 
 const SCATTER_METRICS = new Set(['cadence', 'stride', 'gct', 'vert_osc', 'vert_ratio'])
@@ -19,6 +19,7 @@ export default function ChartTabs({ chartData, metricZones }: Props) {
   const keys = Object.keys(chartData)
   const [activeKey, setActiveKey] = useState(keys[0] || '')
   const { theme } = useTheme()
+  const { skin } = useSkin()
   const reduceMotion = usePrefersReducedMotion()
 
   if (keys.length === 0) return null
@@ -33,7 +34,7 @@ export default function ChartTabs({ chartData, metricZones }: Props) {
   // Reverse Y for pace metrics (lower value = faster = better)
   const reversed = activeKey === 'pace' || activeKey === 'gap_pace'
 
-  const { contentStyle: tooltipStyle, labelStyle: tooltipTextStyle } = getTooltipProps(theme)
+  const { contentStyle: tooltipStyle, labelStyle: tooltipTextStyle } = getTooltipProps(theme, skin)
 
   const yTickFormatter = (v: number) => {
     if (activeKey === 'pace' || activeKey === 'gap_pace') {
@@ -90,7 +91,7 @@ export default function ChartTabs({ chartData, metricZones }: Props) {
                 domain={['auto', 'auto']}
                 tickCount={7}
                 tickFormatter={yTickFormatter}
-                tick={getAxisTick(theme)}
+                tick={getAxisTick(theme, undefined, skin)}
                 axisLine={false}
                 tickLine={false}
                 width={38}
@@ -104,7 +105,7 @@ export default function ChartTabs({ chartData, metricZones }: Props) {
               />
               <ReferenceLine
                 y={average}
-                stroke="#888"
+                stroke={getChartTickColor(theme, skin)}
                 strokeDasharray="6 4"
                 strokeWidth={1.5}
               />
@@ -114,7 +115,7 @@ export default function ChartTabs({ chartData, metricZones }: Props) {
                 isAnimationActive={!reduceMotion}
                 shape={(props: any) => {
                   const dotColor = zones && zones.length > 0
-                    ? getZoneColor(props.payload.y, zones)
+                    ? getZoneColor(props.payload.y, zones, skin)
                     : color
                   return <circle cx={props.cx} cy={props.cy} r={2.5} fill={dotColor} />
                 }}

--- a/frontend/src/components/activity-detail/HrZonesChart.tsx
+++ b/frontend/src/components/activity-detail/HrZonesChart.tsx
@@ -1,7 +1,6 @@
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
-import { useTheme } from '../../App'
-import { getChartTooltipStyle, getChartTickColor, getChartTooltipTextStyle } from '../../utils/theme'
-import { usePrefersReducedMotion } from '../../utils/chartTheme'
+import { useTheme, useSkin } from '../../App'
+import { getTooltipProps, getChartTickColor, SIGNAL_ZONE_RAMP, usePrefersReducedMotion } from '../../utils/chartTheme'
 import './HrZonesChart.css'
 
 const ZONE_COLORS = ['#2ecc71', '#27ae60', '#f39c12', '#e67e22', '#e74c3c']
@@ -13,7 +12,10 @@ interface Props {
 
 export default function HrZonesChart({ zones }: Props) {
   const { theme } = useTheme()
+  const { skin } = useSkin()
   const reduceMotion = usePrefersReducedMotion()
+  const { contentStyle, labelStyle, itemStyle } = getTooltipProps(theme, skin)
+  const zoneFillColors = skin === 'nothing-signal' ? SIGNAL_ZONE_RAMP : ZONE_COLORS
 
   if (!zones || !Array.isArray(zones) || zones.length === 0) return null
 
@@ -46,20 +48,20 @@ export default function HrZonesChart({ zones }: Props) {
             <YAxis
               type="category"
               dataKey="zone"
-              tick={{ fontSize: 11, fill: getChartTickColor(theme) }}
+              tick={{ fontSize: 11, fill: getChartTickColor(theme, skin) }}
               axisLine={false}
               tickLine={false}
               width={48}
             />
             <Tooltip
-              contentStyle={getChartTooltipStyle(theme)}
-              labelStyle={getChartTooltipTextStyle(theme)}
-              itemStyle={getChartTooltipTextStyle(theme)}
+              contentStyle={contentStyle}
+              labelStyle={labelStyle}
+              itemStyle={itemStyle}
               formatter={(value: number) => [`${value} min`, 'Time']}
             />
             <Bar dataKey="minutes" radius={[0, 4, 4, 0]} barSize={20} isAnimationActive={!reduceMotion}>
               {data.map((_: any, i: number) => (
-                <Cell key={i} fill={ZONE_COLORS[i] || '#6c5ce7'} />
+                <Cell key={i} fill={zoneFillColors[i] || '#6c5ce7'} />
               ))}
             </Bar>
           </BarChart>

--- a/frontend/src/components/activity-detail/PaceZonesChart.tsx
+++ b/frontend/src/components/activity-detail/PaceZonesChart.tsx
@@ -1,9 +1,8 @@
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
 import { useZoneConfigs } from '../../api/hooks'
 import type { ChartSeries } from '../../api/types'
-import { useTheme } from '../../App'
-import { getChartTooltipStyle, getChartTickColor, getChartTooltipTextStyle } from '../../utils/theme'
-import { usePrefersReducedMotion } from '../../utils/chartTheme'
+import { useTheme, useSkin } from '../../App'
+import { getTooltipProps, getChartTickColor, SIGNAL_ZONE_RAMP, usePrefersReducedMotion } from '../../utils/chartTheme'
 import './PaceZonesChart.css'
 
 interface Props {
@@ -19,7 +18,9 @@ function formatPace(minPerKm: number): string {
 export default function PaceZonesChart({ paceSeries }: Props) {
   const { data: zoneData, isLoading } = useZoneConfigs()
   const { theme } = useTheme()
+  const { skin } = useSkin()
   const reduceMotion = usePrefersReducedMotion()
+  const { contentStyle, labelStyle, itemStyle } = getTooltipProps(theme, skin)
 
   if (isLoading || !zoneData) return null
 
@@ -56,7 +57,7 @@ export default function PaceZonesChart({ paceSeries }: Props) {
 
   if (total === 0) return null
 
-  const chartData = zones.map(z => {
+  const chartData = zones.map((z, i) => {
     const count = counts.get(z.zone_number) ?? 0
     const pct = total > 0 ? Math.round((count / total) * 100) : 0
     const minPace = z.min_pct !== null ? threshold * z.min_pct / 100 : null
@@ -68,7 +69,7 @@ export default function PaceZonesChart({ paceSeries }: Props) {
     return {
       zone: `Z${z.zone_number}: ${z.zone_name}`,
       pct,
-      color: z.zone_color,
+      color: skin === 'nothing-signal' ? SIGNAL_ZONE_RAMP[i % SIGNAL_ZONE_RAMP.length] : z.zone_color,
       rangeLabel,
     }
   })
@@ -92,15 +93,15 @@ export default function PaceZonesChart({ paceSeries }: Props) {
             <YAxis
               type="category"
               dataKey="zone"
-              tick={{ fontSize: 11, fill: getChartTickColor(theme) }}
+              tick={{ fontSize: 11, fill: getChartTickColor(theme, skin) }}
               axisLine={false}
               tickLine={false}
               width={90}
             />
             <Tooltip
-              contentStyle={getChartTooltipStyle(theme)}
-              labelStyle={getChartTooltipTextStyle(theme)}
-              itemStyle={getChartTooltipTextStyle(theme)}
+              contentStyle={contentStyle}
+              labelStyle={labelStyle}
+              itemStyle={itemStyle}
               formatter={(value: number, _name: string, props: any) => [
                 `${value}% (${props.payload.rangeLabel})`,
                 'Time',

--- a/frontend/src/components/activity-detail/RouteMap.tsx
+++ b/frontend/src/components/activity-detail/RouteMap.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ActivityRoute } from '../../api/types'
+import { useSkin } from '../../App'
 import './RouteMap.css'
 
 type Mode = 'solid' | 'hr' | 'pace' | 'power' | 'elevation'
@@ -42,6 +43,7 @@ export default function RouteMap({ route, activityColor }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [mode, setMode] = useState<Mode>('solid')
   const [width, setWidth] = useState(0)
+  const { skin } = useSkin()
 
   // Keep only valid GPS points, carrying their original index so metric
   // streams (aligned 1:1 with route.points) stay matched up.
@@ -149,12 +151,19 @@ export default function RouteMap({ route, activityColor }: Props) {
 
     const segCount = projected.length - 1
 
+    // Canvas can't read var() — under the Nothing skins the route (like every
+    // other chart series) collapses to the single accent colour instead of
+    // the passed-in per-activity hue.
+    const strokeColor = skin.startsWith('nothing')
+      ? getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || activityColor
+      : activityColor
+
     // Per-segment colour for the active metric (value at the segment's start
     // point, normalised across the activity's own range).
     const segColor = (i: number): string => {
-      if (mode === 'solid' || !activeMetric?.data || !range) return activityColor
+      if (mode === 'solid' || !activeMetric?.data || !range) return strokeColor
       const v = activeMetric.data[projected[i].idx]
-      if (v === null || v === undefined) return activityColor
+      if (v === null || v === undefined) return strokeColor
       const span = range.max - range.min || 1
       let t = (v - range.min) / span
       if (activeMetric.reverse) t = 1 - t
@@ -201,7 +210,7 @@ export default function RouteMap({ route, activityColor }: Props) {
       const n = Math.min(count, segCount)
       if (mode === 'solid') {
         // Single stroke for the whole drawn portion.
-        ctx.strokeStyle = activityColor
+        ctx.strokeStyle = strokeColor
         ctx.beginPath()
         ctx.moveTo(projected[0].x, projected[0].y)
         for (let i = 1; i <= n; i++) ctx.lineTo(projected[i].x, projected[i].y)
@@ -223,7 +232,7 @@ export default function RouteMap({ route, activityColor }: Props) {
       if (n >= segCount) {
         drawFinishMarker(last.x, last.y) // finish (checkered flag)
       } else {
-        drawMarker(projected[n].x, projected[n].y, activityColor, 4.5) // current position
+        drawMarker(projected[n].x, projected[n].y, strokeColor, 4.5) // current position
       }
     }
 
@@ -256,7 +265,7 @@ export default function RouteMap({ route, activityColor }: Props) {
       cancelAnimationFrame(raf)
       if (timer) clearTimeout(timer)
     }
-  }, [projected, width, mode, activeMetric, range, activityColor])
+  }, [projected, width, mode, activeMetric, range, activityColor, skin])
 
   if (!valid) return null
 

--- a/frontend/src/components/activity-detail/SplitsBars.test.tsx
+++ b/frontend/src/components/activity-detail/SplitsBars.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import SplitsBars from './SplitsBars'
+import { ThemeContext } from '../../App'
 import type { MetricZone } from '../../api/types'
 
 const splits = [
@@ -51,5 +52,27 @@ describe('SplitsBars', () => {
   it('renders nothing when there are no splits', () => {
     const { container } = render(<SplitsBars splits={[]} color="#6c5ce7" />)
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('maps bars and legend swatches onto SIGNAL_ZONE_RAMP, by zone identity, under nothing-signal', () => {
+    const { container } = render(
+      <ThemeContext.Provider value={{ theme: 'dark', toggleTheme: () => {}, skin: 'nothing-signal', setSkin: () => {} }}>
+        <SplitsBars splits={splits} paceZones={paceZones} color="#6c5ce7" />
+      </ThemeContext.Provider>,
+    )
+
+    const bars = container.querySelectorAll('.split-bar')
+    // "Fast" is zones[0] -> SIGNAL_ZONE_RAMP[0] (#3a3a3a); "Easy" is zones[1] -> SIGNAL_ZONE_RAMP[1] (#5c5c5c).
+    expect((bars[0] as HTMLElement).style.background).toBe('rgb(92, 92, 92)')
+    expect((bars[1] as HTMLElement).style.background).toBe('rgb(92, 92, 92)')
+    expect((bars[2] as HTMLElement).style.background).toBe('rgb(58, 58, 58)')
+
+    // The legend must still render both zones — the identity-based filter
+    // still finds them even though getZoneColor no longer returns zone_color.
+    expect(screen.getByText('Fast')).toBeInTheDocument()
+    expect(screen.getByText('Easy')).toBeInTheDocument()
+    const swatches = container.querySelectorAll('.split-legend i')
+    expect((swatches[0] as HTMLElement).style.background).toBe('rgb(58, 58, 58)')
+    expect((swatches[1] as HTMLElement).style.background).toBe('rgb(92, 92, 92)')
   })
 })

--- a/frontend/src/components/activity-detail/SplitsBars.tsx
+++ b/frontend/src/components/activity-detail/SplitsBars.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { MetricZone } from '../../api/types'
-import { getZoneColor } from '../../utils/chartTheme'
+import { useSkin } from '../../App'
+import { getZoneColor, getZoneSwatchColor, findZone } from '../../utils/chartTheme'
 import { formatPace } from '../../utils/formatting'
 import LapsTable from './LapsTable'
 import './SplitsBars.css'
@@ -26,6 +27,7 @@ function lapHr(lap: any): number | null {
 }
 
 export default function SplitsBars({ splits, paceZones, color }: Props) {
+  const { skin } = useSkin()
   const list = Array.isArray(splits) ? splits : []
   const [mode, setMode] = useState<'bars' | 'table'>(list.length >= 3 ? 'bars' : 'table')
 
@@ -42,12 +44,15 @@ export default function SplitsBars({ splits, paceZones, color }: Props) {
   }
 
   function barColor(pace: number | null): string {
-    if (pace != null && paceZones && paceZones.length > 0) return getZoneColor(pace, paceZones)
+    if (pace != null && paceZones && paceZones.length > 0) return getZoneColor(pace, paceZones, skin)
     return color
   }
 
+  // Compare by zone identity, not colour — under nothing-signal, getZoneColor
+  // stops returning zone_color entirely, so a colour-equality filter here
+  // would always miss and the legend would render empty.
   const usedZones = paceZones && paceZones.length > 0
-    ? paceZones.filter(z => paces.some(p => getZoneColor(p, paceZones) === z.zone_color))
+    ? paceZones.filter(z => paces.some(p => findZone(p, paceZones) === z))
     : []
 
   return (
@@ -100,7 +105,7 @@ export default function SplitsBars({ splits, paceZones, color }: Props) {
               <div className="split-legend">
                 {usedZones.map(z => (
                   <span key={z.zone_name}>
-                    <i style={{ background: z.zone_color }} />
+                    <i style={{ background: getZoneSwatchColor(z, paceZones!, skin) }} />
                     {z.zone_name}
                   </span>
                 ))}

--- a/frontend/src/components/today/ReadinessCard.tsx
+++ b/frontend/src/components/today/ReadinessCard.tsx
@@ -39,7 +39,7 @@ export default function ReadinessCard({ readiness }: Props) {
   return (
     <div className="card readiness-card">
       <div className="readiness-header">
-        <ScoreRing score={readiness.score} color={color} size={72} />
+        <ScoreRing score={readiness.score} color={color} size={100} />
         <div className="readiness-label-block">
           <span className="readiness-label" style={{ color }}>{readiness.label}</span>
           <span className="readiness-sub">Training Readiness</span>

--- a/frontend/src/components/today/TodayHero.tsx
+++ b/frontend/src/components/today/TodayHero.tsx
@@ -202,7 +202,7 @@ export default function TodayHero({ data }: Props) {
             aria-expanded={readinessExpanded}
             aria-label={`Training readiness ${readiness.score} out of 100 — tap for details`}
           >
-            <ScoreRing score={readiness.score} color={ringColor} size={64} subLabel={readiness.label} />
+            <ScoreRing score={readiness.score} color={ringColor} size={100} subLabel={readiness.label} />
           </button>
         )}
         <HeroSession

--- a/frontend/src/components/today/TrainingLoadChart.tsx
+++ b/frontend/src/components/today/TrainingLoadChart.tsx
@@ -69,8 +69,8 @@ export default function TrainingLoadChart({ current }: Props) {
   const { contentStyle } = getTooltipProps(theme, skin)
   const refLineColor = getGridStroke(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
-  const { ctl: CTL_COLOR, atl: ATL_COLOR, tsb: TSB_COLOR, acwr: ACWR_COLOR } = getSeriesColors(skin, LOAD_COLORS_DEFAULT)
-  const SPORT_COLORS = getSeriesColors(skin, SPORT_COLORS_DEFAULT)
+  const { ctl: CTL_COLOR, atl: ATL_COLOR, tsb: TSB_COLOR, acwr: ACWR_COLOR } = getSeriesColors(theme, skin, LOAD_COLORS_DEFAULT)
+  const SPORT_COLORS = getSeriesColors(theme, skin, SPORT_COLORS_DEFAULT)
   function sportColor(sport: string): string {
     return SPORT_COLORS[sport] ?? SPORT_COLORS.other
   }

--- a/frontend/src/components/today/TrainingLoadChart.tsx
+++ b/frontend/src/components/today/TrainingLoadChart.tsx
@@ -11,20 +11,22 @@ import {
 } from 'recharts'
 import { useTrainingLoad } from '../../api/hooks'
 import type { TrainingLoadPoint } from '../../api/types'
-import { useTheme } from '../../App'
-import { getAxisTick, getGridStroke, getTooltipProps, usePrefersReducedMotion } from '../../utils/chartTheme'
+import { useTheme, useSkin } from '../../App'
+import { getAxisTick, getGridStroke, getTooltipProps, getSeriesColors, usePrefersReducedMotion } from '../../utils/chartTheme'
 import './TrainingLoadChart.css'
 
 interface Props {
   current: TrainingLoadPoint
 }
 
-const CTL_COLOR = '#6c5ce7' // Fitness — purple
-const ATL_COLOR = '#e17055' // Fatigue — orange
-const TSB_COLOR = '#00b894' // Form — green
-const ACWR_COLOR = '#fdcb6e' // ACWR — amber
+const LOAD_COLORS_DEFAULT = {
+  ctl: '#6c5ce7', // Fitness — purple
+  atl: '#e17055', // Fatigue — orange
+  tsb: '#00b894', // Form — green
+  acwr: '#fdcb6e', // ACWR — amber
+}
 
-const SPORT_COLORS: Record<string, string> = {
+const SPORT_COLORS_DEFAULT: Record<string, string> = {
   run: '#6c5ce7',
   ride: '#0984e3',
   swim: '#00cec9',
@@ -38,10 +40,6 @@ const SPORT_LABELS: Record<string, string> = {
   swim: 'Swim',
   strength: 'Strength',
   other: 'Other',
-}
-
-function sportColor(sport: string): string {
-  return SPORT_COLORS[sport] ?? SPORT_COLORS.other
 }
 
 function sportLabel(sport: string): string {
@@ -67,9 +65,15 @@ function rsbTone(zone: string | null): string {
 export default function TrainingLoadChart({ current }: Props) {
   const { data } = useTrainingLoad(90)
   const { theme } = useTheme()
-  const { contentStyle } = getTooltipProps(theme)
-  const refLineColor = getGridStroke(theme)
+  const { skin } = useSkin()
+  const { contentStyle } = getTooltipProps(theme, skin)
+  const refLineColor = getGridStroke(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
+  const { ctl: CTL_COLOR, atl: ATL_COLOR, tsb: TSB_COLOR, acwr: ACWR_COLOR } = getSeriesColors(skin, LOAD_COLORS_DEFAULT)
+  const SPORT_COLORS = getSeriesColors(skin, SPORT_COLORS_DEFAULT)
+  function sportColor(sport: string): string {
+    return SPORT_COLORS[sport] ?? SPORT_COLORS.other
+  }
 
   function CustomTooltip({ active, payload, label }: { active?: boolean; payload?: any[]; label?: string }) {
     if (!active || !payload || !payload.length) return null
@@ -174,12 +178,12 @@ export default function TrainingLoadChart({ current }: Props) {
               </defs>
               <XAxis
                 dataKey="label"
-                tick={getAxisTick(theme)}
+                tick={getAxisTick(theme, undefined, skin)}
                 axisLine={false}
                 tickLine={false}
                 minTickGap={28}
               />
-              <YAxis yAxisId="load" tick={getAxisTick(theme)} axisLine={false} tickLine={false} width={28} />
+              <YAxis yAxisId="load" tick={getAxisTick(theme, undefined, skin)} axisLine={false} tickLine={false} width={28} />
               <YAxis yAxisId="form" orientation="right" hide />
               {hasAcwr && (
                 <YAxis yAxisId="acwr" orientation="right" domain={[0, 2.5]} hide />

--- a/frontend/src/components/today/WeekOverview.tsx
+++ b/frontend/src/components/today/WeekOverview.tsx
@@ -1,8 +1,8 @@
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
 import type { WeeklyMileage } from '../../api/types'
-import { useTheme } from '../../App'
-import { getAxisTick, getGridStroke, getTooltipProps, usePrefersReducedMotion } from '../../utils/chartTheme'
-import { SPORT_COLORS } from '../../utils/colors'
+import { useTheme, useSkin } from '../../App'
+import { getAxisTick, getGridStroke, getTooltipProps, getSeriesColors, getHoverFill, usePrefersReducedMotion } from '../../utils/chartTheme'
+import { SPORT_COLORS as SPORT_COLORS_DEFAULT } from '../../utils/colors'
 import './WeekOverview.css'
 
 interface Props {
@@ -32,10 +32,12 @@ export default function WeekOverview({ data }: Props) {
   const maxKm = Math.max(...data.map(d => d.km), 1)
   const activityTypes = getActivityTypes(data)
   const { theme } = useTheme()
-  const { contentStyle } = getTooltipProps(theme)
-  const borderColor = getGridStroke(theme)
+  const { skin } = useSkin()
+  const { contentStyle } = getTooltipProps(theme, skin)
+  const borderColor = getGridStroke(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
   const totalKm = data.reduce((s, d) => s + d.km, 0)
+  const SPORT_COLORS = getSeriesColors(skin, SPORT_COLORS_DEFAULT)
 
   function CustomTooltip({ active, payload, label }: { active?: boolean; payload?: any[]; label?: string }) {
     if (active && payload && payload.length) {
@@ -88,12 +90,12 @@ export default function WeekOverview({ data }: Props) {
           <BarChart data={data} barCategoryGap="20%">
             <XAxis
               dataKey="label"
-              tick={getAxisTick(theme, 11)}
+              tick={getAxisTick(theme, 11, skin)}
               axisLine={false}
               tickLine={false}
             />
             <YAxis hide domain={[0, maxKm * 1.15]} />
-            <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(108, 92, 231, 0.1)' }} />
+            <Tooltip content={<CustomTooltip />} cursor={{ fill: getHoverFill(theme, skin) }} />
             {activityTypes.map((type, index) => (
               <Bar
                 key={type}

--- a/frontend/src/components/today/WeekOverview.tsx
+++ b/frontend/src/components/today/WeekOverview.tsx
@@ -37,7 +37,7 @@ export default function WeekOverview({ data }: Props) {
   const borderColor = getGridStroke(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
   const totalKm = data.reduce((s, d) => s + d.km, 0)
-  const SPORT_COLORS = getSeriesColors(skin, SPORT_COLORS_DEFAULT)
+  const SPORT_COLORS = getSeriesColors(theme, skin, SPORT_COLORS_DEFAULT)
 
   function CustomTooltip({ active, payload, label }: { active?: boolean; payload?: any[]; label?: string }) {
     if (active && payload && payload.length) {

--- a/frontend/src/components/trends/AerobicTrendsView.tsx
+++ b/frontend/src/components/trends/AerobicTrendsView.tsx
@@ -61,7 +61,7 @@ export default function AerobicTrendsView() {
   const tickColor = getChartTickColor(theme, skin)
   const tooltipProps = getTooltipProps(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
-  const AEROBIC_COLORS = getSeriesColors(skin, AEROBIC_COLORS_DEFAULT)
+  const AEROBIC_COLORS = getSeriesColors(theme, skin, AEROBIC_COLORS_DEFAULT)
 
   if (isLoading) {
     return <AerobicSkeleton />

--- a/frontend/src/components/trends/AerobicTrendsView.tsx
+++ b/frontend/src/components/trends/AerobicTrendsView.tsx
@@ -10,8 +10,8 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 import { useAerobicTrends } from '../../api/hooks'
-import { useTheme } from '../../App'
-import { getChartTickColor, getTooltipProps, AEROBIC_COLORS, usePrefersReducedMotion } from '../../utils/chartTheme'
+import { useTheme, useSkin } from '../../App'
+import { getChartTickColor, getTooltipProps, getSeriesColors, AEROBIC_COLORS as AEROBIC_COLORS_DEFAULT, usePrefersReducedMotion } from '../../utils/chartTheme'
 import RangeSelector, { DEFAULT_RANGE_OPTIONS, type RangeDays } from '../ui/RangeSelector'
 import Skeleton from '../ui/Skeleton'
 import type { AerobicTrendPoint } from '../../api/types'
@@ -57,9 +57,11 @@ export default function AerobicTrendsView() {
   const [days, setDays] = useState<RangeDays>(90)
   const { data, isLoading } = useAerobicTrends(days)
   const { theme } = useTheme()
-  const tickColor = getChartTickColor(theme)
-  const tooltipProps = getTooltipProps(theme)
+  const { skin } = useSkin()
+  const tickColor = getChartTickColor(theme, skin)
+  const tooltipProps = getTooltipProps(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
+  const AEROBIC_COLORS = getSeriesColors(skin, AEROBIC_COLORS_DEFAULT)
 
   if (isLoading) {
     return <AerobicSkeleton />

--- a/frontend/src/components/trends/CustomChartsView.tsx
+++ b/frontend/src/components/trends/CustomChartsView.tsx
@@ -9,8 +9,8 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 import { useCustomChartMetrics, useCustomChartData } from '../../api/hooks'
-import { useTheme } from '../../App'
-import { getChartTickColor, getTooltipProps, CHART_SERIES_COLORS, usePrefersReducedMotion } from '../../utils/chartTheme'
+import { useTheme, useSkin } from '../../App'
+import { getChartTickColor, getTooltipProps, getSeriesColors, getSeriesDash, CHART_SERIES_COLORS, usePrefersReducedMotion } from '../../utils/chartTheme'
 import Skeleton from '../ui/Skeleton'
 import type { CustomChartMetric, CustomChartMetricGroup } from '../../api/types'
 import './CustomChartsView.css'
@@ -31,8 +31,6 @@ const GROUP_LABELS: Record<CustomChartMetricGroup, string> = {
 }
 
 const GROUP_ORDER: CustomChartMetricGroup[] = ['activity', 'wellness', 'load']
-
-const SERIES_COLORS = CHART_SERIES_COLORS
 
 const MAX_METRICS = 4
 const CONFIG_KEY = 'runningCoach.customChart.config'
@@ -86,9 +84,11 @@ export default function CustomChartsView() {
   const [config, setConfig] = useState<ChartConfig>(loadConfig)
   const [presets, setPresets] = useState<ChartPreset[]>(loadPresets)
   const { theme } = useTheme()
-  const tickColor = getChartTickColor(theme)
-  const { contentStyle: tooltipStyle } = getTooltipProps(theme)
+  const { skin } = useSkin()
+  const tickColor = getChartTickColor(theme, skin)
+  const { contentStyle: tooltipStyle } = getTooltipProps(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
+  const SERIES_COLORS = getSeriesColors(skin, CHART_SERIES_COLORS)
 
   const { metricIds, days, compare = false } = config
   const { data: chartData, isLoading: dataLoading } = useCustomChartData(metricIds, days, compare)
@@ -287,6 +287,7 @@ export default function CustomChartsView() {
                   yAxisId={id}
                   stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
                   strokeWidth={2}
+                  strokeDasharray={getSeriesDash(skin, i)}
                   dot={false}
                   connectNulls
                   name={metricsById.get(id)?.label ?? id}

--- a/frontend/src/components/trends/CustomChartsView.tsx
+++ b/frontend/src/components/trends/CustomChartsView.tsx
@@ -88,7 +88,7 @@ export default function CustomChartsView() {
   const tickColor = getChartTickColor(theme, skin)
   const { contentStyle: tooltipStyle } = getTooltipProps(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
-  const SERIES_COLORS = getSeriesColors(skin, CHART_SERIES_COLORS)
+  const SERIES_COLORS = getSeriesColors(theme, skin, CHART_SERIES_COLORS)
 
   const { metricIds, days, compare = false } = config
   const { data: chartData, isLoading: dataLoading } = useCustomChartData(metricIds, days, compare)

--- a/frontend/src/components/trends/IntensityTrendsView.tsx
+++ b/frontend/src/components/trends/IntensityTrendsView.tsx
@@ -9,8 +9,13 @@ import {
   Legend,
 } from 'recharts'
 import { useIntensityTrends } from '../../api/hooks'
-import { useTheme } from '../../App'
-import { getChartTickColor, getTooltipProps, INTENSITY_ZONE_COLORS, INTENSITY_BUCKET_COLORS, usePrefersReducedMotion } from '../../utils/chartTheme'
+import { useTheme, useSkin } from '../../App'
+import {
+  getChartTickColor, getTooltipProps, getSeriesColors,
+  INTENSITY_ZONE_COLORS as INTENSITY_ZONE_COLORS_DEFAULT,
+  INTENSITY_BUCKET_COLORS as INTENSITY_BUCKET_COLORS_DEFAULT,
+  usePrefersReducedMotion,
+} from '../../utils/chartTheme'
 import RangeSelector, { DEFAULT_RANGE_OPTIONS, type RangeDays } from '../ui/RangeSelector'
 import Skeleton from '../ui/Skeleton'
 import type { IntensityWeek } from '../../api/types'
@@ -50,6 +55,8 @@ function buildChartData(weeks: IntensityWeek[]) {
 }
 
 function PolarizationBar({ easy, moderate, hard }: { easy: number; moderate: number; hard: number }) {
+  const { skin } = useSkin()
+  const INTENSITY_BUCKET_COLORS = getSeriesColors(skin, INTENSITY_BUCKET_COLORS_DEFAULT)
   return (
     <div style={{ display: 'flex', height: 8, borderRadius: 4, overflow: 'hidden', gap: 1 }}>
       <div style={{ flex: easy, background: INTENSITY_BUCKET_COLORS.easy }} title={`Easy ${easy.toFixed(0)}%`} />
@@ -80,9 +87,12 @@ export default function IntensityTrendsView() {
   const [zoneType, setZoneType] = useState<ZoneType>('hr')
   const { data, isLoading } = useIntensityTrends(days, zoneType)
   const { theme } = useTheme()
-  const tickColor = getChartTickColor(theme)
-  const { contentStyle } = getTooltipProps(theme)
+  const { skin } = useSkin()
+  const tickColor = getChartTickColor(theme, skin)
+  const { contentStyle } = getTooltipProps(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
+  const INTENSITY_ZONE_COLORS = getSeriesColors(skin, INTENSITY_ZONE_COLORS_DEFAULT)
+  const INTENSITY_BUCKET_COLORS = getSeriesColors(skin, INTENSITY_BUCKET_COLORS_DEFAULT)
 
   const allZones = ['1', '2', '3', '4', '5']
 

--- a/frontend/src/components/trends/IntensityTrendsView.tsx
+++ b/frontend/src/components/trends/IntensityTrendsView.tsx
@@ -55,8 +55,9 @@ function buildChartData(weeks: IntensityWeek[]) {
 }
 
 function PolarizationBar({ easy, moderate, hard }: { easy: number; moderate: number; hard: number }) {
+  const { theme } = useTheme()
   const { skin } = useSkin()
-  const INTENSITY_BUCKET_COLORS = getSeriesColors(skin, INTENSITY_BUCKET_COLORS_DEFAULT)
+  const INTENSITY_BUCKET_COLORS = getSeriesColors(theme, skin, INTENSITY_BUCKET_COLORS_DEFAULT)
   return (
     <div style={{ display: 'flex', height: 8, borderRadius: 4, overflow: 'hidden', gap: 1 }}>
       <div style={{ flex: easy, background: INTENSITY_BUCKET_COLORS.easy }} title={`Easy ${easy.toFixed(0)}%`} />
@@ -91,8 +92,8 @@ export default function IntensityTrendsView() {
   const tickColor = getChartTickColor(theme, skin)
   const { contentStyle } = getTooltipProps(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
-  const INTENSITY_ZONE_COLORS = getSeriesColors(skin, INTENSITY_ZONE_COLORS_DEFAULT)
-  const INTENSITY_BUCKET_COLORS = getSeriesColors(skin, INTENSITY_BUCKET_COLORS_DEFAULT)
+  const INTENSITY_ZONE_COLORS = getSeriesColors(theme, skin, INTENSITY_ZONE_COLORS_DEFAULT)
+  const INTENSITY_BUCKET_COLORS = getSeriesColors(theme, skin, INTENSITY_BUCKET_COLORS_DEFAULT)
 
   const allZones = ['1', '2', '3', '4', '5']
 

--- a/frontend/src/components/trends/PerformanceCurveView.tsx
+++ b/frontend/src/components/trends/PerformanceCurveView.tsx
@@ -9,8 +9,8 @@ import {
   CartesianGrid,
 } from 'recharts'
 import { usePerformanceCurve, type PerformanceCurveCompareParams } from '../../api/hooks'
-import { useTheme } from '../../App'
-import { getChartTickColor, getTooltipProps, getGridStroke, PERFORMANCE_CURVE_COLORS, usePrefersReducedMotion } from '../../utils/chartTheme'
+import { useTheme, useSkin } from '../../App'
+import { getChartTickColor, getTooltipProps, getGridStroke, getSeriesColors, PERFORMANCE_CURVE_COLORS, usePrefersReducedMotion } from '../../utils/chartTheme'
 import Skeleton from '../ui/Skeleton'
 import Numeral from '../ui/Numeral'
 import type { PerformanceCurveCompareMode, PerformanceCurvePoint } from '../../api/types'
@@ -34,8 +34,6 @@ const COMPARE_OPTIONS: { label: string; value: CompareChoice }[] = [
   { label: 'Vs. year ago', value: 'year_ago' },
   { label: 'Vs. custom range', value: 'custom' },
 ]
-
-const { actual: ACTUAL_COLOR, model: MODEL_COLOR, compare: COMPARE_COLOR } = PERFORMANCE_CURVE_COLORS
 
 function isoDate(d: Date): string {
   return d.toISOString().slice(0, 10)
@@ -114,9 +112,11 @@ export default function PerformanceCurveView() {
 
   const { data, isLoading } = usePerformanceCurve(days, compareParams)
   const { theme } = useTheme()
-  const tickColor = getChartTickColor(theme)
-  const { contentStyle } = getTooltipProps(theme)
+  const { skin } = useSkin()
+  const tickColor = getChartTickColor(theme, skin)
+  const { contentStyle } = getTooltipProps(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
+  const { actual: ACTUAL_COLOR, model: MODEL_COLOR, compare: COMPARE_COLOR } = getSeriesColors(skin, PERFORMANCE_CURVE_COLORS)
 
   if (isLoading) {
     return (
@@ -335,7 +335,7 @@ export default function PerformanceCurveView() {
           >
             <ResponsiveContainer width="100%" height={200}>
               <ComposedChart data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke={getGridStroke(theme)} />
+                <CartesianGrid strokeDasharray="3 3" stroke={getGridStroke(theme, skin)} />
                 <XAxis
                   dataKey="label"
                   tick={{ fill: tickColor, fontSize: 10 }}

--- a/frontend/src/components/trends/PerformanceCurveView.tsx
+++ b/frontend/src/components/trends/PerformanceCurveView.tsx
@@ -116,7 +116,7 @@ export default function PerformanceCurveView() {
   const tickColor = getChartTickColor(theme, skin)
   const { contentStyle } = getTooltipProps(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
-  const { actual: ACTUAL_COLOR, model: MODEL_COLOR, compare: COMPARE_COLOR } = getSeriesColors(skin, PERFORMANCE_CURVE_COLORS)
+  const { actual: ACTUAL_COLOR, model: MODEL_COLOR, compare: COMPARE_COLOR } = getSeriesColors(theme, skin, PERFORMANCE_CURVE_COLORS)
 
   if (isLoading) {
     return (

--- a/frontend/src/components/trends/WellnessTrendsView.tsx
+++ b/frontend/src/components/trends/WellnessTrendsView.tsx
@@ -10,20 +10,12 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 import { useWellnessTrends } from '../../api/hooks'
-import { useTheme } from '../../App'
-import { getChartTickColor, getTooltipProps, WELLNESS_METRIC_COLORS, usePrefersReducedMotion } from '../../utils/chartTheme'
+import { useTheme, useSkin } from '../../App'
+import { getChartTickColor, getTooltipProps, getSeriesColors, WELLNESS_METRIC_COLORS, usePrefersReducedMotion } from '../../utils/chartTheme'
 import RangeSelector, { DEFAULT_RANGE_OPTIONS, type RangeDays } from '../ui/RangeSelector'
 import Skeleton from '../ui/Skeleton'
 import Numeral from '../ui/Numeral'
 import './WellnessTrendsView.css'
-
-const {
-  sleep: SLEEP_COLOR,
-  restingHr: RHR_COLOR,
-  stress: STRESS_COLOR,
-  bodyBattery: BATTERY_COLOR,
-  hrv: HRV_COLOR,
-} = WELLNESS_METRIC_COLORS
 
 function avg7(data: any[], key: string): number | null {
   const vals = data.slice(-7).map(d => d[key]).filter((v: any) => v != null) as number[]
@@ -53,9 +45,17 @@ export default function WellnessTrendsView() {
   const [days, setDays] = useState<RangeDays>(30)
   const { data, isLoading } = useWellnessTrends(days)
   const { theme } = useTheme()
-  const tickColor = getChartTickColor(theme)
-  const { contentStyle } = getTooltipProps(theme)
+  const { skin } = useSkin()
+  const tickColor = getChartTickColor(theme, skin)
+  const { contentStyle } = getTooltipProps(theme, skin)
   const reduceMotion = usePrefersReducedMotion()
+  const {
+    sleep: SLEEP_COLOR,
+    restingHr: RHR_COLOR,
+    stress: STRESS_COLOR,
+    bodyBattery: BATTERY_COLOR,
+    hrv: HRV_COLOR,
+  } = getSeriesColors(skin, WELLNESS_METRIC_COLORS)
 
   function MetricTooltip({ active, payload, label, unit }: { active?: boolean; payload?: any[]; label?: string; unit: string }) {
     if (!active || !payload?.length) return null

--- a/frontend/src/components/trends/WellnessTrendsView.tsx
+++ b/frontend/src/components/trends/WellnessTrendsView.tsx
@@ -55,7 +55,7 @@ export default function WellnessTrendsView() {
     stress: STRESS_COLOR,
     bodyBattery: BATTERY_COLOR,
     hrv: HRV_COLOR,
-  } = getSeriesColors(skin, WELLNESS_METRIC_COLORS)
+  } = getSeriesColors(theme, skin, WELLNESS_METRIC_COLORS)
 
   function MetricTooltip({ active, payload, label, unit }: { active?: boolean; payload?: any[]; label?: string; unit: string }) {
     if (!active || !payload?.length) return null

--- a/frontend/src/components/ui/ScoreRing.css
+++ b/frontend/src/components/ui/ScoreRing.css
@@ -6,6 +6,7 @@
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.15);
   flex-shrink: 0;
+  overflow: hidden;
 }
 
 .score-ring-svg {

--- a/frontend/src/components/ui/ScoreRing.tsx
+++ b/frontend/src/components/ui/ScoreRing.tsx
@@ -17,6 +17,12 @@ export default function ScoreRing({ score, color, size = 72, subLabel = '/100' }
     height: size,
   } as CSSProperties
   const progress = Math.max(0, Math.min(100, score))
+  // DotMatrix renders at a fixed pixel size by default — scale it down with
+  // the ring so a 2-3 digit score never outgrows the circle it sits in
+  // (Numeral/DotMatrix's own default is sized for looser contexts like
+  // StatGrid cells, not a tight circular one).
+  const numeralDot = Math.max(1.3, size * 0.021)
+  const numeralGap = numeralDot * 0.6
 
   return (
     <div className="score-ring" style={style}>
@@ -47,7 +53,7 @@ export default function ScoreRing({ score, color, size = 72, subLabel = '/100' }
       </svg>
       <div className="score-ring-center">
         <span className="score-ring-number" style={{ color }}>
-          <Numeral value={String(Math.round(score))} />
+          <Numeral value={String(Math.round(score))} dot={numeralDot} gap={numeralGap} />
         </span>
         <span className="score-ring-sub">{subLabel}</span>
       </div>

--- a/frontend/src/components/ui/ScoreRing.tsx
+++ b/frontend/src/components/ui/ScoreRing.tsx
@@ -17,12 +17,6 @@ export default function ScoreRing({ score, color, size = 72, subLabel = '/100' }
     height: size,
   } as CSSProperties
   const progress = Math.max(0, Math.min(100, score))
-  // DotMatrix renders at a fixed pixel size by default — scale it down with
-  // the ring so a 2-3 digit score never outgrows the circle it sits in
-  // (Numeral/DotMatrix's own default is sized for looser contexts like
-  // StatGrid cells, not a tight circular one).
-  const numeralDot = Math.max(1.3, size * 0.021)
-  const numeralGap = numeralDot * 0.6
 
   return (
     <div className="score-ring" style={style}>
@@ -53,7 +47,7 @@ export default function ScoreRing({ score, color, size = 72, subLabel = '/100' }
       </svg>
       <div className="score-ring-center">
         <span className="score-ring-number" style={{ color }}>
-          <Numeral value={String(Math.round(score))} dot={numeralDot} gap={numeralGap} />
+          <Numeral value={String(Math.round(score))} />
         </span>
         <span className="score-ring-sub">{subLabel}</span>
       </div>

--- a/frontend/src/styles/skins/nothing.css
+++ b/frontend/src/styles/skins/nothing.css
@@ -1,6 +1,8 @@
 /* Nothing OS skin — Phase 1 (token layer) + Phase 2 (semantic ink tokens)
    + Phase 3 (structural restyle) + Phase 4 (dot-matrix numerals & ring).
-   See docs/NOTHING_OS_SKIN_PLAN.md Phase 5+ for the chart work still to come. */
+   Phase 5 (charts) lives in utils/chartTheme.ts, not here — Recharts takes
+   literal colour props, not var(), so there's no CSS-side token layer for it.
+   See docs/NOTHING_OS_SKIN_PLAN.md Phase 6 for the remaining QA pass. */
 
 /* ---- shared by both Nothing skins, both modes ---- */
 html[data-skin="nothing-signal"][data-theme="dark"],

--- a/frontend/src/styles/skins/nothing.css
+++ b/frontend/src/styles/skins/nothing.css
@@ -330,6 +330,33 @@ html[data-skin^="nothing"] .alert-banner-icon {
   display: none;
 }
 
+/* ---- 3.5 Training-load form/risk badges: same hairline-not-fill treatment
+   as the alert banner above. Under app-inks the semantic colour-coding
+   (fresh/fatigued, low/high risk) stays in the text, just without the tinted
+   background; under signal-red it collapses to ink + the one accent, same as
+   every other status indicator in that skin. ---- */
+html[data-skin^="nothing"] .tl-form-badge {
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-xs);
+}
+
+html[data-skin="nothing-signal"] .tl-form-fresh,
+html[data-skin="nothing-signal"] .tl-risk-low {
+  color: var(--text);
+}
+
+html[data-skin="nothing-signal"] .tl-form-neutral {
+  color: var(--text-secondary);
+}
+
+html[data-skin="nothing-signal"] .tl-form-building,
+html[data-skin="nothing-signal"] .tl-form-fatigued,
+html[data-skin="nothing-signal"] .tl-risk-moderate,
+html[data-skin="nothing-signal"] .tl-risk-high {
+  color: var(--accent);
+}
+
 /* ---- 3.6 Perforated fills — apply via className="card perf" in TSX ---- */
 html[data-skin^="nothing"] .perf {
   background-image: radial-gradient(var(--dot-off) 1px, transparent 1px);
@@ -365,4 +392,19 @@ html[data-skin^="nothing"] .score-ring {
 
 html[data-skin^="nothing"] .score-ring-arc {
   stroke-dasharray: 1.5 6;
+}
+
+/* ---- 4.4 Numeral in a .stat-value: DotMatrix has no real text baseline (it's
+   a grid of <i> dots, line-height: 0), so plain inline baseline alignment
+   against a sibling .stat-unit synthesises the numeral's baseline at its
+   bottom edge — that lands it at a different height depending on whether a
+   unit span is present at all, which is why cells with a unit ("bpm", "ms")
+   and cells without one ("Sleep", "Body Battery") drift out of vertical sync
+   in a shared-row StatGrid. Flex + explicit center alignment removes the
+   font-metric guesswork entirely. ---- */
+html[data-skin^="nothing"] .stat-value,
+html[data-skin^="nothing"] .stat-value-lg {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
 }

--- a/frontend/src/utils/chartTheme.test.ts
+++ b/frontend/src/utils/chartTheme.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { getTooltipProps, getChartTickColor, getAxisTick, getGridStroke, usePrefersReducedMotion } from './chartTheme'
+import {
+  getTooltipProps, getChartTickColor, getAxisTick, getGridStroke, getHoverFill,
+  getSeriesColors, getSeriesDash, getZoneColor, getZoneSwatchColor, findZone,
+  usePrefersReducedMotion,
+} from './chartTheme'
+import type { MetricZone } from '../api/types'
 
 describe('getTooltipProps', () => {
   it('returns dark-theme colors', () => {
@@ -37,6 +42,93 @@ describe('getGridStroke', () => {
   it('matches the --border token per theme', () => {
     expect(getGridStroke('dark')).toBe('#2d2d44')
     expect(getGridStroke('light')).toBe('#e0e4ec')
+  })
+})
+
+describe('skin-aware chartTheme helpers', () => {
+  it('getTooltipProps/getChartTickColor/getAxisTick/getGridStroke fall back to default-skin colors when skin is omitted', () => {
+    expect(getTooltipProps('dark').contentStyle.background).toBe('#1a1a2e')
+    expect(getChartTickColor('dark')).toBe('#888')
+    expect(getAxisTick('dark')).toEqual({ fontSize: 10, fill: '#888' })
+    expect(getGridStroke('dark')).toBe('#2d2d44')
+  })
+
+  it('getTooltipProps matches the Nothing skins\' --bg-card/--border/--text tokens', () => {
+    expect(getTooltipProps('dark', 'nothing-signal').contentStyle).toMatchObject({ background: '#0b0b0b', border: '1px solid #232323', color: '#ffffff' })
+    expect(getTooltipProps('light', 'nothing-app').contentStyle).toMatchObject({ background: '#f4f4f4', border: '1px solid #e0e0e0', color: '#000000' })
+  })
+
+  it('getChartTickColor/getAxisTick/getGridStroke match the Nothing skins\' --text-muted/--border tokens', () => {
+    expect(getChartTickColor('dark', 'nothing-signal')).toBe('#6e6e6e')
+    expect(getChartTickColor('light', 'nothing-app')).toBe('#8b8b8b')
+    expect(getAxisTick('light', 11, 'nothing-signal')).toEqual({ fontSize: 11, fill: '#8b8b8b' })
+    expect(getGridStroke('dark', 'nothing-app')).toBe('#232323')
+    expect(getGridStroke('light', 'nothing-signal')).toBe('#e0e0e0')
+  })
+
+  it('getHoverFill is neutral under Nothing, purple by default', () => {
+    expect(getHoverFill('dark')).toBe('rgba(108, 92, 231, 0.1)')
+    expect(getHoverFill('dark', 'nothing-signal')).toBe('rgba(255, 255, 255, 0.08)')
+    expect(getHoverFill('light', 'nothing-app')).toBe('rgba(0, 0, 0, 0.06)')
+  })
+})
+
+describe('getSeriesColors', () => {
+  const fallbackArray = ['#6c5ce7', '#00b894', '#e17055', '#0984e3']
+  const fallbackRecord = { sleep: '#6c5ce7', hrv: '#0984e3' }
+
+  it('returns the fallback unchanged for default and nothing-app', () => {
+    expect(getSeriesColors('default', fallbackArray)).toBe(fallbackArray)
+    expect(getSeriesColors('nothing-app', fallbackRecord)).toBe(fallbackRecord)
+  })
+
+  it('maps an array onto the monochrome ramp, ordinally, for nothing-signal', () => {
+    expect(getSeriesColors('nothing-signal', fallbackArray)).toEqual(['#ffffff', '#d71921', '#8a8a8a', '#4a4a4a'])
+  })
+
+  it('maps a record onto the monochrome ramp, preserving keys, for nothing-signal', () => {
+    expect(getSeriesColors('nothing-signal', fallbackRecord)).toEqual({ sleep: '#ffffff', hrv: '#d71921' })
+  })
+})
+
+describe('getSeriesDash', () => {
+  it('is undefined below index 2 and for non-signal skins', () => {
+    expect(getSeriesDash('nothing-signal', 0)).toBeUndefined()
+    expect(getSeriesDash('nothing-signal', 1)).toBeUndefined()
+    expect(getSeriesDash('default', 3)).toBeUndefined()
+  })
+
+  it('returns a dash pattern for index >= 2 under nothing-signal', () => {
+    expect(getSeriesDash('nothing-signal', 2)).toBe('5 3')
+    expect(getSeriesDash('nothing-signal', 3)).toBe('2 2')
+  })
+})
+
+describe('getZoneColor / getZoneSwatchColor / findZone', () => {
+  const zones: MetricZone[] = [
+    { metric_key: 'pace', zone_name: 'Fast', zone_color: '#fab1a0', percentile_label: '', min_value: null, max_value: 4.5 },
+    { metric_key: 'pace', zone_name: 'Easy', zone_color: '#55efc4', percentile_label: '', min_value: 4.5, max_value: null },
+  ]
+
+  it('returns the matched zone\'s own color by default', () => {
+    expect(getZoneColor(4, zones)).toBe('#fab1a0')
+    expect(getZoneColor(5, zones)).toBe('#55efc4')
+  })
+
+  it('maps the matched zone\'s index onto SIGNAL_ZONE_RAMP under nothing-signal', () => {
+    expect(getZoneColor(4, zones, 'nothing-signal')).toBe('#3a3a3a')
+    expect(getZoneColor(5, zones, 'nothing-signal')).toBe('#5c5c5c')
+  })
+
+  it('findZone returns the zone object so callers can compare by identity', () => {
+    const zone = findZone(4, zones)
+    expect(zone).toBe(zones[0])
+    expect(getZoneSwatchColor(zone!, zones, 'nothing-signal')).toBe('#3a3a3a')
+    expect(getZoneSwatchColor(zone!, zones)).toBe('#fab1a0')
+  })
+
+  it('falls back to a default purple when no zone matches', () => {
+    expect(getZoneColor(4, [])).toBe('#6c5ce7')
   })
 })
 

--- a/frontend/src/utils/chartTheme.test.ts
+++ b/frontend/src/utils/chartTheme.test.ts
@@ -78,16 +78,20 @@ describe('getSeriesColors', () => {
   const fallbackRecord = { sleep: '#6c5ce7', hrv: '#0984e3' }
 
   it('returns the fallback unchanged for default and nothing-app', () => {
-    expect(getSeriesColors('default', fallbackArray)).toBe(fallbackArray)
-    expect(getSeriesColors('nothing-app', fallbackRecord)).toBe(fallbackRecord)
+    expect(getSeriesColors('dark', 'default', fallbackArray)).toBe(fallbackArray)
+    expect(getSeriesColors('dark', 'nothing-app', fallbackRecord)).toBe(fallbackRecord)
   })
 
   it('maps an array onto the monochrome ramp, ordinally, for nothing-signal', () => {
-    expect(getSeriesColors('nothing-signal', fallbackArray)).toEqual(['#ffffff', '#d71921', '#8a8a8a', '#4a4a4a'])
+    expect(getSeriesColors('dark', 'nothing-signal', fallbackArray)).toEqual(['#ffffff', '#d71921', '#b4b4b4', '#6e6e6e'])
   })
 
   it('maps a record onto the monochrome ramp, preserving keys, for nothing-signal', () => {
-    expect(getSeriesColors('nothing-signal', fallbackRecord)).toEqual({ sleep: '#ffffff', hrv: '#d71921' })
+    expect(getSeriesColors('dark', 'nothing-signal', fallbackRecord)).toEqual({ sleep: '#ffffff', hrv: '#d71921' })
+  })
+
+  it('uses a darker ramp under light theme, matching --text/--text-secondary/--text-muted', () => {
+    expect(getSeriesColors('light', 'nothing-signal', fallbackArray)).toEqual(['#000000', '#d71921', '#4a4a4a', '#8b8b8b'])
   })
 })
 

--- a/frontend/src/utils/chartTheme.ts
+++ b/frontend/src/utils/chartTheme.ts
@@ -136,21 +136,30 @@ export const PERFORMANCE_CURVE_COLORS = {
 export const CHART_SERIES_COLORS = ['#6c5ce7', '#00b894', '#e17055', '#0984e3']
 
 /** Monochrome + one-accent palette every `nothing-signal` series maps onto,
- * ordinally, regardless of how many named colours the default palette has. */
-const NOTHING_SIGNAL_SERIES = ['#ffffff', '#d71921', '#8a8a8a', '#4a4a4a']
+ * ordinally, regardless of how many named colours the default palette has.
+ * Reuses `nothing.css`'s own --text/--text-secondary/--text-muted/--accent
+ * hex values per theme (Recharts needs literal hex, not var()) — the same
+ * label-hierarchy grays already used everywhere else in the skin, chosen to
+ * stay legible and mutually distinct against a pure black/white surface,
+ * rather than a made-up gray pair that reads flat on either background. */
+const NOTHING_SIGNAL_SERIES: Record<Theme, string[]> = {
+  dark: ['#ffffff', '#d71921', '#b4b4b4', '#6e6e6e'],
+  light: ['#000000', '#d71921', '#4a4a4a', '#8b8b8b'],
+}
 
 /** Resolves a palette to its `nothing-signal` monochrome equivalent, ordinally
  * by key/index — `default` and `nothing-app` return `fallback` unchanged, so
  * those two skins need no palette maintenance beyond this call. */
-export function getSeriesColors(skin: ChartSkin, fallback: string[]): string[]
-export function getSeriesColors<T extends Record<string, string>>(skin: ChartSkin, fallback: T): T
-export function getSeriesColors(skin: ChartSkin, fallback: string[] | Record<string, string>): string[] | Record<string, string> {
+export function getSeriesColors(theme: Theme, skin: ChartSkin, fallback: string[]): string[]
+export function getSeriesColors<T extends Record<string, string>>(theme: Theme, skin: ChartSkin, fallback: T): T
+export function getSeriesColors(theme: Theme, skin: ChartSkin, fallback: string[] | Record<string, string>): string[] | Record<string, string> {
   if (skin !== 'nothing-signal') return fallback
+  const ramp = NOTHING_SIGNAL_SERIES[theme]
   if (Array.isArray(fallback)) {
-    return fallback.map((_, i) => NOTHING_SIGNAL_SERIES[i % NOTHING_SIGNAL_SERIES.length])
+    return fallback.map((_, i) => ramp[i % ramp.length])
   }
   const keys = Object.keys(fallback)
-  return Object.fromEntries(keys.map((k, i) => [k, NOTHING_SIGNAL_SERIES[i % NOTHING_SIGNAL_SERIES.length]]))
+  return Object.fromEntries(keys.map((k, i) => [k, ramp[i % ramp.length]]))
 }
 
 /** Dash pattern for the 3rd+ series in a `nothing-signal` chart where more

--- a/frontend/src/utils/chartTheme.ts
+++ b/frontend/src/utils/chartTheme.ts
@@ -3,6 +3,11 @@ import type { MetricZone } from '../api/types'
 
 export type Theme = 'dark' | 'light'
 
+/** Mirrors `Skin` from `App.tsx` — kept independent to avoid a utils→component
+ * import cycle. `useSkin()`'s value is structurally identical and passes
+ * straight through. */
+export type ChartSkin = 'default' | 'nothing-signal' | 'nothing-app'
+
 /**
  * Tracks `prefers-reduced-motion`. Recharts animates via its own rAF loop
  * (react-smooth), independent of CSS — the global reduced-motion media query
@@ -33,7 +38,14 @@ export interface ChartTooltipProps {
 }
 
 /** Recharts `<Tooltip>` props (contentStyle/labelStyle/itemStyle), theme-correct. */
-export function getTooltipProps(theme: Theme): ChartTooltipProps {
+export function getTooltipProps(theme: Theme, skin: ChartSkin = 'default'): ChartTooltipProps {
+  if (skin !== 'default') {
+    const contentStyle: CSSProperties = theme === 'light'
+      ? { background: '#f4f4f4', border: '1px solid #e0e0e0', borderRadius: 8, fontSize: 12, color: '#000000' }
+      : { background: '#0b0b0b', border: '1px solid #232323', borderRadius: 8, fontSize: 12, color: '#ffffff' }
+    const textStyle: CSSProperties = { color: theme === 'light' ? '#000000' : '#ffffff' }
+    return { contentStyle, labelStyle: textStyle, itemStyle: textStyle }
+  }
   const contentStyle: CSSProperties = theme === 'light'
     ? { background: '#ffffff', border: '1px solid #e0e4ec', borderRadius: 8, fontSize: 12, color: '#1a1a2e' }
     : { background: '#1a1a2e', border: '1px solid #2d2d44', borderRadius: 8, fontSize: 12, color: '#e0e0e0' }
@@ -41,18 +53,26 @@ export function getTooltipProps(theme: Theme): ChartTooltipProps {
   return { contentStyle, labelStyle: textStyle, itemStyle: textStyle }
 }
 
-export function getChartTickColor(theme: Theme): string {
+export function getChartTickColor(theme: Theme, skin: ChartSkin = 'default'): string {
+  if (skin !== 'default') return theme === 'light' ? '#8b8b8b' : '#6e6e6e'
   return theme === 'light' ? '#6b7280' : '#888'
 }
 
 /** Style object for a Recharts axis `tick` prop. */
-export function getAxisTick(theme: Theme, fontSize = 10): { fontSize: number; fill: string } {
-  return { fontSize, fill: getChartTickColor(theme) }
+export function getAxisTick(theme: Theme, fontSize = 10, skin: ChartSkin = 'default'): { fontSize: number; fill: string } {
+  return { fontSize, fill: getChartTickColor(theme, skin) }
 }
 
 /** Stroke colour for gridlines/reference lines — matches the `--border` token. */
-export function getGridStroke(theme: Theme): string {
+export function getGridStroke(theme: Theme, skin: ChartSkin = 'default'): string {
+  if (skin !== 'default') return theme === 'light' ? '#e0e0e0' : '#232323'
   return theme === 'light' ? '#e0e4ec' : '#2d2d44'
+}
+
+/** Bar-hover cursor fill — themed purple by default, neutral under Nothing. */
+export function getHoverFill(theme: Theme, skin: ChartSkin = 'default'): string {
+  if (skin !== 'default') return theme === 'light' ? 'rgba(0, 0, 0, 0.06)' : 'rgba(255, 255, 255, 0.08)'
+  return 'rgba(108, 92, 231, 0.1)'
 }
 
 /** Canonical per-metric colours for activity detail charts (HR, pace, power, dynamics...). */
@@ -115,19 +135,67 @@ export const PERFORMANCE_CURVE_COLORS = {
 /** Ordered categorical palette for arbitrary multi-series charts — CustomChartsView. */
 export const CHART_SERIES_COLORS = ['#6c5ce7', '#00b894', '#e17055', '#0984e3']
 
-/** Which zone a value falls into, by colour — shared by scatter-chart dots and SplitsBars. */
-export function getZoneColor(value: number, zones: MetricZone[]): string {
+/** Monochrome + one-accent palette every `nothing-signal` series maps onto,
+ * ordinally, regardless of how many named colours the default palette has. */
+const NOTHING_SIGNAL_SERIES = ['#ffffff', '#d71921', '#8a8a8a', '#4a4a4a']
+
+/** Resolves a palette to its `nothing-signal` monochrome equivalent, ordinally
+ * by key/index — `default` and `nothing-app` return `fallback` unchanged, so
+ * those two skins need no palette maintenance beyond this call. */
+export function getSeriesColors(skin: ChartSkin, fallback: string[]): string[]
+export function getSeriesColors<T extends Record<string, string>>(skin: ChartSkin, fallback: T): T
+export function getSeriesColors(skin: ChartSkin, fallback: string[] | Record<string, string>): string[] | Record<string, string> {
+  if (skin !== 'nothing-signal') return fallback
+  if (Array.isArray(fallback)) {
+    return fallback.map((_, i) => NOTHING_SIGNAL_SERIES[i % NOTHING_SIGNAL_SERIES.length])
+  }
+  const keys = Object.keys(fallback)
+  return Object.fromEntries(keys.map((k, i) => [k, NOTHING_SIGNAL_SERIES[i % NOTHING_SIGNAL_SERIES.length]]))
+}
+
+/** Dash pattern for the 3rd+ series in a `nothing-signal` chart where more
+ * than two lines overlay with no dash of their own — `NOTHING_SIGNAL_SERIES`
+ * only reads as distinct colour for the first two entries. */
+export function getSeriesDash(skin: ChartSkin, index: number): string | undefined {
+  if (skin !== 'nothing-signal' || index < 2) return undefined
+  return index % 2 === 0 ? '5 3' : '2 2'
+}
+
+/** Ordinal grayscale ramp `nothing-signal` zone bars/dots map onto, replacing
+ * the API-supplied `zone_color` rainbow — index is the zone's position in its
+ * `zones` array (ordinal data → a monochrome ramp is the correct encoding). */
+export const SIGNAL_ZONE_RAMP = ['#3a3a3a', '#5c5c5c', '#8a8a8a', '#c4c4c4', '#ffffff']
+
+/** Which zone a value falls into. */
+export function findZone(value: number, zones: MetricZone[]): MetricZone | undefined {
   for (const zone of zones) {
     const aboveMin = zone.min_value === null || value >= zone.min_value
     const belowMax = zone.max_value === null || value < zone.max_value
-    if (aboveMin && belowMax) return zone.zone_color
+    if (aboveMin && belowMax) return zone
   }
   // Check the last zone (unbounded max) separately with inclusive check
   for (const zone of zones) {
     if (zone.max_value === null) {
       const aboveMin = zone.min_value === null || value >= zone.min_value
-      if (aboveMin) return zone.zone_color
+      if (aboveMin) return zone
     }
   }
-  return '#6c5ce7'
+  return undefined
+}
+
+/** Which zone a value falls into, by colour — shared by scatter-chart dots and SplitsBars. */
+export function getZoneColor(value: number, zones: MetricZone[], skin: ChartSkin = 'default'): string {
+  const zone = findZone(value, zones)
+  if (!zone) return '#6c5ce7'
+  return getZoneSwatchColor(zone, zones, skin)
+}
+
+/** Display colour for a zone the caller already has (e.g. a legend entry) —
+ * same ramp mapping as `getZoneColor`, keyed off the zone itself rather than
+ * a value, so callers that need zone *identity* (not just colour) can use
+ * `findZone`/`indexOf` themselves and still land on the same swatch. */
+export function getZoneSwatchColor(zone: MetricZone, zones: MetricZone[], skin: ChartSkin = 'default'): string {
+  if (skin !== 'nothing-signal') return zone.zone_color
+  const idx = zones.indexOf(zone)
+  return SIGNAL_ZONE_RAMP[idx % SIGNAL_ZONE_RAMP.length]
 }


### PR DESCRIPTION
Adds the Skin type ('default' | 'nothing-signal' | 'nothing-app') alongside
the existing theme context, persisted to localStorage and applied as
document.documentElement's data-skin attribute. A pre-paint inline script in
index.html sets both data-theme and data-skin before first render to avoid a
flash of the wrong appearance.

New Appearance section in Settings lets the user pick mode (dark/light) and
style (default vs. the two upcoming Nothing skins) via native radios, mounted
first in SettingsView. No visual change yet — later phases add the actual
Nothing CSS.

Per docs/NOTHING_OS_SKIN_PLAN.md phase 0.